### PR TITLE
feat: more FixedBytes impls

### DIFF
--- a/crates/dyn-abi/src/eip712/typed_data.rs
+++ b/crates/dyn-abi/src/eip712/typed_data.rs
@@ -214,11 +214,11 @@ impl TypedData {
         let mut buf = [0u8; 66];
         buf[0] = 0x19;
         buf[1] = 0x01;
-        buf[2..34].copy_from_slice(self.domain.separator().as_bytes());
+        buf[2..34].copy_from_slice(self.domain.separator().as_slice());
 
         // compatibility with <https://github.com/MetaMask/eth-sig-util>
         let len = if self.primary_type != "EIP712Domain" {
-            buf[34..].copy_from_slice(self.hash_struct()?.as_bytes());
+            buf[34..].copy_from_slice(self.hash_struct()?.as_slice());
             66
         } else {
             34

--- a/crates/dyn-abi/src/value.rs
+++ b/crates/dyn-abi/src/value.rs
@@ -109,7 +109,7 @@ impl DynSolValue {
     /// Fallible cast to the contents of a variant.
     pub const fn as_fixed_bytes(&self) -> Option<(&[u8], usize)> {
         match self {
-            Self::FixedBytes(w, size) => Some((w.as_bytes(), *size)),
+            Self::FixedBytes(w, size) => Some((w.as_slice(), *size)),
             _ => None,
         }
     }
@@ -185,10 +185,10 @@ impl DynSolValue {
     /// Encodes the packed value and appends it to the end of a byte array.
     pub fn encode_packed_to(&self, buf: &mut Vec<u8>) {
         match self {
-            Self::Address(addr) => buf.extend_from_slice(addr.as_bytes()),
+            Self::Address(addr) => buf.extend_from_slice(addr.as_slice()),
             Self::Bool(b) => buf.push(*b as u8),
             Self::Bytes(bytes) => buf.extend_from_slice(bytes),
-            Self::FixedBytes(word, size) => buf.extend_from_slice(&word.as_bytes()[..*size]),
+            Self::FixedBytes(word, size) => buf.extend_from_slice(&word.as_slice()[..*size]),
             Self::Int(num, size) => {
                 let mut bytes = num.to_be_bytes::<32>();
                 let start = 32 - *size;
@@ -209,7 +209,7 @@ impl DynSolValue {
             | Self::CustomStruct { tuple: inner, .. } => {
                 inner.iter().for_each(|v| v.encode_packed_to(buf))
             }
-            Self::CustomValue { inner, .. } => buf.extend_from_slice(inner.as_bytes()),
+            Self::CustomValue { inner, .. } => buf.extend_from_slice(inner.as_slice()),
         }
     }
 

--- a/crates/primitives/src/bits/bloom.rs
+++ b/crates/primitives/src/bits/bloom.rs
@@ -3,7 +3,7 @@
 //! Adapted from <https://github.com/paritytech/parity-common/blob/2fb72eea96b6de4a085144ce239feb49da0cd39e/ethbloom/src/lib.rs>
 
 use crate::{keccak256, wrap_fixed_bytes, FixedBytes};
-use core::borrow::{Borrow, BorrowMut};
+use core::borrow::Borrow;
 
 /// Number of bits to set per input in Ethereum bloom filter.
 pub const BLOOM_BITS_PER_ITEM: usize = 3;
@@ -54,7 +54,10 @@ impl From<BloomInput<'_>> for Bloom {
     }
 }
 
-wrap_fixed_bytes!(Bloom<256>);
+wrap_fixed_bytes!(
+    /// Ethereum 256 byte bloom filter.
+    pub struct Bloom<256>;
+);
 
 impl Bloom {
     /// Returns a reference to the underlying data.
@@ -120,30 +123,6 @@ impl Bloom {
             let bit = (h[i + 1] as usize + ((h[i] as usize) << 8)) & 0x7FF;
             self.0[BLOOM_SIZE_BYTES - 1 - bit / 8] |= 1 << (bit % 8);
         }
-    }
-}
-
-impl Borrow<[u8; 256]> for Bloom {
-    fn borrow(&self) -> &[u8; 256] {
-        self.data()
-    }
-}
-
-impl Borrow<[u8]> for Bloom {
-    fn borrow(&self) -> &[u8] {
-        self.data()
-    }
-}
-
-impl BorrowMut<[u8; 256]> for Bloom {
-    fn borrow_mut(&mut self) -> &mut [u8; 256] {
-        self.data_mut()
-    }
-}
-
-impl BorrowMut<[u8]> for Bloom {
-    fn borrow_mut(&mut self) -> &mut [u8] {
-        self.data_mut()
     }
 }
 

--- a/crates/primitives/src/bits/fixed.rs
+++ b/crates/primitives/src/bits/fixed.rs
@@ -1,25 +1,38 @@
-use core::{
-    borrow::{Borrow, BorrowMut},
-    fmt, ops, str,
-};
-use derive_more::{Deref, DerefMut, From, Index, IndexMut};
+use core::{fmt, ops, str};
+use derive_more::{Deref, DerefMut, From, Index, IndexMut, IntoIterator};
 
-/// A bytearray of fixed length.
+/// A byte array of fixed length (`[u8; N]`).
 ///
 /// This type allows us to more tightly control serialization, deserialization.
 /// rlp encoding, decoding, and other type-level attributes for fixed-length
-/// byte arrays. Users looking to prevent type-confusion between byte arrays of
-/// different lengths should use the [`crate::wrap_fixed_bytes`] macro to
-/// create a new fixed-length byte array type.
+/// byte arrays.
+///
+/// Users looking to prevent type-confusion between byte arrays of different
+/// lengths should use the [`wrap_fixed_bytes!`](crate::wrap_fixed_bytes) macro
+/// to create a new fixed-length byte array type.
 #[derive(
-    Deref, DerefMut, From, Hash, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Index, IndexMut,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Deref,
+    DerefMut,
+    From,
+    Index,
+    IndexMut,
+    IntoIterator,
 )]
 #[cfg_attr(
     feature = "arbitrary",
     derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
 )]
 #[repr(transparent)]
-pub struct FixedBytes<const N: usize>(pub [u8; N]);
+pub struct FixedBytes<const N: usize>(#[into_iterator(owned, ref, ref_mut)] pub [u8; N]);
+
+crate::impl_fixed_bytes_traits!(FixedBytes<N>, N, const);
 
 impl<const N: usize> Default for FixedBytes<N> {
     fn default() -> Self {
@@ -60,31 +73,19 @@ impl<const N: usize> From<FixedBytes<N>> for [u8; N] {
     }
 }
 
-// Borrow is not implemented for references
-macro_rules! borrow_impls {
-    (impl Borrow<$t:ty> for $($b:ty),+) => {$(
-        impl<const N: usize> Borrow<$t> for $b {
-            #[inline]
-            fn borrow(&self) -> &$t {
-                &self.0
-            }
-        }
-    )+};
-
-    (impl BorrowMut<$t:ty> for $($b:ty),+) => {$(
-        impl<const N: usize> BorrowMut<$t> for $b {
-            #[inline]
-            fn borrow_mut(&mut self) -> &mut $t {
-                &mut self.0
-            }
-        }
-    )+};
+impl<const N: usize> AsRef<[u8; N]> for FixedBytes<N> {
+    #[inline]
+    fn as_ref(&self) -> &[u8; N] {
+        &self.0
+    }
 }
 
-borrow_impls!(impl Borrow<[u8]>       for FixedBytes<N>, &mut FixedBytes<N>, &FixedBytes<N>);
-borrow_impls!(impl Borrow<[u8; N]>    for FixedBytes<N>, &mut FixedBytes<N>, &FixedBytes<N>);
-borrow_impls!(impl BorrowMut<[u8]>    for FixedBytes<N>, &mut FixedBytes<N>);
-borrow_impls!(impl BorrowMut<[u8; N]> for FixedBytes<N>, &mut FixedBytes<N>);
+impl<const N: usize> AsMut<[u8; N]> for FixedBytes<N> {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [u8; N] {
+        &mut self.0
+    }
+}
 
 impl<const N: usize> AsRef<[u8]> for FixedBytes<N> {
     #[inline]
@@ -100,230 +101,10 @@ impl<const N: usize> AsMut<[u8]> for FixedBytes<N> {
     }
 }
 
-impl<const N: usize> AsRef<[u8; N]> for FixedBytes<N> {
-    #[inline]
-    fn as_ref(&self) -> &[u8; N] {
-        &self.0
-    }
-}
-
-impl<const N: usize> AsMut<[u8; N]> for FixedBytes<N> {
-    #[inline]
-    fn as_mut(&mut self) -> &mut [u8; N] {
-        &mut self.0
-    }
-}
-
-impl<const N: usize> FixedBytes<N> {
-    /// Array of Zero bytes.
-    pub const ZERO: Self = Self([0u8; N]);
-
-    /// Instantiates a new fixed hash from the given bytes array.
-    #[inline]
-    pub const fn new(bytes: [u8; N]) -> Self {
-        Self(bytes)
-    }
-
-    /// Utility function to create a fixed hash with the last byte set to `x`.
-    #[inline]
-    pub const fn with_last_byte(x: u8) -> Self {
-        let mut bytes = [0u8; N];
-        bytes[N - 1] = x;
-        Self(bytes)
-    }
-
-    /// Instantiates a new fixed hash with cryptographically random content.
-    #[cfg(feature = "getrandom")]
-    #[inline]
-    pub fn random() -> Self {
-        Self::try_random().unwrap()
-    }
-
-    /// Instantiates a new fixed hash with cryptographically random content.
-    #[cfg(feature = "getrandom")]
-    pub fn try_random() -> Result<Self, getrandom::Error> {
-        let mut bytes: [_; N] = super::impl_core::uninit_array();
-        getrandom::getrandom_uninit(&mut bytes)?;
-        // SAFETY: The array is initialized by getrandom_uninit.
-        Ok(Self(unsafe { super::impl_core::array_assume_init(bytes) }))
-    }
-
-    /// Concatenate two `FixedBytes`. Due to rust constraints, the user must
-    /// specify Z. Incorrect specification will result in a panic.
-    pub const fn concat_const<const M: usize, const Z: usize>(
-        self,
-        other: FixedBytes<M>,
-    ) -> FixedBytes<Z> {
-        assert!(
-            N + M == Z,
-            "Output size `Z` must equal the sum of the input sizes `M` and `N`"
-        );
-
-        let mut result = [0u8; Z];
-        let mut i = 0;
-        while i < Z {
-            result[i] = if i >= N { other.0[i - N] } else { self.0[i] };
-            i += 1;
-        }
-        FixedBytes(result)
-    }
-
-    /// Returns a new fixed hash where all bits are set to the given byte.
-    #[inline]
-    pub const fn repeat_byte(byte: u8) -> Self {
-        Self([byte; N])
-    }
-
-    /// Returns the size of this hash in bytes.
-    #[inline]
-    pub const fn len_bytes() -> usize {
-        N
-    }
-
-    /// Extracts a byte slice containing the entire fixed hash.
-    #[inline]
-    pub const fn as_bytes(&self) -> &[u8] {
-        &self.0
-    }
-
-    /// Extracts a mutable byte slice containing the entire fixed hash.
-    #[inline]
-    pub fn as_bytes_mut(&mut self) -> &mut [u8] {
-        &mut self.0
-    }
-
-    /// Extracts a reference to the byte array containing the entire fixed hash.
-    #[inline]
-    pub const fn as_fixed_bytes(&self) -> &[u8; N] {
-        &self.0
-    }
-
-    /// Extracts a reference to the byte array containing the entire fixed hash.
-    #[inline]
-    pub fn as_fixed_bytes_mut(&mut self) -> &mut [u8; N] {
-        &mut self.0
-    }
-
-    /// Returns the inner bytes array.
-    #[inline]
-    pub const fn to_fixed_bytes(self) -> [u8; N] {
-        self.0
-    }
-
-    /// Returns a constant raw pointer to the value.
-    #[inline]
-    pub const fn as_ptr(&self) -> *const u8 {
-        self.0.as_ptr()
-    }
-
-    /// Returns a mutable raw pointer to the value.
-    #[inline]
-    pub fn as_mut_ptr(&mut self) -> *mut u8 {
-        self.0.as_mut_ptr()
-    }
-
-    /// Create a new fixed-hash from the given slice `src`.
-    ///
-    /// # Note
-    ///
-    /// The given bytes are interpreted in big endian order.
-    ///
-    /// # Panics
-    ///
-    /// If the length of `src` and the number of bytes in `Self` do not match.
-    #[track_caller]
-    pub fn from_slice(src: &[u8]) -> Self {
-        let mut bytes = [0; N];
-        bytes.copy_from_slice(src);
-        Self(bytes)
-    }
-
-    /// Returns `true` if all bits set in `b` are also set in `self`.
-    #[inline]
-    pub fn covers(&self, b: &Self) -> bool {
-        &(*b & *self) == b
-    }
-
-    /// Returns `true` if no bits are set.
-    #[inline]
-    pub fn is_zero(&self) -> bool {
-        self.as_bytes().iter().all(|x| *x == 0)
-    }
-
-    // TODO
-    // pub fn hex_encode(&self) -> String {
-    // }
-
-    /// Compile-time equality. NOT constant-time equality.
-    #[inline]
-    pub const fn const_eq(&self, other: &Self) -> bool {
-        let mut i = 0;
-        loop {
-            if self.0[i] != other.0[i] {
-                return false
-            }
-            i += 1;
-            if i == N {
-                break
-            }
-        }
-
-        true
-    }
-
-    /// Returns `true` if no bits are set.
-    #[inline]
-    pub const fn const_is_zero(&self) -> bool {
-        self.const_eq(&Self::ZERO)
-    }
-
-    /// Computes the bitwise AND of two `FixedBytes`.
-    pub const fn bit_and(self, rhs: Self) -> Self {
-        let mut ret = Self::ZERO;
-        let mut i = 0;
-        loop {
-            ret.0[i] = self.0[i] & rhs.0[i];
-            i += 1;
-            if i == N {
-                break
-            }
-        }
-        ret
-    }
-
-    /// Computes the bitwise OR of two `FixedBytes`.
-    pub const fn bit_or(self, rhs: Self) -> Self {
-        let mut ret = Self::ZERO;
-        let mut i = 0;
-        loop {
-            ret.0[i] = self.0[i] | rhs.0[i];
-            i += 1;
-            if i == N {
-                break
-            }
-        }
-        ret
-    }
-
-    /// Computes the bitwise XOR of two `FixedBytes`.
-    pub const fn bit_xor(self, rhs: Self) -> Self {
-        let mut ret = Self::ZERO;
-        let mut i = 0;
-        loop {
-            ret.0[i] = self.0[i] ^ rhs.0[i];
-            i += 1;
-            if i == N {
-                break
-            }
-        }
-        ret
-    }
-}
-
 impl<const N: usize> fmt::Debug for FixedBytes<N> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.fmt_hex(f, true)
+        self.fmt_hex::<false>(f, true)
     }
 }
 
@@ -331,7 +112,7 @@ impl<const N: usize> fmt::Display for FixedBytes<N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // If the alternate flag is NOT set, we write the full hex.
         if N <= 4 || !f.alternate() {
-            return self.fmt_hex(f, true)
+            return self.fmt_hex::<false>(f, true)
         }
 
         // If the alternate flag is set, we use middle-out compression.
@@ -351,14 +132,14 @@ impl<const N: usize> fmt::Display for FixedBytes<N> {
 impl<const N: usize> fmt::LowerHex for FixedBytes<N> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.fmt_hex(f, f.alternate())
+        self.fmt_hex::<false>(f, f.alternate())
     }
 }
 
 impl<const N: usize> fmt::UpperHex for FixedBytes<N> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.fmt_hex_upper(f, f.alternate())
+        self.fmt_hex::<true>(f, f.alternate())
     }
 }
 
@@ -423,14 +204,178 @@ impl<const N: usize> core::str::FromStr for FixedBytes<N> {
 }
 
 impl<const N: usize> FixedBytes<N> {
-    fn fmt_hex(&self, f: &mut fmt::Formatter<'_>, prefix: bool) -> fmt::Result {
-        let mut buf = hex::Buffer::<N, true>::new();
-        f.write_str(&buf.format(&self.0)[(!prefix as usize) * 2..])
+    /// Array of Zero bytes.
+    pub const ZERO: Self = Self([0u8; N]);
+
+    /// Instantiates a new fixed hash from the given bytes array.
+    #[inline]
+    pub const fn new(bytes: [u8; N]) -> Self {
+        Self(bytes)
     }
 
-    fn fmt_hex_upper(&self, f: &mut fmt::Formatter<'_>, prefix: bool) -> fmt::Result {
+    /// Utility function to create a fixed hash with the last byte set to `x`.
+    #[inline]
+    pub const fn with_last_byte(x: u8) -> Self {
+        let mut bytes = [0u8; N];
+        bytes[N - 1] = x;
+        Self(bytes)
+    }
+
+    /// Instantiates a new fixed hash with cryptographically random content.
+    #[cfg(feature = "getrandom")]
+    #[inline]
+    pub fn random() -> Self {
+        Self::try_random().unwrap()
+    }
+
+    /// Instantiates a new fixed hash with cryptographically random content.
+    #[cfg(feature = "getrandom")]
+    pub fn try_random() -> Result<Self, getrandom::Error> {
+        let mut bytes: [_; N] = super::impl_core::uninit_array();
+        getrandom::getrandom_uninit(&mut bytes)?;
+        // SAFETY: The array is initialized by getrandom_uninit.
+        Ok(Self(unsafe { super::impl_core::array_assume_init(bytes) }))
+    }
+
+    /// Concatenate two `FixedBytes`.
+    ///
+    /// Due to constraints in the language, the user must specify the value of
+    /// the output size `Z`.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `Z` is not equal to `N + M`.
+    pub const fn concat_const<const M: usize, const Z: usize>(
+        self,
+        other: FixedBytes<M>,
+    ) -> FixedBytes<Z> {
+        assert!(
+            N + M == Z,
+            "Output size `Z` must equal the sum of the input sizes `N` and `M`"
+        );
+
+        let mut result = [0u8; Z];
+        let mut i = 0;
+        while i < Z {
+            result[i] = if i >= N { other.0[i - N] } else { self.0[i] };
+            i += 1;
+        }
+        FixedBytes(result)
+    }
+
+    /// Returns a new fixed hash where all bits are set to the given byte.
+    #[inline]
+    pub const fn repeat_byte(byte: u8) -> Self {
+        Self([byte; N])
+    }
+
+    /// Returns the size of this hash in bytes.
+    #[inline]
+    pub const fn len_bytes() -> usize {
+        N
+    }
+
+    /// Create a new fixed-hash from the given slice `src`.
+    ///
+    /// # Note
+    ///
+    /// The given bytes are interpreted in big endian order.
+    ///
+    /// # Panics
+    ///
+    /// If the length of `src` and the number of bytes in `Self` do not match.
+    #[track_caller]
+    #[inline]
+    pub fn from_slice(src: &[u8]) -> Self {
+        Self(src.try_into().unwrap())
+    }
+
+    /// Returns a slice containing the entire array. Equivalent to `&s[..]`.
+    #[inline]
+    pub const fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Returns a mutable slice containing the entire array. Equivalent to
+    /// `&mut s[..]`.
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+
+    /// Returns `true` if all bits set in `b` are also set in `self`.
+    #[inline]
+    pub fn covers(&self, b: &Self) -> bool {
+        &(*b & *self) == b
+    }
+
+    /// Returns `true` if no bits are set.
+    #[inline]
+    pub fn is_zero(&self) -> bool {
+        *self == Self::ZERO
+    }
+
+    /// Compile-time equality. NOT constant-time equality.
+    #[inline]
+    pub const fn const_eq(&self, other: &Self) -> bool {
+        let mut i = 0;
+        while i < N {
+            if self.0[i] != other.0[i] {
+                return false
+            }
+            i += 1;
+        }
+
+        true
+    }
+
+    /// Returns `true` if no bits are set.
+    #[inline]
+    pub const fn const_is_zero(&self) -> bool {
+        self.const_eq(&Self::ZERO)
+    }
+
+    /// Computes the bitwise AND of two `FixedBytes`.
+    pub const fn bit_and(self, rhs: Self) -> Self {
+        let mut ret = Self::ZERO;
+        let mut i = 0;
+        while i < N {
+            ret.0[i] = self.0[i] & rhs.0[i];
+            i += 1;
+        }
+        ret
+    }
+
+    /// Computes the bitwise OR of two `FixedBytes`.
+    pub const fn bit_or(self, rhs: Self) -> Self {
+        let mut ret = Self::ZERO;
+        let mut i = 0;
+        while i < N {
+            ret.0[i] = self.0[i] | rhs.0[i];
+            i += 1;
+        }
+        ret
+    }
+
+    /// Computes the bitwise XOR of two `FixedBytes`.
+    pub const fn bit_xor(self, rhs: Self) -> Self {
+        let mut ret = Self::ZERO;
+        let mut i = 0;
+        while i < N {
+            ret.0[i] = self.0[i] ^ rhs.0[i];
+            i += 1;
+        }
+        ret
+    }
+
+    fn fmt_hex<const UPPER: bool>(&self, f: &mut fmt::Formatter<'_>, prefix: bool) -> fmt::Result {
         let mut buf = hex::Buffer::<N, true>::new();
-        f.write_str(&buf.format_upper(&self.0)[(!prefix as usize) * 2..])
+        let s = if UPPER {
+            buf.format_upper(self)
+        } else {
+            buf.format(self)
+        };
+        f.write_str(&s[(!prefix as usize) * 2..])
     }
 }
 

--- a/crates/sol-types/src/types/data_type.rs
+++ b/crates/sol-types/src/types/data_type.rs
@@ -424,7 +424,7 @@ where
         let rust = rust.borrow();
         let encoded = rust
             .iter()
-            .flat_map(|element| T::eip712_data_word(element).to_fixed_bytes())
+            .flat_map(|element| T::eip712_data_word(element).0)
             .collect::<Vec<u8>>();
         keccak256(encoded)
     }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,7 +2,8 @@ reorder_imports = true
 use_field_init_shorthand = true
 
 # Nightly
-imports_granularity = "Crate"
-wrap_comments = true
+max_width = 100
 comment_width = 80
+imports_granularity = "Crate"
 trailing_semicolon = false
+wrap_comments = true


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

- derive Into, IntoIterator
- impl PartialEq, PartialOrd, Borrow with bytes
- better Address docs and impls
- checksum in Address Display
- some methods like `as_ptr` don't need to be implemented here because we deref to array/slice
- rename `as_bytes` to `as_slice` because we are already bytes

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
