### PR TITLE
fix(alloy-primitives): fix broken documentation link

### DIFF
--- a/crates/primitives/README.md
+++ b/crates/primitives/README.md
@@ -21,7 +21,7 @@ Primitive types shared by [alloy], [foundry], [revm], and [reth].
 This library has straightforward, basic, types. Usage is correspondingly simple.
 Please consult [the documentation][docs] for more information.
 
-[docs]: https://docs.rs/alloy-types/latest/alloy-types/
+[docs]: https://docs.rs/alloy-primitives/latest/alloy_primitives/
 
 ```rust
 use alloy_primitives::{U256, Address, FixedBytes, I256};


### PR DESCRIPTION
## Motivation

Noticed broken crate link.

## Solution

Found what I think is the correct crate and updated the link. Presumably this happened because of a name change.

Note: I read through the contribution guidelines, but feel free to lmk if there's anything I should've done in this PR that I didn't (I assume most things don't apply to trivial docs fixes).

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
