### PR TITLE
feat/perf: abi benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: dtolnay/rust-toolchain@clippy
-            - run: cargo clippy --workspace --tests
+            - run: cargo clippy --workspace --all-targets
               env:
                   RUSTFLAGS: -Dwarnings
 

--- a/crates/dyn-abi/Cargo.toml
+++ b/crates/dyn-abi/Cargo.toml
@@ -25,6 +25,16 @@ hex.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, features = ["alloc"] }
 
+[dev-dependencies]
+hex-literal.workspace = true
+criterion = "0.5"
+ethabi = "18"
+
 [features]
 default = ["std"]
 std = ["alloy-sol-types/std", "alloy-primitives/std", "hex/std", "serde/std", "serde_json/std"]
+
+[[bench]]
+name = "abi"
+path = "benches/abi.rs"
+harness = false

--- a/crates/dyn-abi/benches/abi.rs
+++ b/crates/dyn-abi/benches/abi.rs
@@ -1,0 +1,236 @@
+use alloy_dyn_abi::{DynSolType, DynSolValue};
+use alloy_primitives::U256;
+use alloy_sol_types::{sol, SolType};
+use criterion::{
+    criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
+};
+use hex_literal::hex;
+use std::{hint::black_box, time::Duration};
+
+fn ethabi_encode(c: &mut Criterion) {
+    let mut g = group(c, "ethabi/encode");
+
+    g.bench_function("single", |b| {
+        let input = encode_single_input();
+        b.iter(|| {
+            let token = ethabi::Token::String(black_box(&input).clone());
+            ethabi::encode(&[token])
+        });
+    });
+
+    g.bench_function("struct", |b| {
+        let tokens = encode_struct_input_tokens();
+        b.iter(|| ethabi::encode(black_box(&tokens)));
+    });
+
+    g.finish();
+}
+
+fn ethabi_decode(c: &mut Criterion) {
+    let mut g = group(c, "ethabi/decode");
+
+    g.bench_function("word", |b| {
+        let input = decode_word_input();
+        b.iter(|| {
+            let ty = ethabi::ParamType::Uint(256);
+            ethabi::decode(&[ty], black_box(&input)).unwrap()
+        });
+    });
+
+    g.bench_function("dynamic", |b| {
+        let input = decode_dynamic_input();
+        b.iter(|| {
+            let ty = ethabi::ParamType::String;
+            ethabi::decode(&[ty], black_box(&input)).unwrap()
+        });
+    });
+
+    g.finish();
+}
+
+fn dyn_abi_encode(c: &mut Criterion) {
+    let mut g = group(c, "dyn-abi/encode");
+
+    g.bench_function("single", |b| {
+        let input = encode_single_input();
+        b.iter(|| {
+            let ty = DynSolType::String;
+            let value = DynSolValue::String(input.clone());
+            ty.encode_single(black_box(value))
+        });
+    });
+
+    g.bench_function("struct", |b| {
+        let tys = vec![
+            DynSolType::Address,
+            DynSolType::Address,
+            DynSolType::Uint(24),
+            DynSolType::Address,
+            DynSolType::Uint(256),
+            DynSolType::Uint(256),
+            DynSolType::Uint(256),
+            DynSolType::Uint(160),
+        ];
+        let ty = DynSolType::Tuple(tys);
+        let input = encode_struct_sol_values();
+        let input = DynSolValue::Tuple(input.to_vec());
+        b.iter(|| ty.encode_single(black_box(&input).clone()));
+    });
+
+    g.finish();
+}
+
+fn dyn_abi_decode(c: &mut Criterion) {
+    let mut g = group(c, "dyn-abi/decode");
+
+    g.bench_function("word", |b| {
+        let ty = DynSolType::Uint(256);
+        let input = decode_word_input();
+        b.iter(|| ty.decode_single(black_box(&input)).unwrap());
+    });
+
+    g.bench_function("dynamic", |b| {
+        let ty = DynSolType::String;
+        let input = decode_dynamic_input();
+        b.iter(|| ty.decode_single(black_box(&input)).unwrap());
+    });
+
+    g.finish();
+}
+
+fn sol_types_encode(c: &mut Criterion) {
+    let mut g = group(c, "sol-types/encode");
+
+    g.bench_function("single", |b| {
+        let input = encode_single_input();
+        b.iter(|| alloy_sol_types::sol_data::String::encode_single(black_box(&input)));
+    });
+
+    g.bench_function("struct", |b| {
+        let input = encode_struct_input();
+        b.iter(|| Input::encode(&input));
+    });
+
+    g.finish();
+}
+
+fn sol_types_decode(c: &mut Criterion) {
+    let mut g = group(c, "sol-types/decode");
+
+    g.bench_function("word", |b| {
+        let input = decode_word_input();
+        b.iter(|| {
+            alloy_sol_types::sol_data::Uint::<256>::decode_single(black_box(&input), false).unwrap()
+        });
+    });
+
+    g.bench_function("dynamic", |b| {
+        let input = decode_dynamic_input();
+        b.iter(|| {
+            alloy_sol_types::sol_data::String::decode_single(black_box(&input), false).unwrap()
+        });
+    });
+
+    g.finish();
+}
+
+sol! {
+    /// UniswapV3's `SwapRouter::ExactInputSingleParams`:
+    /// <https://github.com/Uniswap/v3-periphery/blob/6cce88e63e176af1ddb6cc56e029110289622317/contracts/interfaces/ISwapRouter.sol#L10C10-L19>
+    struct Input {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 deadline;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+        uint160 sqrtPriceLimitX96;
+    }
+}
+
+fn encode_single_input() -> String {
+    String::from("Hello World!")
+}
+
+fn encode_struct_input() -> Input {
+    Input {
+        tokenIn: hex!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").into(),
+        tokenOut: hex!("955d5c14C8D4944dA1Ea7836bd44D54a8eC35Ba1").into(),
+        fee: 10000,
+        recipient: hex!("299A299A22F8C7397d9DB3702439069d951AeA74").into(),
+        deadline: U256::from(1685523099_u64),
+        amountIn: U256::from(10000000000000000000_u128),
+        amountOutMinimum: U256::from(836797564735606450550734848_u128),
+        sqrtPriceLimitX96: U256::ZERO,
+    }
+}
+
+fn encode_struct_input_tokens() -> [ethabi::Token; 8] {
+    let input = encode_struct_input();
+    [
+        ethabi::Token::Address(input.tokenIn.0 .0.into()),
+        ethabi::Token::Address(input.tokenOut.0 .0.into()),
+        ethabi::Token::Uint(input.fee.into()),
+        ethabi::Token::Address(input.recipient.0 .0.into()),
+        ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+            &input.deadline.to_be_bytes_vec(),
+        )),
+        ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+            &input.amountIn.to_be_bytes_vec(),
+        )),
+        ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+            &input.amountOutMinimum.to_be_bytes_vec(),
+        )),
+        ethabi::Token::Uint(ethabi::Uint::from_big_endian(
+            &input.sqrtPriceLimitX96.to_be_bytes_vec(),
+        )),
+    ]
+}
+
+fn encode_struct_sol_values() -> [DynSolValue; 8] {
+    let input = encode_struct_input();
+    [
+        input.tokenIn.into(),
+        input.tokenOut.into(),
+        input.fee.into(),
+        input.recipient.into(),
+        input.deadline.into(),
+        input.amountIn.into(),
+        input.amountOutMinimum.into(),
+        input.sqrtPriceLimitX96.into(),
+    ]
+}
+
+fn decode_word_input() -> Vec<u8> {
+    vec![0u8; 32]
+}
+
+fn decode_dynamic_input() -> Vec<u8> {
+    hex!(
+        "0000000000000000000000000000000000000000000000000000000000000020"
+        "000000000000000000000000000000000000000000000000000000000000000c"
+        "48656c6c6f20576f726c64210000000000000000000000000000000000000000"
+    )
+    .to_vec()
+}
+
+fn group<'a>(c: &'a mut Criterion, group_name: &str) -> BenchmarkGroup<'a, WallTime> {
+    let mut g = c.benchmark_group(group_name);
+    g.noise_threshold(0.03)
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(3))
+        .sample_size(200);
+    g
+}
+
+criterion_group!(
+    benches,
+    ethabi_encode,
+    ethabi_decode,
+    dyn_abi_encode,
+    dyn_abi_decode,
+    sol_types_encode,
+    sol_types_decode,
+);
+criterion_main!(benches);

--- a/crates/dyn-abi/src/lib.rs
+++ b/crates/dyn-abi/src/lib.rs
@@ -11,11 +11,11 @@
 #![warn(
     missing_docs,
     unreachable_pub,
-    unused_crate_dependencies,
     missing_copy_implementations,
     missing_debug_implementations,
     clippy::missing_const_for_fn
 )]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]

--- a/crates/dyn-abi/src/value.rs
+++ b/crates/dyn-abi/src/value.rs
@@ -242,6 +242,27 @@ impl From<Vec<u8>> for DynSolValue {
     }
 }
 
+impl From<String> for DynSolValue {
+    #[inline]
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<Vec<DynSolValue>> for DynSolValue {
+    #[inline]
+    fn from(value: Vec<DynSolValue>) -> Self {
+        Self::Array(value)
+    }
+}
+
+impl<const N: usize> From<[DynSolValue; N]> for DynSolValue {
+    #[inline]
+    fn from(value: [DynSolValue; N]) -> Self {
+        Self::FixedArray(value.to_vec())
+    }
+}
+
 macro_rules! impl_from_int {
     ($($t:ty),+) => {$(
         impl From<$t> for DynSolValue {
@@ -254,7 +275,7 @@ macro_rules! impl_from_int {
                 let mut word = if value.is_negative() {
                     alloy_primitives::B256::repeat_byte(0xff)
                 } else {
-                    alloy_primitives::B256::default()
+                    alloy_primitives::B256::ZERO
                 };
                 word[32 - BYTES..].copy_from_slice(&value.to_be_bytes());
 
@@ -284,70 +305,11 @@ macro_rules! impl_from_uint {
     )+};
 }
 
-// TODO: more?
 impl_from_uint!(u8, u16, u32, u64, usize, u128);
 
 impl From<U256> for DynSolValue {
     #[inline]
     fn from(value: U256) -> Self {
         Self::Uint(value, 256)
-    }
-}
-
-impl From<String> for DynSolValue {
-    fn from(value: String) -> Self {
-        Self::String(value)
-    }
-}
-
-macro_rules! impl_from_tuple {
-    ($num:expr, $( $ty:ident : $no:tt ),+ $(,)?) => {
-        impl<$($ty,)+> From<($( $ty, )+)> for DynSolValue
-        where
-            $(
-                $ty: Into<DynSolValue>,
-            )+
-        {
-            fn from(value: ($( $ty, )+)) -> Self {
-                Self::Tuple(vec![$( value.$no.into(), )+])
-            }
-        }
-    }
-}
-
-impl_from_tuple!(1, A:0, );
-impl_from_tuple!(2, A:0, B:1, );
-impl_from_tuple!(3, A:0, B:1, C:2, );
-impl_from_tuple!(4, A:0, B:1, C:2, D:3, );
-impl_from_tuple!(5, A:0, B:1, C:2, D:3, E:4, );
-impl_from_tuple!(6, A:0, B:1, C:2, D:3, E:4, F:5, );
-impl_from_tuple!(7, A:0, B:1, C:2, D:3, E:4, F:5, G:6, );
-impl_from_tuple!(8, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, );
-impl_from_tuple!(9, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, );
-impl_from_tuple!(10, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, );
-impl_from_tuple!(11, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, );
-impl_from_tuple!(12, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, L:11, );
-impl_from_tuple!(13, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, L:11, M:12, );
-impl_from_tuple!(14, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, L:11, M:12, N:13, );
-impl_from_tuple!(15, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, L:11, M:12, N:13, O:14, );
-impl_from_tuple!(16, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, L:11, M:12, N:13, O:14, P:15, );
-impl_from_tuple!(17, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, L:11, M:12, N:13, O:14, P:15, Q:16,);
-impl_from_tuple!(18, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, L:11, M:12, N:13, O:14, P:15, Q:16, R:17,);
-impl_from_tuple!(19, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, L:11, M:12, N:13, O:14, P:15, Q:16, R:17, S:18,);
-impl_from_tuple!(20, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, L:11, M:12, N:13, O:14, P:15, Q:16, R:17, S:18, T:19,);
-impl_from_tuple!(21, A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, L:11, M:12, N:13, O:14, P:15, Q:16, R:17, S:18, T:19, U:20,);
-
-impl From<Vec<DynSolValue>> for DynSolValue {
-    fn from(value: Vec<DynSolValue>) -> Self {
-        Self::Array(value)
-    }
-}
-
-impl<T, const N: usize> From<[T; N]> for DynSolValue
-where
-    T: Into<DynSolValue>,
-{
-    fn from(value: [T; N]) -> Self {
-        Self::Array(value.into_iter().map(|v| v.into()).collect())
     }
 }

--- a/crates/sol-types/Cargo.toml
+++ b/crates/sol-types/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 alloy-primitives.workspace = true
 alloy-sol-macro.workspace = true
 
-hex = { workspace = true, features = ["alloc"] }
+hex.workspace = true
 
 serde = { workspace = true, optional = true, features = ["derive"] }
 
@@ -30,6 +30,6 @@ hex-literal.workspace = true
 trybuild = "1.0"
 
 [features]
-default = ["std", "hex/alloc"]
+default = ["std"]
 std = ["alloy-primitives/std", "hex/std", "serde?/std"]
 eip712-serde = ["dep:serde", "serde?/alloc", "alloy-primitives/serde"]

--- a/crates/sol-types/src/coder/decoder.rs
+++ b/crates/sol-types/src/coder/decoder.rs
@@ -58,14 +58,14 @@ impl<'a> Decoder<'a> {
     /// flag.
     #[inline]
     fn child(&self, offset: usize) -> Result<Decoder<'a>, Error> {
-        if offset > self.buf.len() {
-            return Err(Error::Overrun)
-        }
-        Ok(Self {
-            buf: &self.buf[offset..],
-            offset: 0,
-            validate: self.validate,
-        })
+        self.buf
+            .get(offset..)
+            .map(|buf| Self {
+                buf,
+                offset: 0,
+                validate: self.validate,
+            })
+            .ok_or(Error::Overrun)
     }
 
     /// Get a child decoder at the current offset.

--- a/crates/sol-types/src/coder/token.rs
+++ b/crates/sol-types/src/coder/token.rs
@@ -152,7 +152,7 @@ impl TokenType for WordToken {
 
     #[inline]
     fn decode_from(dec: &mut Decoder<'_>) -> Result<Self> {
-        dec.take_word().map(Into::into)
+        dec.take_word().map(Self)
     }
 
     #[inline]
@@ -183,7 +183,7 @@ impl WordToken {
 
     /// Copy the inner word.
     #[inline]
-    pub const fn inner(&self) -> Word {
+    pub const fn inner(self) -> Word {
         self.0
     }
 }

--- a/crates/sol-types/src/lib.rs
+++ b/crates/sol-types/src/lib.rs
@@ -143,21 +143,17 @@
 #![warn(
     missing_docs,
     unreachable_pub,
-    unused_crate_dependencies,
     missing_copy_implementations,
     missing_debug_implementations,
     clippy::missing_const_for_fn
 )]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[macro_use]
 extern crate alloc;
-
-// This crate is used in tests/compiletest.rs
-#[cfg(test)]
-use trybuild as _;
 
 #[doc(hidden)]
 pub mod no_std_prelude {


### PR DESCRIPTION
### Results

`sol-types`: good
`dyn-abi`: not so good, optimizations needed, probably in `DynSolType::encode_single`

```clojure
ethabi/encode/single    time:   [86.689 ns 87.177 ns 87.735 ns]
ethabi/encode/struct    time:   [172.32 ns 172.65 ns 173.02 ns]
ethabi/decode/word      time:   [33.044 ns 33.168 ns 33.310 ns]
ethabi/decode/dynamic   time:   [72.122 ns 72.273 ns 72.452 ns]

dyn-abi/encode/single   time:   [91.784 ns 92.412 ns 93.107 ns]
dyn-abi/encode/struct   time:   [724.03 ns 729.16 ns 734.79 ns]
dyn-abi/decode/word     time:   [72.234 ns 72.568 ns 72.967 ns]
dyn-abi/decode/dynamic  time:   [99.585 ns 99.764 ns 99.945 ns]

sol-types/encode/single time:   [43.869 ns 44.193 ns 44.581 ns]
sol-types/encode/struct time:   [55.131 ns 55.286 ns 55.423 ns]
sol-types/decode/word   time:   [1.3890 ns 1.4000 ns 1.4141 ns]
sol-types/decode/dynamic
                        time:   [36.848 ns 36.983 ns 37.135 ns]
```