### PR TITLE
fix: remove to_rust from most traits

### DIFF
--- a/crates/sol-macro/src/expand/error.rs
+++ b/crates/sol-macro/src/expand/error.rs
@@ -57,11 +57,7 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, error: &ItemError) -> Result<TokenStream>
                 const SIGNATURE: &'static str = #signature;
                 const SELECTOR: [u8; 4] = #selector;
 
-                fn to_rust<'a>(&self) -> <Self::Tuple<'a> as ::alloy_sol_types::SolType>::RustType {
-                    self.clone().into()
-                }
-
-                fn from_rust<'a>(tuple: <Self::Tuple<'a> as ::alloy_sol_types::SolType>::RustType) -> Self {
+                fn new<'a>(tuple: <Self::Tuple<'a> as ::alloy_sol_types::SolType>::RustType) -> Self {
                     tuple.into()
                 }
 

--- a/crates/sol-macro/src/expand/event.rs
+++ b/crates/sol-macro/src/expand/event.rs
@@ -55,12 +55,6 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, event: &ItemEvent) -> Result<TokenStream>
         quote!(#name: #param)
     });
 
-    let data_tuple_names = event
-        .non_indexed_params()
-        .map(|p| p.name.as_ref())
-        .enumerate()
-        .map(anon_name);
-
     let topic_tuple_names = event
         .indexed_params()
         .map(|p| p.name.as_ref())
@@ -139,11 +133,6 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, event: &ItemEvent) -> Result<TokenStream>
                     Self {
                         #(#new_impl,)*
                     }
-                }
-
-                fn body(&self) -> <Self::DataTuple<'_> as ::alloy_sol_types::SolType>::RustType {
-                    // TODO: Avoid cloning
-                    (#(self.#data_tuple_names.clone(),)*)
                 }
 
                 fn tokenize_body(&self) -> Self::DataToken<'_> {

--- a/crates/sol-macro/src/expand/function.rs
+++ b/crates/sol-macro/src/expand/function.rs
@@ -82,11 +82,7 @@ fn expand_call(
                 const SIGNATURE: &'static str = #signature;
                 const SELECTOR: [u8; 4] = #selector;
 
-                fn to_rust<'a>(&self) -> <Self::Tuple<'a> as ::alloy_sol_types::SolType>::RustType {
-                    self.clone().into()
-                }
-
-                fn from_rust<'a>(tuple: <Self::Tuple<'a> as ::alloy_sol_types::SolType>::RustType) -> Self {
+                fn new<'a>(tuple: <Self::Tuple<'a> as ::alloy_sol_types::SolType>::RustType) -> Self {
                     tuple.into()
                 }
 

--- a/crates/sol-macro/src/expand/struct.rs
+++ b/crates/sol-macro/src/expand/struct.rs
@@ -111,7 +111,7 @@ pub(super) fn expand(_cx: &ExpCtxt<'_>, s: &ItemStruct) -> Result<TokenStream> {
                     self.clone().into()
                 }
 
-                fn from_rust<'a>(tuple: UnderlyingRustTuple<'a>) -> Self {
+                fn new<'a>(tuple: UnderlyingRustTuple<'a>) -> Self {
                     tuple.into()
                 }
 

--- a/crates/sol-types/src/types/call.rs
+++ b/crates/sol-types/src/types/call.rs
@@ -1,4 +1,4 @@
-use crate::{no_std_prelude::*, token::TokenSeq, Result, SolType};
+use crate::{no_std_prelude::*, token::TokenSeq, Result, SolType, TokenType, Word};
 
 /// Solidity call (a tuple with a selector).
 ///
@@ -22,12 +22,8 @@ pub trait SolCall: Sized {
     /// The function selector: `keccak256(SIGNATURE)[0..4]`
     const SELECTOR: [u8; 4];
 
-    // TODO: avoid clones here
-    /// Converts to the tuple type used for ABI encoding and decoding.
-    fn to_rust<'a>(&self) -> <Self::Tuple<'a> as SolType>::RustType;
-
     /// Convert from the tuple type used for ABI encoding and decoding.
-    fn from_rust(tuple: <Self::Tuple<'_> as SolType>::RustType) -> Self;
+    fn new(tuple: <Self::Tuple<'_> as SolType>::RustType) -> Self;
 
     /// Tokenize the call's arguments.
     fn tokenize(&self) -> Self::Token<'_>;
@@ -39,14 +35,14 @@ pub trait SolCall: Sized {
             return size
         }
 
-        <<Self as SolCall>::Tuple<'_> as SolType>::encoded_size(&self.to_rust())
+        self.tokenize().total_words() * Word::len_bytes()
     }
 
     /// ABI decode this call's arguments from the given slice, **without** its
     /// selector.
     #[inline]
     fn decode_raw(data: &[u8], validate: bool) -> Result<Self> {
-        <Self::Tuple<'_> as SolType>::decode(data, validate).map(Self::from_rust)
+        <Self::Tuple<'_> as SolType>::decode(data, validate).map(Self::new)
     }
 
     /// ABI decode this call's arguments from the given slice, **with** the

--- a/crates/sol-types/src/types/event/mod.rs
+++ b/crates/sol-types/src/types/event/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     token::{TokenSeq, WordToken},
-    Result, SolType,
+    Result, SolType, TokenType, Word,
 };
 use alloc::vec::Vec;
 use alloy_primitives::{FixedBytes, B256};
@@ -58,10 +58,6 @@ pub trait SolEvent: Sized {
         data: <Self::DataTuple<'_> as SolType>::RustType,
     ) -> Self;
 
-    // TODO: avoid clones here
-    /// The event's non-indexed parameters.
-    fn body(&self) -> <Self::DataTuple<'_> as SolType>::RustType;
-
     /// Tokenize the event's non-indexed parameters.
     fn tokenize_body(&self) -> Self::DataToken<'_>;
 
@@ -76,7 +72,8 @@ pub trait SolEvent: Sized {
         if let Some(size) = <Self::DataTuple<'_> as SolType>::ENCODED_SIZE {
             return size
         }
-        <Self::DataTuple<'_>>::encoded_size(&self.body())
+
+        self.tokenize_body().total_words() * Word::len_bytes()
     }
 
     /// ABI-encode the dynamic data of this event into the given buffer.


### PR DESCRIPTION

## Motivation

Mostly closes #90 

Exception is `SolStruct::to_rust` for reasons found here:
https://github.com/alloy-rs/core/issues/90#issuecomment-1599687204


## Solution

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
