### PR TITLE
[WIP] feature preview: introduce Encodable associated type

### DIFF
--- a/crates/sol-types/src/coder/token.rs
+++ b/crates/sol-types/src/coder/token.rs
@@ -317,6 +317,13 @@ impl<T, const N: usize> FixedSeqToken<T, N> {
 #[derive(Clone, Debug, PartialEq)]
 pub struct DynSeqToken<T>(pub Vec<T>);
 
+impl<T> FromIterator<T> for DynSeqToken<T> {
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
 impl<T> From<Vec<T>> for DynSeqToken<T> {
     #[inline]
     fn from(value: Vec<T>) -> Self {
@@ -399,6 +406,12 @@ impl<T> DynSeqToken<T> {
 /// A Packed Sequence - `bytes` or `string`
 #[derive(Clone, PartialEq)]
 pub struct PackedSeqToken(pub Vec<u8>);
+
+impl From<&[u8]> for PackedSeqToken {
+    fn from(value: &[u8]) -> Self {
+        Self(value.to_vec())
+    }
+}
 
 impl From<Vec<u8>> for PackedSeqToken {
     fn from(value: Vec<u8>) -> Self {

--- a/crates/sol-types/src/types/event/topic.rs
+++ b/crates/sol-types/src/types/event/topic.rs
@@ -142,18 +142,30 @@ macro_rules! array_impl {
     };
 }
 
-impl<T: EventTopic> EventTopic for Array<T> {
+impl<T: EventTopic> EventTopic for Array<T>
+where
+    for<'a> <T as SolType>::Encodable<'a>: 'a,
+{
     array_impl!(T);
 }
 
-impl<T: EventTopic, const N: usize> EventTopic for FixedArray<T, N> {
+impl<T: EventTopic, const N: usize> EventTopic for FixedArray<T, N>
+where
+    for<'a> <T as SolType>::Encodable<'a>: 'a,
+{
     array_impl!(T);
 }
 
 macro_rules! tuple_impls {
     ($($t:ident),+) => {
         #[allow(non_snake_case)]
-        impl<$($t: EventTopic,)+> EventTopic for ($($t,)+) {
+        impl<$($t: EventTopic,)+> EventTopic for ($($t,)+)
+        where
+        $(
+            for<'a> <$t as SolType>::Encodable<'a>: 'a,
+        )+
+
+        {
             #[inline]
             fn topic_preimage_length<B: Borrow<Self::RustType>>(rust: B) -> usize {
                 let ($($t,)+) = rust.borrow();

--- a/crates/sol-types/src/types/event/topic_list.rs
+++ b/crates/sol-types/src/types/event/topic_list.rs
@@ -32,7 +32,12 @@ mod sealed {
 macro_rules! impl_topic_list_tuples {
     ($($c:literal => $($t:ident),*;)+) => {$(
         impl<$($t: SolType<TokenType = WordToken>,)*> sealed::Sealed for ($($t,)*) {}
-        impl<$($t: SolType<TokenType = WordToken>,)*> TopicList for ($($t,)*) {
+        impl<$($t: SolType<TokenType = WordToken>,)*> TopicList for ($($t,)*)
+        where
+        $(
+            for<'a> <$t as SolType>::Encodable<'a>: 'a,
+        )+
+        {
             const COUNT: usize = $c;
 
             fn detokenize<I, D>(topics: I) -> Result<Self::RustType>

--- a/crates/sol-types/src/types/struct.rs
+++ b/crates/sol-types/src/types/struct.rs
@@ -131,6 +131,7 @@ pub trait SolStruct {
 impl<T: SolStruct> SolType for T {
     type RustType = T;
     type TokenType = TupleTokenTypeFor<T>;
+    type Encodable<'a> = T;
 
     const DYNAMIC: bool = TupleFor::<T>::DYNAMIC;
 
@@ -159,6 +160,11 @@ impl<T: SolStruct> SolType for T {
     #[inline]
     fn tokenize<B: Borrow<Self::RustType>>(rust: B) -> Self::TokenType {
         let tuple = rust.borrow().to_rust();
+        TupleFor::<T>::tokenize(tuple)
+    }
+
+    fn tokenize_2<'a>(encodable: &Self::Encodable<'a>) -> Self::TokenType {
+        let tuple = encodable.to_rust();
         TupleFor::<T>::tokenize(tuple)
     }
 

--- a/crates/sol-types/src/types/type.rs
+++ b/crates/sol-types/src/types/type.rs
@@ -50,6 +50,10 @@ pub trait SolType {
     /// See implementers of [`TokenType`].
     type TokenType: TokenType;
 
+    /// Concrete rust types which can be encoded by this type.
+    // TODO: when default associated types are avilable, set the default
+    type Encodable<'a>; // = &'a Self::RustType;
+
     /// The encoded size of the type, if known at compile time
     const ENCODED_SIZE: Option<usize> = Some(32);
 
@@ -79,6 +83,9 @@ pub trait SolType {
 
     /// Tokenize.
     fn tokenize<B: Borrow<Self::RustType>>(rust: B) -> Self::TokenType;
+
+    /// Tokenize
+    fn tokenize_2<'a>(encodable: &Self::Encodable<'a>) -> Self::TokenType;
 
     /// The encoded struct type (as EIP-712), if any. None for non-structs.
     #[inline]


### PR DESCRIPTION
This is a WIP

## Motivation

The current `Borrow` bound on `tokenize` is really annoying as it mandates copying data before tokenization, and often AGAIN during tokenization and AGAIN during coding

## Solution

- Introduce a new `Encodable<'a>` associated type
- make a `tokenize` method that takes `&Self::Encodable<'a>
- implement encodable and tokenize for existing `SolType` types

### Not Done 

- replace old `tokenize`
- update `sol!`
- tests

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
