### PR TITLE
fix: remove unwrap in decode_populate

### DIFF
--- a/crates/dyn-abi/src/token.rs
+++ b/crates/dyn-abi/src/token.rs
@@ -166,7 +166,7 @@ impl<'a> DynToken<'a> {
 
                 new_tokens
                     .iter_mut()
-                    .for_each(|t| t.decode_populate(&mut child).unwrap());
+                    .try_for_each(|t| t.decode_populate(&mut child))?;
 
                 *contents = new_tokens.into();
             }


### PR DESCRIPTION
## Motivation

Fixes #170

## Solution

Remove a reachable and unnecessary unwrap in `decode_populate`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
