### PR TITLE
Refactoring `dyn-abi` to performance parity with ethabi

### DIFF
--- a/crates/dyn-abi/README.md
+++ b/crates/dyn-abi/README.md
@@ -29,7 +29,7 @@ let uints = DynSolValue::FixedArray(vec![0u8.into(), 1u8.into()]);
 let my_values = DynSolValue::Array(vec![uints]);
 
 // encode
-let encoded = my_type.encode_single(my_values.clone()).unwrap();
+let encoded = my_type.encode_single(&my_values).unwrap();
 
 // decode
 let decoded = my_type.decode_single(&encoded).unwrap();
@@ -56,8 +56,8 @@ instance of [`DynSolType`]. This type is used to tokenize and detokenize
 [`DynSolValue`] instances. The [`std::str::FromStr`] impl is used to parse a
 solidity type string into a [`DynSolType`] object.
 
-- Tokenizing:   `DynSolType` + `DynSolValue` = `DynToken`
-- Detokenizing: `DynSolType` + `DynToken`    = `DynSolValue`
+- Tokenizing: `DynSolType` + `DynSolValue` = `DynToken`
+- Detokenizing: `DynSolType` + `DynToken` = `DynSolValue`
 
 Users must manually handle the conversions between [`DynSolValue`] and their
 own rust types. We provide several `From` implementations, but they fall

--- a/crates/dyn-abi/README.md
+++ b/crates/dyn-abi/README.md
@@ -29,7 +29,7 @@ let uints = DynSolValue::FixedArray(vec![0u8.into(), 1u8.into()]);
 let my_values = DynSolValue::Array(vec![uints]);
 
 // encode
-let encoded = my_type.encode_single(&my_values).unwrap();
+let encoded = my_values.encode_single();
 
 // decode
 let decoded = my_type.decode_single(&encoded).unwrap();

--- a/crates/dyn-abi/README.md
+++ b/crates/dyn-abi/README.md
@@ -51,18 +51,15 @@ equivalent to an enum over types used as [`crate::SolType::RustType`]. The
 the types implementing the [`alloy_sol_types::TokenType`] trait.
 
 Where the static encoding system encodes the expected type information into
-the rust type system, the dynamic encoder/decoder encodes it as a concrete
-instance of [`DynSolType`]. This type is used to tokenize and detokenize
-[`DynSolValue`] instances. The [`std::str::FromStr`] impl is used to parse a
-solidity type string into a [`DynSolType`] object.
+the Rust type system, the dynamic encoder/decoder encodes it as a concrete
+instance of [`DynSolType`].
 
-- Tokenizing: `DynSolType` + `DynSolValue` = `DynToken`
 - Detokenizing: `DynSolType` + `DynToken` = `DynSolValue`
 
 Users must manually handle the conversions between [`DynSolValue`] and their
 own rust types. We provide several `From` implementations, but they fall
-short when dealing with arrays and tuples. We also provide fallible casts
-into the contents of each variant.
+short when dealing with arrays, tuples and structs. We also provide fallible
+casts into the contents of each variant.
 
 ## `DynToken::decode_populate`
 

--- a/crates/dyn-abi/README.md
+++ b/crates/dyn-abi/README.md
@@ -29,7 +29,7 @@ let uints = DynSolValue::FixedArray(vec![0u8.into(), 1u8.into()]);
 let my_values = DynSolValue::Array(vec![uints]);
 
 // encode
-let encoded = my_values.encode_single();
+let encoded = my_values.clone().encode_single();
 
 // decode
 let decoded = my_type.decode_single(&encoded).unwrap();

--- a/crates/dyn-abi/benches/abi.rs
+++ b/crates/dyn-abi/benches/abi.rs
@@ -54,27 +54,15 @@ fn dyn_abi_encode(c: &mut Criterion) {
     g.bench_function("single", |b| {
         let input = encode_single_input();
         b.iter(|| {
-            let ty = DynSolType::String;
             let value = DynSolValue::String(input.clone());
-            ty.encode_single(black_box(&value))
+            black_box(&value).encode()
         });
     });
 
     g.bench_function("struct", |b| {
-        let tys = vec![
-            DynSolType::Address,
-            DynSolType::Address,
-            DynSolType::Uint(24),
-            DynSolType::Address,
-            DynSolType::Uint(256),
-            DynSolType::Uint(256),
-            DynSolType::Uint(256),
-            DynSolType::Uint(160),
-        ];
-        let ty = DynSolType::Tuple(tys);
         let input = encode_struct_sol_values();
         let input = DynSolValue::Tuple(input.to_vec());
-        b.iter(|| ty.encode_sequence(black_box(&input)));
+        b.iter(|| black_box(&input).encode());
     });
 
     g.finish();

--- a/crates/dyn-abi/benches/abi.rs
+++ b/crates/dyn-abi/benches/abi.rs
@@ -59,10 +59,22 @@ fn dyn_abi_encode(c: &mut Criterion) {
         });
     });
 
-    g.bench_function("struct", |b| {
+    g.bench_function("tokenize_struct", |b| {
+        let input = encode_struct_sol_values();
+        let input = DynSolValue::Tuple(input.to_vec());
+        b.iter(|| black_box(&input).tokenize());
+    });
+
+    g.bench_function("new_struct", |b| {
         let input = encode_struct_sol_values();
         let input = DynSolValue::Tuple(input.to_vec());
         b.iter(|| black_box(&input).encode());
+    });
+
+    g.bench_function("struct", |b| {
+        let input = encode_struct_sol_values();
+        let input = DynSolValue::Tuple(input.to_vec());
+        b.iter(|| black_box(&input).old_encode());
     });
 
     g.finish();

--- a/crates/dyn-abi/benches/abi.rs
+++ b/crates/dyn-abi/benches/abi.rs
@@ -56,7 +56,7 @@ fn dyn_abi_encode(c: &mut Criterion) {
         b.iter(|| {
             let ty = DynSolType::String;
             let value = DynSolValue::String(input.clone());
-            ty.encode_single(black_box(value))
+            ty.encode_single(black_box(&value))
         });
     });
 
@@ -74,7 +74,7 @@ fn dyn_abi_encode(c: &mut Criterion) {
         let ty = DynSolType::Tuple(tys);
         let input = encode_struct_sol_values();
         let input = DynSolValue::Tuple(input.to_vec());
-        b.iter(|| ty.encode_single(black_box(&input).clone()));
+        b.iter(|| ty.encode_single(black_box(&input)));
     });
 
     g.finish();

--- a/crates/dyn-abi/benches/abi.rs
+++ b/crates/dyn-abi/benches/abi.rs
@@ -59,22 +59,10 @@ fn dyn_abi_encode(c: &mut Criterion) {
         });
     });
 
-    g.bench_function("tokenize_struct", |b| {
-        let input = encode_struct_sol_values();
-        let input = DynSolValue::Tuple(input.to_vec());
-        b.iter(|| black_box(&input).tokenize());
-    });
-
-    g.bench_function("new_struct", |b| {
-        let input = encode_struct_sol_values();
-        let input = DynSolValue::Tuple(input.to_vec());
-        b.iter(|| black_box(&input).encode());
-    });
-
     g.bench_function("struct", |b| {
         let input = encode_struct_sol_values();
         let input = DynSolValue::Tuple(input.to_vec());
-        b.iter(|| black_box(&input).old_encode());
+        b.iter(|| black_box(&input).encode());
     });
 
     g.finish();

--- a/crates/dyn-abi/benches/abi.rs
+++ b/crates/dyn-abi/benches/abi.rs
@@ -55,7 +55,7 @@ fn dyn_abi_encode(c: &mut Criterion) {
         let input = encode_single_input();
         b.iter(|| {
             let value = DynSolValue::String(input.clone());
-            black_box(&value).encode()
+            black_box(value).encode_single()
         });
     });
 

--- a/crates/dyn-abi/benches/abi.rs
+++ b/crates/dyn-abi/benches/abi.rs
@@ -74,7 +74,7 @@ fn dyn_abi_encode(c: &mut Criterion) {
         let ty = DynSolType::Tuple(tys);
         let input = encode_struct_sol_values();
         let input = DynSolValue::Tuple(input.to_vec());
-        b.iter(|| ty.encode_single(black_box(&input)));
+        b.iter(|| ty.encode_sequence(black_box(&input)));
     });
 
     g.finish();

--- a/crates/dyn-abi/src/lib.rs
+++ b/crates/dyn-abi/src/lib.rs
@@ -69,7 +69,7 @@ mod tests {
         let my_values = DynSolValue::Array(vec![uints]);
 
         // tokenize and detokenize
-        let tokens = my_type.tokenize(my_values.clone()).unwrap();
+        let tokens = my_type.tokenize(&my_values).unwrap();
         let detokenized = my_type.detokenize(tokens.clone()).unwrap();
         assert_eq!(detokenized, my_values);
 

--- a/crates/dyn-abi/src/lib.rs
+++ b/crates/dyn-abi/src/lib.rs
@@ -69,7 +69,7 @@ mod tests {
         let my_values = DynSolValue::Array(vec![uints]);
 
         // tokenize and detokenize
-        let tokens = my_type.tokenize(&my_values).unwrap();
+        let tokens = my_values.tokenize();
         let detokenized = my_type.detokenize(tokens.clone()).unwrap();
         assert_eq!(detokenized, my_values);
 

--- a/crates/dyn-abi/src/lib.rs
+++ b/crates/dyn-abi/src/lib.rs
@@ -74,9 +74,7 @@ mod tests {
         assert_eq!(detokenized, my_values);
 
         // encode
-        let mut encoder = Encoder::default();
-        tokens.encode_single(&mut encoder).unwrap();
-        let encoded = encoder.into_bytes();
+        let encoded = my_values.encode_single();
 
         // decode
         let mut decoder = Decoder::new(&encoded, true);

--- a/crates/dyn-abi/src/lib.rs
+++ b/crates/dyn-abi/src/lib.rs
@@ -29,7 +29,7 @@ extern crate alloc;
 
 mod no_std_prelude {
     pub(crate) use alloc::{
-        borrow::{Borrow, ToOwned},
+        borrow::{Borrow, Cow, ToOwned},
         boxed::Box,
         string::{String, ToString},
         vec::Vec,

--- a/crates/dyn-abi/src/lib.rs
+++ b/crates/dyn-abi/src/lib.rs
@@ -74,7 +74,7 @@ mod tests {
         assert_eq!(detokenized, my_values);
 
         // encode
-        let encoded = my_values.encode_single();
+        let encoded = my_values.clone().encode_single();
 
         // decode
         let mut decoder = Decoder::new(&encoded, true);

--- a/crates/dyn-abi/src/token.rs
+++ b/crates/dyn-abi/src/token.rs
@@ -265,12 +265,6 @@ impl<'a> DynToken<'a> {
         }
     }
 
-    /// Encode a single item of this type, as a sequence of length 1.
-    #[inline]
-    pub(crate) fn encode_single(&'a self, enc: &mut Encoder) -> Result<()> {
-        Self::FixedSeq(core::slice::from_ref(self).into(), 1).encode_sequence(enc)
-    }
-
     /// Decode a single item of this type, as a sequence of length 1.
     #[inline]
     pub(crate) fn decode_single_populate(&mut self, dec: &mut Decoder<'a>) -> Result<()> {

--- a/crates/dyn-abi/src/type.rs
+++ b/crates/dyn-abi/src/type.rs
@@ -28,7 +28,7 @@ struct StructProp {
 /// let my_type = DynSolType::Uint(256);
 /// let my_data: DynSolValue = U256::from(183).into();
 ///
-/// let encoded = my_data.encode_single();
+/// let encoded = my_data.clone().encode_single();
 /// let decoded = my_type.decode_single(&encoded)?;
 ///
 /// assert_eq!(decoded, my_data);
@@ -36,7 +36,7 @@ struct StructProp {
 /// let my_type = DynSolType::Array(Box::new(DynSolType::Uint(256)));
 /// let my_data = DynSolValue::Array(vec![my_data.clone()]);
 ///
-/// let encoded = my_data.encode_single();
+/// let encoded = my_data.clone().encode_single();
 /// let decoded = my_type.decode_single(&encoded)?;
 ///
 /// assert_eq!(decoded, my_data);
@@ -276,7 +276,7 @@ mod tests {
             DynToken::FixedSeq(vec![DynToken::Word(word1), DynToken::Word(word2)].into(), 2)
         );
         let mut enc = crate::Encoder::default();
-        token.encode_sequence(&mut enc).unwrap();
+        val.encode_sequence(&mut enc).unwrap();
         assert_eq!(enc.finish(), vec![word1, word2]);
     }
 

--- a/crates/dyn-abi/src/type.rs
+++ b/crates/dyn-abi/src/type.rs
@@ -91,7 +91,7 @@ impl DynSolType {
             (DynSolType::Bool, DynSolValue::Bool(val)) => Ok(DynToken::Word(
                 alloy_sol_types::Encodable::<sol_data::Bool>::to_tokens(val).0,
             )),
-            (DynSolType::Bytes, DynSolValue::Bytes(val)) => Ok(DynToken::PackedSeq(&val)),
+            (DynSolType::Bytes, DynSolValue::Bytes(val)) => Ok(DynToken::PackedSeq(val)),
             (DynSolType::FixedBytes(len), DynSolValue::FixedBytes(word, size)) => {
                 if size != len {
                     return Err(crate::Error::custom(format!(
@@ -120,7 +120,7 @@ impl DynSolType {
             }
             (DynSolType::Array(t), DynSolValue::Array(values)) => {
                 let contents: Vec<_> = values
-                    .into_iter()
+                    .iter()
                     .map(|val| t.tokenize(val))
                     .collect::<Result<_, _>>()?;
                 let template = Box::new(contents.first().unwrap().clone());
@@ -139,7 +139,7 @@ impl DynSolType {
                 }
                 Ok(DynToken::FixedSeq(
                     tokens
-                        .into_iter()
+                        .iter()
                         .map(|token| t.tokenize(token))
                         .collect::<Result<_, _>>()?,
                     *size,
@@ -195,7 +195,7 @@ impl DynSolType {
                 let len = tuple.len();
                 let tuple = tuple
                     .iter()
-                    .zip(tuple_val.into_iter())
+                    .zip(tuple_val.iter())
                     .map(|(ty, token)| ty.tokenize(token))
                     .collect::<Result<_, _>>()?;
                 Ok(DynToken::FixedSeq(tuple, len))
@@ -385,7 +385,7 @@ impl DynSolType {
     /// type. Is a no-op if this type or the values are not a sequence.
     pub fn encode_sequence(&self, values: &DynSolValue) -> Result<Vec<u8>> {
         let mut encoder = crate::Encoder::default();
-        self.tokenize(&values)?.encode_sequence(&mut encoder)?;
+        self.tokenize(values)?.encode_sequence(&mut encoder)?;
         Ok(encoder.into_bytes())
     }
 

--- a/crates/dyn-abi/src/type.rs
+++ b/crates/dyn-abi/src/type.rs
@@ -215,7 +215,7 @@ impl DynSolType {
             ),
             DynSolType::Array(t) => DynToken::DynSeq {
                 contents: Default::default(),
-                template: Box::new(t.empty_dyn_token()),
+                template: Some(Box::new(t.empty_dyn_token())),
             },
             DynSolType::FixedArray(t, size) => {
                 DynToken::FixedSeq(vec![t.empty_dyn_token(); *size].into(), *size)

--- a/crates/dyn-abi/src/type.rs
+++ b/crates/dyn-abi/src/type.rs
@@ -276,7 +276,7 @@ mod tests {
             DynToken::FixedSeq(vec![DynToken::Word(word1), DynToken::Word(word2)].into(), 2)
         );
         let mut enc = crate::Encoder::default();
-        val.encode_sequence(&mut enc).unwrap();
+        DynSolValue::encode_sequence(val.as_fixed_seq().unwrap(), &mut enc);
         assert_eq!(enc.finish(), vec![word1, word2]);
     }
 

--- a/crates/dyn-abi/src/type.rs
+++ b/crates/dyn-abi/src/type.rs
@@ -28,7 +28,7 @@ struct StructProp {
 /// let my_type = DynSolType::Uint(256);
 /// let my_data: DynSolValue = U256::from(183).into();
 ///
-/// let encoded = my_type.encode_single(&my_data)?;
+/// let encoded = my_data.encode_single();
 /// let decoded = my_type.decode_single(&encoded)?;
 ///
 /// assert_eq!(decoded, my_data);
@@ -36,7 +36,7 @@ struct StructProp {
 /// let my_type = DynSolType::Array(Box::new(DynSolType::Uint(256)));
 /// let my_data = DynSolValue::Array(vec![my_data.clone()]);
 ///
-/// let encoded = my_type.encode_single(&my_data)?;
+/// let encoded = my_data.encode_single();
 /// let decoded = my_type.decode_single(&encoded)?;
 ///
 /// assert_eq!(decoded, my_data);
@@ -366,27 +366,12 @@ impl DynSolType {
         }
     }
 
-    /// Encode a single value. Fails if the value does not match this type.
-    pub fn encode_single(&self, value: &DynSolValue) -> Result<Vec<u8>> {
-        let mut encoder = crate::Encoder::default();
-        self.tokenize(value)?.encode_single(&mut encoder)?;
-        Ok(encoder.into_bytes())
-    }
-
     /// Decode a single value. Fails if the value does not match this type.
     pub fn decode_single(&self, data: &[u8]) -> Result<DynSolValue> {
         let mut decoder = crate::Decoder::new(data, false);
         let mut token = self.empty_dyn_token();
         token.decode_single_populate(&mut decoder)?;
         self.detokenize(token)
-    }
-
-    /// Encode a sequence of values. Fails if the values do not match this
-    /// type. Is a no-op if this type or the values are not a sequence.
-    pub fn encode_sequence(&self, values: &DynSolValue) -> Result<Vec<u8>> {
-        let mut encoder = crate::Encoder::default();
-        self.tokenize(values)?.encode_sequence(&mut encoder)?;
-        Ok(encoder.into_bytes())
     }
 
     /// Decode a sequence of values. Fails if the values do not match this type.

--- a/crates/dyn-abi/src/value.rs
+++ b/crates/dyn-abi/src/value.rs
@@ -470,7 +470,6 @@ impl DynSolValue {
             return
         }
 
-        dbg!(self);
         unreachable!()
     }
 

--- a/crates/dyn-abi/src/value.rs
+++ b/crates/dyn-abi/src/value.rs
@@ -49,20 +49,20 @@ pub enum DynSolValue {
 
 impl DynSolValue {
     /// The Solidity type name.
-    pub fn sol_type_name(&self) -> String {
+    pub fn sol_type_name(&self) -> Cow<'_, str> {
         match self {
-            Self::Address(_) => "address".to_string(),
-            Self::Bool(_) => "bool".to_string(),
-            Self::Bytes(_) => "bytes".to_string(),
-            Self::FixedBytes(_, size) => format!("bytes{}", size),
-            Self::Int(_, size) => format!("int{}", size),
-            Self::Uint(_, size) => format!("uint{}", size),
-            Self::String(_) => "string".to_string(),
-            Self::Tuple(_) => "tuple".to_string(),
-            Self::Array(_) => "array".to_string(),
-            Self::FixedArray(_) => "fixed_array".to_string(),
-            Self::CustomStruct { name, .. } => name.clone(),
-            Self::CustomValue { name, .. } => name.clone(),
+            Self::Address(_) => Cow::Borrowed("address"),
+            Self::Bool(_) => Cow::Borrowed("bool"),
+            Self::Bytes(_) => Cow::Borrowed("bytes"),
+            Self::FixedBytes(_, size) => Cow::Owned(format!("bytes{}", size)),
+            Self::Int(_, size) => Cow::Owned(format!("int{}", size)),
+            Self::Uint(_, size) => Cow::Owned(format!("uint{}", size)),
+            Self::String(_) => Cow::Borrowed("string"),
+            Self::Tuple(_) => Cow::Borrowed("tuple"),
+            Self::Array(_) => Cow::Borrowed("array"),
+            Self::FixedArray(_) => Cow::Borrowed("fixed_array"),
+            Self::CustomStruct { name, .. } => Cow::Borrowed(name),
+            Self::CustomValue { name, .. } => Cow::Borrowed(name),
         }
     }
 
@@ -301,11 +301,6 @@ impl DynSolValue {
             .expect("tokens is definitely a sequence");
 
         Some(encoder.into_bytes())
-    }
-
-    ///
-    pub fn detokenize_populate() -> Self {
-        todo!()
     }
 }
 

--- a/crates/dyn-abi/src/value.rs
+++ b/crates/dyn-abi/src/value.rs
@@ -1,6 +1,6 @@
 use crate::{
     no_std_prelude::{Cow, *},
-    DynToken, Word,
+    DynSolType, DynToken, Word,
 };
 use alloy_primitives::{Address, I256, U256};
 use alloy_sol_types::Encoder;
@@ -49,24 +49,6 @@ pub enum DynSolValue {
 }
 
 impl DynSolValue {
-    /// The Solidity type name.
-    pub fn sol_type_name(&self) -> Cow<'_, str> {
-        match self {
-            Self::Address(_) => Cow::Borrowed("address"),
-            Self::Bool(_) => Cow::Borrowed("bool"),
-            Self::Bytes(_) => Cow::Borrowed("bytes"),
-            Self::FixedBytes(_, size) => Cow::Owned(format!("bytes{}", size)),
-            Self::Int(_, size) => Cow::Owned(format!("int{}", size)),
-            Self::Uint(_, size) => Cow::Owned(format!("uint{}", size)),
-            Self::String(_) => Cow::Borrowed("string"),
-            Self::Tuple(_) => Cow::Borrowed("tuple"),
-            Self::Array(_) => Cow::Borrowed("array"),
-            Self::FixedArray(_) => Cow::Borrowed("fixed_array"),
-            Self::CustomStruct { name, .. } => Cow::Borrowed(name),
-            Self::CustomValue { name, .. } => Cow::Borrowed(name),
-        }
-    }
-
     /// Trust if this value is encoded as a single word. False otherwise.
     pub const fn is_word(&self) -> bool {
         matches!(


### PR DESCRIPTION
This PR brings dyn-abi to performance parity with ethabi (or better) on all benchmarks

It does this by

- removing unnecessary type checks during value encoding
- removing buffer copies during decoding into tokens
- bypassing tokenization during value encoding

Followup work may bypass decoding into tokens and decode directly into values

## Motivation

dyn-abi is slow and should be fast 😤 

## Solution

make it faster

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
