### PR TITLE
feat/refactor(rlp): improve implementations

### DIFF
--- a/crates/primitives/src/bits/macros.rs
+++ b/crates/primitives/src/bits/macros.rs
@@ -380,7 +380,7 @@ macro_rules! impl_rlp {
     ($t:ty) => {
         impl $crate::private::alloy_rlp::Decodable for $t {
             #[inline]
-            fn decode(buf: &mut &[u8]) -> Result<Self, $crate::private::alloy_rlp::DecodeError> {
+            fn decode(buf: &mut &[u8]) -> $crate::private::alloy_rlp::Result<Self> {
                 $crate::private::alloy_rlp::Decodable::decode(buf).map(Self)
             }
         }

--- a/crates/primitives/src/bits/macros.rs
+++ b/crates/primitives/src/bits/macros.rs
@@ -168,7 +168,7 @@ macro_rules! wrap_fixed_bytes {
 
         $crate::impl_fixed_bytes_traits!($name, $n);
         $crate::impl_getrandom!($name);
-        $crate::impl_rlp!($name);
+        $crate::impl_rlp!($name, $n);
         $crate::impl_serde!($name);
         $crate::impl_arbitrary!($name, $n);
 
@@ -377,7 +377,7 @@ macro_rules! impl_getrandom {
 #[macro_export]
 #[cfg(feature = "rlp")]
 macro_rules! impl_rlp {
-    ($t:ty) => {
+    ($t:ty, $n:literal) => {
         impl $crate::private::alloy_rlp::Decodable for $t {
             #[inline]
             fn decode(buf: &mut &[u8]) -> $crate::private::alloy_rlp::Result<Self> {
@@ -396,6 +396,10 @@ macro_rules! impl_rlp {
                 $crate::private::alloy_rlp::Encodable::encode(&self.0, out)
             }
         }
+
+        $crate::private::alloy_rlp::impl_max_encoded_len!($t, {
+            $n + $crate::private::alloy_rlp::length_of_length($n)
+        });
     };
 }
 
@@ -403,7 +407,7 @@ macro_rules! impl_rlp {
 #[macro_export]
 #[cfg(not(feature = "rlp"))]
 macro_rules! impl_rlp {
-    ($t:ty) => {};
+    ($t:ty, $n:literal) => {};
 }
 
 #[doc(hidden)]

--- a/crates/primitives/src/bits/rlp.rs
+++ b/crates/primitives/src/bits/rlp.rs
@@ -3,7 +3,7 @@ use alloy_rlp::{impl_max_encoded_len, length_of_length, Decodable, Encodable};
 
 impl<const N: usize> Decodable for FixedBytes<N> {
     #[inline]
-    fn decode(buf: &mut &[u8]) -> Result<Self, alloy_rlp::DecodeError> {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
         Decodable::decode(buf).map(Self)
     }
 }

--- a/crates/primitives/src/bits/rlp.rs
+++ b/crates/primitives/src/bits/rlp.rs
@@ -1,5 +1,5 @@
 use super::FixedBytes;
-use alloy_rlp::{impl_max_encoded_len, length_of_length, Decodable, Encodable};
+use alloy_rlp::{length_of_length, Decodable, Encodable, MaxEncodedLen, MaxEncodedLenAssoc};
 
 impl<const N: usize> Decodable for FixedBytes<N> {
     #[inline]
@@ -24,8 +24,12 @@ impl<const N: usize> Encodable for FixedBytes<N> {
 // https://github.com/rust-lang/rust/issues/76560
 macro_rules! fixed_bytes_max_encoded_len {
     ($($sz:literal),+) => {$(
-        impl_max_encoded_len!(FixedBytes<$sz>, $sz + length_of_length($sz));
+        unsafe impl MaxEncodedLen<{ $sz + length_of_length($sz) }> for FixedBytes<$sz> {}
     )+};
 }
 
 fixed_bytes_max_encoded_len!(0, 1, 2, 4, 8, 16, 20, 32, 64, 128, 256, 512, 1024);
+
+unsafe impl<const N: usize> MaxEncodedLenAssoc for FixedBytes<N> {
+    const LEN: usize = N + length_of_length(N);
+}

--- a/crates/primitives/src/bytes/rlp.rs
+++ b/crates/primitives/src/bytes/rlp.rs
@@ -2,17 +2,20 @@ use super::Bytes;
 use alloy_rlp::{Decodable, Encodable};
 
 impl Encodable for Bytes {
+    #[inline]
     fn length(&self) -> usize {
         self.0.length()
     }
 
+    #[inline]
     fn encode(&self, out: &mut dyn bytes::BufMut) {
         self.0.encode(out)
     }
 }
 
 impl Decodable for Bytes {
-    fn decode(buf: &mut &[u8]) -> Result<Self, alloy_rlp::DecodeError> {
-        Ok(Self(bytes::Bytes::decode(buf)?))
+    #[inline]
+    fn decode(buf: &mut &[u8]) -> Result<Self, alloy_rlp::Error> {
+        bytes::Bytes::decode(buf).map(Self)
     }
 }

--- a/crates/rlp/Cargo.toml
+++ b/crates/rlp/Cargo.toml
@@ -18,15 +18,17 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-arrayvec.workspace = true
 bytes.workspace = true
-
 alloy-rlp-derive = { workspace = true, optional = true }
+arrayvec = { workspace = true, optional = true }
+smol_str = { version = "0.2", default-features = false, optional = true }
 
 [dev-dependencies]
 hex-literal.workspace = true
 
 [features]
 default = ["std"]
-std = ["arrayvec/std", "bytes/std"]
+std = ["bytes/std", "arrayvec?/std", "smol_str?/std"]
 derive = ["dep:alloy-rlp-derive"]
+arrayvec = ["dep:arrayvec"]
+smol_str = ["dep:smol_str"]

--- a/crates/rlp/src/decode.rs
+++ b/crates/rlp/src/decode.rs
@@ -1,11 +1,10 @@
-use crate::Header;
-use bytes::{Buf, Bytes, BytesMut};
-use core::fmt;
+use crate::{Error, Header, Result};
+use bytes::{Bytes, BytesMut};
 
 /// A type that can be decoded from an RLP blob.
 pub trait Decodable: Sized {
     /// Decode the blob into the appropriate type.
-    fn decode(buf: &mut &[u8]) -> Result<Self, DecodeError>;
+    fn decode(buf: &mut &[u8]) -> Result<Self>;
 }
 
 /// An active RLP decoder, with a specific slice of a payload.
@@ -15,19 +14,14 @@ pub struct Rlp<'a> {
 
 impl<'a> Rlp<'a> {
     /// Instantiate an RLP decoder with a payload slice.
-    pub fn new(mut payload: &'a [u8]) -> Result<Self, DecodeError> {
-        let h = Header::decode(&mut payload)?;
-        if !h.list {
-            return Err(DecodeError::UnexpectedString)
-        }
-
-        let payload_view = &payload[..h.payload_length];
+    pub fn new(mut payload: &'a [u8]) -> Result<Self> {
+        let payload_view = Header::decode_bytes(&mut payload, true)?;
         Ok(Self { payload_view })
     }
 
     /// Decode the next item from the buffer.
     #[inline]
-    pub fn get_next<T: Decodable>(&mut self) -> Result<Option<T>, DecodeError> {
+    pub fn get_next<T: Decodable>(&mut self) -> Result<Option<T>> {
         if self.payload_view.is_empty() {
             Ok(None)
         } else {
@@ -36,195 +30,32 @@ impl<'a> Rlp<'a> {
     }
 }
 
-/// Errors for RLP decoding.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum DecodeError {
-    /// Numeric Overflow.
-    Overflow,
-    /// Leading zero disallowed.
-    LeadingZero,
-    /// Overran input while decoding.
-    InputTooShort,
-    /// Expected single byte, but got invalid value.
-    NonCanonicalSingleByte,
-    /// Expected size, but got invalid value.
-    NonCanonicalSize,
-    /// Expected a payload of a specific size, got an unexpected size.
-    UnexpectedLength,
-    /// Expected another type, got a string instead.
-    UnexpectedString,
-    /// Expected another type, got a list instead.
-    UnexpectedList,
-    /// Got an unexpected number of items in a list.
-    ListLengthMismatch {
-        /// Expected length.
-        expected: usize,
-        /// Actual length.
-        got: usize,
-    },
-    /// Custom Err.
-    Custom(&'static str),
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for DecodeError {}
-
-impl fmt::Display for DecodeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            DecodeError::Overflow => f.write_str("overflow"),
-            DecodeError::LeadingZero => f.write_str("leading zero"),
-            DecodeError::InputTooShort => f.write_str("input too short"),
-            DecodeError::NonCanonicalSingleByte => f.write_str("non-canonical single byte"),
-            DecodeError::NonCanonicalSize => f.write_str("non-canonical size"),
-            DecodeError::UnexpectedLength => f.write_str("unexpected length"),
-            DecodeError::UnexpectedString => f.write_str("unexpected string"),
-            DecodeError::UnexpectedList => f.write_str("unexpected list"),
-            DecodeError::ListLengthMismatch { got, expected } => {
-                write!(f, "unexpected list length (got {got}, expected {expected})")
-            }
-            DecodeError::Custom(err) => f.write_str(err),
-        }
+impl Decodable for bool {
+    #[inline]
+    fn decode(buf: &mut &[u8]) -> Result<Self> {
+        Ok(match u8::decode(buf)? {
+            0 => false,
+            1 => true,
+            _ => return Err(Error::Custom("invalid bool value, must be 0 or 1")),
+        })
     }
 }
 
-impl Header {
-    /// Returns the decoded header.
-    ///
-    /// Returns an error if the given `buf`'s len is less than the expected
-    /// payload.
-    pub fn decode(buf: &mut &[u8]) -> Result<Self, DecodeError> {
-        if !buf.has_remaining() {
-            return Err(DecodeError::InputTooShort)
-        }
-
-        let b = buf[0];
-        let h: Self = {
-            if b < 0x80 {
-                Self {
-                    list: false,
-                    payload_length: 1,
-                }
-            } else if b < 0xB8 {
-                buf.advance(1);
-                let h = Self {
-                    list: false,
-                    payload_length: b as usize - 0x80,
-                };
-
-                if h.payload_length == 1 {
-                    if !buf.has_remaining() {
-                        return Err(DecodeError::InputTooShort)
-                    }
-                    if buf[0] < 0x80 {
-                        return Err(DecodeError::NonCanonicalSingleByte)
-                    }
-                }
-
-                h
-            } else if b < 0xC0 {
-                buf.advance(1);
-                let len_of_len = b as usize - 0xB7;
-                if buf.len() < len_of_len {
-                    return Err(DecodeError::InputTooShort)
-                }
-                let payload_length = usize::try_from(u64::from_be_bytes(
-                    static_left_pad(&buf[..len_of_len]).ok_or(DecodeError::LeadingZero)?,
-                ))
-                .map_err(|_| DecodeError::Custom("Input too big"))?;
-                buf.advance(len_of_len);
-                if payload_length < 56 {
-                    return Err(DecodeError::NonCanonicalSize)
-                }
-
-                Self {
-                    list: false,
-                    payload_length,
-                }
-            } else if b < 0xF8 {
-                buf.advance(1);
-                Self {
-                    list: true,
-                    payload_length: b as usize - 0xC0,
-                }
-            } else {
-                buf.advance(1);
-                let list = true;
-                let len_of_len = b as usize - 0xF7;
-                if buf.len() < len_of_len {
-                    return Err(DecodeError::InputTooShort)
-                }
-                let payload_length = usize::try_from(u64::from_be_bytes(
-                    static_left_pad(&buf[..len_of_len]).ok_or(DecodeError::LeadingZero)?,
-                ))
-                .map_err(|_| DecodeError::Custom("Input too big"))?;
-                buf.advance(len_of_len);
-                if payload_length < 56 {
-                    return Err(DecodeError::NonCanonicalSize)
-                }
-
-                Self {
-                    list,
-                    payload_length,
-                }
-            }
-        };
-
-        if buf.remaining() < h.payload_length {
-            return Err(DecodeError::InputTooShort)
-        }
-
-        Ok(h)
+impl<const N: usize> Decodable for [u8; N] {
+    #[inline]
+    fn decode(from: &mut &[u8]) -> Result<Self> {
+        let bytes = Header::decode_bytes(from, false)?;
+        Self::try_from(bytes).map_err(|_| Error::UnexpectedLength)
     }
-}
-
-/// Left-pads a slice to a statically known size array. Returns None if the
-/// slice is too long or if the first byte is 0.
-fn static_left_pad<const LEN: usize>(data: &[u8]) -> Option<[u8; LEN]> {
-    if data.len() > LEN {
-        return None
-    }
-
-    let mut v = [0; LEN];
-
-    if data.is_empty() {
-        return Some(v)
-    }
-
-    if data[0] == 0 {
-        return None
-    }
-
-    v[LEN - data.len()..].copy_from_slice(data);
-    Some(v)
 }
 
 macro_rules! decode_integer {
     ($($t:ty),+ $(,)?) => {$(
         impl Decodable for $t {
             #[inline]
-            fn decode(buf: &mut &[u8]) -> Result<Self, DecodeError> {
-                let h = Header::decode(buf)?;
-                if h.list {
-                    return Err(DecodeError::UnexpectedList)
-                }
-                if h.payload_length > <$t>::BITS as usize / 8 {
-                    return Err(DecodeError::Overflow)
-                }
-                if buf.remaining() < h.payload_length {
-                    return Err(DecodeError::InputTooShort)
-                }
-                // In the case of 0x80, the Header will be decoded, leaving h.payload_length to
-                // be zero.
-                // 0x80 is the canonical encoding of 0, so we return 0 here.
-                if h.payload_length == 0 {
-                    return Ok(0)
-                }
-                let v = <$t>::from_be_bytes(
-                    static_left_pad(&buf[..h.payload_length]).ok_or(DecodeError::LeadingZero)?,
-                );
-                buf.advance(h.payload_length);
-                Ok(v)
+            fn decode(buf: &mut &[u8]) -> Result<Self> {
+                let bytes = Header::decode_bytes(buf, false)?;
+                static_left_pad(bytes).map(<$t>::from_be_bytes)
             }
         }
     )+};
@@ -232,121 +63,66 @@ macro_rules! decode_integer {
 
 decode_integer!(u8, u16, u32, u64, usize, u128);
 
-impl Decodable for bool {
+impl Decodable for Bytes {
     #[inline]
-    fn decode(buf: &mut &[u8]) -> Result<Self, DecodeError> {
-        Ok(match u8::decode(buf)? {
-            0 => false,
-            1 => true,
-            _ => return Err(DecodeError::Custom("invalid bool value, must be 0 or 1")),
-        })
-    }
-}
-
-impl<const N: usize> Decodable for [u8; N] {
-    #[inline]
-    fn decode(from: &mut &[u8]) -> Result<Self, DecodeError> {
-        let h = Header::decode(from)?;
-        if h.list {
-            return Err(DecodeError::UnexpectedList)
-        }
-        if h.payload_length != N {
-            return Err(DecodeError::UnexpectedLength)
-        }
-        if from.remaining() < N {
-            return Err(DecodeError::InputTooShort)
-        }
-
-        let mut to = [0_u8; N];
-        to.copy_from_slice(&from[..N]);
-        from.advance(N);
-
-        Ok(to)
+    fn decode(buf: &mut &[u8]) -> Result<Self> {
+        Header::decode_bytes(buf, false).map(|x| Self::from(x.to_vec()))
     }
 }
 
 impl Decodable for BytesMut {
     #[inline]
-    fn decode(from: &mut &[u8]) -> Result<Self, DecodeError> {
-        let h = Header::decode(from)?;
-        if h.list {
-            return Err(DecodeError::UnexpectedList)
-        }
-        if from.remaining() < h.payload_length {
-            return Err(DecodeError::InputTooShort)
-        }
-        let mut to = BytesMut::with_capacity(h.payload_length);
-        to.extend_from_slice(&from[..h.payload_length]);
-        from.advance(h.payload_length);
-
-        Ok(to)
-    }
-}
-
-impl Decodable for Bytes {
-    #[inline]
-    fn decode(buf: &mut &[u8]) -> Result<Self, DecodeError> {
-        BytesMut::decode(buf).map(BytesMut::freeze)
+    fn decode(buf: &mut &[u8]) -> Result<Self> {
+        Header::decode_bytes(buf, false).map(Self::from)
     }
 }
 
 impl Decodable for alloc::string::String {
     #[inline]
-    fn decode(from: &mut &[u8]) -> Result<Self, DecodeError> {
-        let h = Header::decode(from)?;
-        if h.list {
-            return Err(DecodeError::UnexpectedList)
-        }
-        if from.remaining() < h.payload_length {
-            return Err(DecodeError::InputTooShort)
-        }
-        let mut to = alloc::vec::Vec::with_capacity(h.payload_length);
-        to.extend_from_slice(&from[..h.payload_length]);
-        from.advance(h.payload_length);
-
-        Self::from_utf8(to).map_err(|_| DecodeError::Custom("invalid string"))
+    fn decode(buf: &mut &[u8]) -> Result<Self> {
+        Header::decode_str(buf).map(Into::into)
     }
 }
 
-impl<E: Decodable> Decodable for alloc::vec::Vec<E> {
+impl<T: Decodable> Decodable for alloc::vec::Vec<T> {
     #[inline]
-    fn decode(buf: &mut &[u8]) -> Result<Self, DecodeError> {
-        let h = Header::decode(buf)?;
-        if !h.list {
-            return Err(DecodeError::UnexpectedString)
-        }
-        if buf.remaining() < h.payload_length {
-            return Err(DecodeError::InputTooShort)
-        }
-
-        let payload_view = &mut &buf[..h.payload_length];
-
-        let mut to = alloc::vec::Vec::new();
+    fn decode(buf: &mut &[u8]) -> Result<Self> {
+        let mut bytes = Header::decode_bytes(buf, true)?;
+        let mut vec = Self::new();
+        let payload_view = &mut bytes;
         while !payload_view.is_empty() {
-            to.push(E::decode(payload_view)?);
+            vec.push(T::decode(payload_view)?);
         }
+        Ok(vec)
+    }
+}
 
-        buf.advance(h.payload_length);
-
-        Ok(to)
+#[cfg(feature = "smol_str")]
+impl Decodable for smol_str::SmolStr {
+    #[inline]
+    fn decode(buf: &mut &[u8]) -> Result<Self> {
+        Header::decode_str(buf).map(Into::into)
     }
 }
 
 macro_rules! wrap_impl {
-    ($([$($gen:tt)*] <$t:ty>::$new:ident),+ $(,)?) => {$(
+    ($($(#[$attr:meta])* [$($gen:tt)*] <$t:ty>::$new:ident($t2:ty)),+ $(,)?) => {$(
+        $(#[$attr])*
         impl<$($gen)*> Decodable for $t {
             #[inline]
-            fn decode(buf: &mut &[u8]) -> Result<Self, DecodeError> {
-                 Decodable::decode(buf).map(<$t>::$new)
+            fn decode(buf: &mut &[u8]) -> Result<Self> {
+                <$t2 as Decodable>::decode(buf).map(<$t>::$new)
             }
         }
     )+};
 }
 
 wrap_impl! {
-    [T: ?Sized + Decodable] <alloc::boxed::Box<T>>::new,
-    [T: ?Sized + Decodable] <alloc::rc::Rc<T>>::new,
-    [T: ?Sized + Decodable] <alloc::sync::Arc<T>>::new,
+    #[cfg(feature = "arrayvec")]
+    [const N: usize] <arrayvec::ArrayVec<u8, N>>::from([u8; N]),
+    [T: ?Sized + Decodable] <alloc::boxed::Box<T>>::new(T),
+    [T: ?Sized + Decodable] <alloc::rc::Rc<T>>::new(T),
+    [T: ?Sized + Decodable] <alloc::sync::Arc<T>>::new(T),
 }
 
 impl<T: ?Sized + alloc::borrow::ToOwned> Decodable for alloc::borrow::Cow<'_, T>
@@ -354,7 +130,7 @@ where
     T::Owned: Decodable,
 {
     #[inline]
-    fn decode(buf: &mut &[u8]) -> Result<Self, DecodeError> {
+    fn decode(buf: &mut &[u8]) -> Result<Self> {
         T::Owned::decode(buf).map(Self::Owned)
     }
 }
@@ -362,34 +138,60 @@ where
 #[cfg(feature = "std")]
 mod std_impl {
     use super::*;
-    impl Decodable for std::net::IpAddr {
-        fn decode(buf: &mut &[u8]) -> Result<Self, DecodeError> {
-            use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-            let h = Header::decode(buf)?;
-            if h.list {
-                return Err(DecodeError::UnexpectedList)
+    impl Decodable for IpAddr {
+        fn decode(buf: &mut &[u8]) -> Result<Self> {
+            let bytes = Header::decode_bytes(buf, false)?;
+            match bytes.len() {
+                4 => static_left_pad(bytes).map(|octets| Self::V4(Ipv4Addr::from(octets))),
+                16 => static_left_pad(bytes).map(|octets| Self::V6(Ipv6Addr::from(octets))),
+                _ => Err(Error::UnexpectedLength),
             }
-            if buf.remaining() < h.payload_length {
-                return Err(DecodeError::InputTooShort)
-            }
-            let o = match h.payload_length {
-                4 => {
-                    let mut to = [0_u8; 4];
-                    to.copy_from_slice(&buf[..4]);
-                    IpAddr::V4(Ipv4Addr::from(to))
-                }
-                16 => {
-                    let mut to = [0u8; 16];
-                    to.copy_from_slice(&buf[..16]);
-                    IpAddr::V6(Ipv6Addr::from(to))
-                }
-                _ => return Err(DecodeError::UnexpectedLength),
-            };
-            buf.advance(h.payload_length);
-            Ok(o)
         }
     }
+
+    impl Decodable for Ipv4Addr {
+        #[inline]
+        fn decode(buf: &mut &[u8]) -> Result<Self> {
+            let bytes = Header::decode_bytes(buf, false)?;
+            static_left_pad::<4>(bytes).map(Self::from)
+        }
+    }
+
+    impl Decodable for Ipv6Addr {
+        #[inline]
+        fn decode(buf: &mut &[u8]) -> Result<Self> {
+            let bytes = Header::decode_bytes(buf, false)?;
+            static_left_pad::<16>(bytes).map(Self::from)
+        }
+    }
+}
+
+/// Left-pads a slice to a statically known size array.
+///
+/// # Errors
+///
+/// Returns an error if the slice is too long or if the first byte is 0.
+#[inline]
+pub(crate) fn static_left_pad<const N: usize>(data: &[u8]) -> Result<[u8; N]> {
+    if data.len() > N {
+        return Err(Error::Overflow)
+    }
+
+    let mut v = [0; N];
+
+    if data.is_empty() {
+        return Ok(v)
+    }
+
+    if data[0] == 0 {
+        return Err(Error::LeadingZero)
+    }
+
+    // SAFETY: length checked above
+    unsafe { v.get_unchecked_mut(N - data.len()..) }.copy_from_slice(data);
+    Ok(v)
 }
 
 #[cfg(test)]
@@ -402,7 +204,7 @@ mod tests {
     fn check_decode<'a, T, IT>(fixtures: IT)
     where
         T: Decodable + PartialEq + Debug,
-        IT: IntoIterator<Item = (Result<T, DecodeError>, &'a [u8])>,
+        IT: IntoIterator<Item = (Result<T>, &'a [u8])>,
     {
         for (expected, mut input) in fixtures {
             assert_eq!(T::decode(&mut input), expected);
@@ -415,7 +217,7 @@ mod tests {
     fn check_decode_list<T, IT>(fixtures: IT)
     where
         T: Decodable + PartialEq + Debug,
-        IT: IntoIterator<Item = (Result<Vec<T>, DecodeError>, &'static [u8])>,
+        IT: IntoIterator<Item = (Result<Vec<T>>, &'static [u8])>,
     {
         for (expected, mut input) in fixtures {
             assert_eq!(Vec::<T>::decode(&mut input), expected);
@@ -433,7 +235,22 @@ mod tests {
                 Ok(hex!("6f62636465666768696a6b6c6d")[..].to_vec().into()),
                 &hex!("8D6F62636465666768696A6B6C6D")[..],
             ),
-            (Err(DecodeError::UnexpectedList), &hex!("C0")[..]),
+            (Err(Error::UnexpectedList), &hex!("C0")[..]),
+        ])
+    }
+
+    #[cfg(feature = "smol_str")]
+    #[test]
+    fn rlp_smol_str() {
+        use crate::Encodable;
+        use alloc::string::ToString;
+        use smol_str::SmolStr;
+
+        let mut b = BytesMut::new();
+        "test smol str".to_string().encode(&mut b);
+        check_decode::<SmolStr, _>(vec![
+            (Ok(SmolStr::new("test smol str")), b.as_ref()),
+            (Err(Error::UnexpectedList), &hex!("C0")[..]),
         ])
     }
 
@@ -445,11 +262,11 @@ mod tests {
                 &hex!("8D6F62636465666768696A6B6C6D")[..],
             ),
             (
-                Err(DecodeError::UnexpectedLength),
+                Err(Error::UnexpectedLength),
                 &hex!("8C6F62636465666768696A6B6C")[..],
             ),
             (
-                Err(DecodeError::UnexpectedLength),
+                Err(Error::UnexpectedLength),
                 &hex!("8E6F62636465666768696A6B6C6D6E")[..],
             ),
         ])
@@ -462,21 +279,18 @@ mod tests {
             (Ok(0_u64), &hex!("80")[..]),
             (Ok(0x0505_u64), &hex!("820505")[..]),
             (Ok(0xCE05050505_u64), &hex!("85CE05050505")[..]),
+            (Err(Error::Overflow), &hex!("8AFFFFFFFFFFFFFFFFFF7C")[..]),
             (
-                Err(DecodeError::Overflow),
-                &hex!("8AFFFFFFFFFFFFFFFFFF7C")[..],
-            ),
-            (
-                Err(DecodeError::InputTooShort),
+                Err(Error::InputTooShort),
                 &hex!("8BFFFFFFFFFFFFFFFFFF7C")[..],
             ),
-            (Err(DecodeError::UnexpectedList), &hex!("C0")[..]),
-            (Err(DecodeError::LeadingZero), &hex!("00")[..]),
-            (Err(DecodeError::NonCanonicalSingleByte), &hex!("8105")[..]),
-            (Err(DecodeError::LeadingZero), &hex!("8200F4")[..]),
-            (Err(DecodeError::NonCanonicalSize), &hex!("B8020004")[..]),
+            (Err(Error::UnexpectedList), &hex!("C0")[..]),
+            (Err(Error::LeadingZero), &hex!("00")[..]),
+            (Err(Error::NonCanonicalSingleByte), &hex!("8105")[..]),
+            (Err(Error::LeadingZero), &hex!("8200F4")[..]),
+            (Err(Error::NonCanonicalSize), &hex!("B8020004")[..]),
             (
-                Err(DecodeError::Overflow),
+                Err(Error::Overflow),
                 &hex!("A101000000000000000000000000000000000000008B000000000000000000000000")[..],
             ),
         ])
@@ -496,31 +310,31 @@ mod tests {
     #[test]
     fn malformed_rlp() {
         check_decode::<Bytes, _>(vec![
-            (Err(DecodeError::InputTooShort), &hex!("C1")[..]),
-            (Err(DecodeError::InputTooShort), &hex!("D7")[..]),
+            (Err(Error::InputTooShort), &hex!("C1")[..]),
+            (Err(Error::InputTooShort), &hex!("D7")[..]),
         ]);
         check_decode::<[u8; 5], _>(vec![
-            (Err(DecodeError::InputTooShort), &hex!("C1")[..]),
-            (Err(DecodeError::InputTooShort), &hex!("D7")[..]),
+            (Err(Error::InputTooShort), &hex!("C1")[..]),
+            (Err(Error::InputTooShort), &hex!("D7")[..]),
         ]);
         #[cfg(feature = "std")]
         check_decode::<std::net::IpAddr, _>(vec![
-            (Err(DecodeError::InputTooShort), &hex!("C1")[..]),
-            (Err(DecodeError::InputTooShort), &hex!("D7")[..]),
+            (Err(Error::InputTooShort), &hex!("C1")[..]),
+            (Err(Error::InputTooShort), &hex!("D7")[..]),
         ]);
         check_decode::<Vec<u8>, _>(vec![
-            (Err(DecodeError::InputTooShort), &hex!("C1")[..]),
-            (Err(DecodeError::InputTooShort), &hex!("D7")[..]),
+            (Err(Error::InputTooShort), &hex!("C1")[..]),
+            (Err(Error::InputTooShort), &hex!("D7")[..]),
         ]);
         check_decode::<String, _>(vec![
-            (Err(DecodeError::InputTooShort), &hex!("C1")[..]),
-            (Err(DecodeError::InputTooShort), &hex!("D7")[..]),
+            (Err(Error::InputTooShort), &hex!("C1")[..]),
+            (Err(Error::InputTooShort), &hex!("D7")[..]),
         ]);
         check_decode::<String, _>(vec![
-            (Err(DecodeError::InputTooShort), &hex!("C1")[..]),
-            (Err(DecodeError::InputTooShort), &hex!("D7")[..]),
+            (Err(Error::InputTooShort), &hex!("C1")[..]),
+            (Err(Error::InputTooShort), &hex!("D7")[..]),
         ]);
-        check_decode::<u8, _>(vec![(Err(DecodeError::InputTooShort), &hex!("82")[..])]);
-        check_decode::<u64, _>(vec![(Err(DecodeError::InputTooShort), &hex!("82")[..])]);
+        check_decode::<u8, _>(vec![(Err(Error::InputTooShort), &hex!("82")[..])]);
+        check_decode::<u64, _>(vec![(Err(Error::InputTooShort), &hex!("82")[..])]);
     }
 }

--- a/crates/rlp/src/encode.rs
+++ b/crates/rlp/src/encode.rs
@@ -7,13 +7,14 @@ use arrayvec::ArrayVec;
 
 /// A type that can be encoded via RLP.
 pub trait Encodable {
-    /// Encode the type into the `out` buffer.
+    /// Encodes the type into the `out` buffer.
     fn encode(&self, out: &mut dyn BufMut);
 
-    /// Return the length of the type in bytes
+    /// Returns the length of the encoding of this type in bytes.
     ///
-    /// The default implementation computes this by encoding the type. If
-    /// feasible, we recommender implementers override this default impl.
+    /// The default implementation computes this by encoding the type.
+    /// When possible, we recommender implementers override this with a
+    /// specialized implementation.
     #[inline]
     fn length(&self) -> usize {
         let mut out = alloc::vec::Vec::new();

--- a/crates/rlp/src/encode.rs
+++ b/crates/rlp/src/encode.rs
@@ -1,54 +1,9 @@
 use crate::{Header, EMPTY_STRING_CODE};
-use arrayvec::ArrayVec;
 use bytes::{BufMut, Bytes, BytesMut};
 use core::borrow::Borrow;
 
-macro_rules! to_be_bytes_trimmed {
-    ($be:ident, $x:expr) => {{
-        $be = $x.to_be_bytes();
-        &$be[($x.leading_zeros() / 8) as usize..]
-    }};
-}
-pub(crate) use to_be_bytes_trimmed;
-
-/// Determine the length in bytes of the length prefix of an RLP item.
-#[inline]
-pub const fn length_of_length(payload_length: usize) -> usize {
-    if payload_length < 56 {
-        1
-    } else {
-        1 + 8 - payload_length.leading_zeros() as usize / 8
-    }
-}
-
-#[doc(hidden)]
-#[inline]
-pub const fn const_add(a: usize, b: usize) -> usize {
-    a + b
-}
-
-#[doc(hidden)]
-pub unsafe trait MaxEncodedLen<const LEN: usize>: Encodable {}
-
-#[doc(hidden)]
-pub unsafe trait MaxEncodedLenAssoc: Encodable {
-    const LEN: usize;
-}
-
-/// Use this to define length of an encoded entity
-///
-/// # Safety
-///
-/// An invalid value can cause the encoder to crash.
-#[macro_export]
-macro_rules! impl_max_encoded_len {
-    ($t:ty, $len:expr) => {
-        unsafe impl $crate::MaxEncodedLen<{ $len }> for $t {}
-        unsafe impl $crate::MaxEncodedLenAssoc for $t {
-            const LEN: usize = $len;
-        }
-    };
-}
+#[cfg(feature = "arrayvec")]
+use arrayvec::ArrayVec;
 
 /// A type that can be encoded via RLP.
 pub trait Encodable {
@@ -61,13 +16,66 @@ pub trait Encodable {
     /// feasible, we recommender implementers override this default impl.
     #[inline]
     fn length(&self) -> usize {
-        let mut out = BytesMut::new();
+        let mut out = alloc::vec::Vec::new();
         self.encode(&mut out);
         out.len()
     }
 }
 
+// The existence of this function makes the compiler catch if the Encodable
+// trait is "object-safe" or not.
+fn _assert_trait_object(_b: &dyn Encodable) {}
+
+/// Defines the max length of an [`Encodable`] type as a const generic.
+///
+/// # Safety
+///
+/// An invalid value can cause the encoder to panic.
+pub unsafe trait MaxEncodedLen<const LEN: usize>: Encodable {}
+
+/// Defines the max length of an [`Encodable`] type as an associated constant.
+///
+/// # Safety
+///
+/// An invalid value can cause the encoder to panic.
+pub unsafe trait MaxEncodedLenAssoc: Encodable {
+    /// The maximum length.
+    const LEN: usize;
+}
+
+/// Implement [`MaxEncodedLen`] and [`MaxEncodedLenAssoc`] for a type.
+///
+/// # Safety
+///
+/// An invalid value can cause the encoder to panic.
+#[macro_export]
+macro_rules! impl_max_encoded_len {
+    ($t:ty, $len:expr) => {
+        unsafe impl $crate::MaxEncodedLen<{ $len }> for $t {}
+        unsafe impl $crate::MaxEncodedLenAssoc for $t {
+            const LEN: usize = $len;
+        }
+    };
+}
+
+macro_rules! to_be_bytes_trimmed {
+    ($be:ident, $x:expr) => {{
+        $be = $x.to_be_bytes();
+        &$be[($x.leading_zeros() / 8) as usize..]
+    }};
+}
+pub(crate) use to_be_bytes_trimmed;
+
 impl Encodable for [u8] {
+    #[inline]
+    fn length(&self) -> usize {
+        let mut len = self.len();
+        if len != 1 || self[0] >= EMPTY_STRING_CODE {
+            len += length_of_length(len);
+        }
+        len
+    }
+
     #[inline]
     fn encode(&self, out: &mut dyn BufMut) {
         if self.len() != 1 || self[0] >= EMPTY_STRING_CODE {
@@ -79,26 +87,17 @@ impl Encodable for [u8] {
         }
         out.put_slice(self);
     }
-
-    #[inline]
-    fn length(&self) -> usize {
-        let mut len = self.len();
-        if self.len() != 1 || self[0] >= EMPTY_STRING_CODE {
-            len += length_of_length(self.len());
-        }
-        len
-    }
 }
 
 impl<const N: usize> Encodable for [u8; N] {
     #[inline]
-    fn encode(&self, out: &mut dyn BufMut) {
-        self[..].encode(out);
+    fn length(&self) -> usize {
+        self[..].length()
     }
 
     #[inline]
-    fn length(&self) -> usize {
-        self[..].length()
+    fn encode(&self, out: &mut dyn BufMut) {
+        self[..].encode(out);
     }
 }
 
@@ -108,27 +107,27 @@ unsafe impl<const N: usize> MaxEncodedLenAssoc for [u8; N] {
 
 impl Encodable for str {
     #[inline]
-    fn encode(&self, out: &mut dyn BufMut) {
-        self.as_bytes().encode(out)
+    fn length(&self) -> usize {
+        self.as_bytes().length()
     }
 
     #[inline]
-    fn length(&self) -> usize {
-        self.as_bytes().length()
+    fn encode(&self, out: &mut dyn BufMut) {
+        self.as_bytes().encode(out)
     }
 }
 
 impl Encodable for bool {
     #[inline]
-    fn encode(&self, out: &mut dyn BufMut) {
-        // inlined `(*self as u8).encode(out)`
-        out.put_u8(if *self { 1 } else { EMPTY_STRING_CODE });
-    }
-
-    #[inline]
     fn length(&self) -> usize {
         // a `bool` is always `< EMPTY_STRING_CODE`
         1
+    }
+
+    #[inline]
+    fn encode(&self, out: &mut dyn BufMut) {
+        // inlined `(*self as u8).encode(out)`
+        out.put_u8(if *self { 1 } else { EMPTY_STRING_CODE });
     }
 }
 
@@ -164,7 +163,8 @@ macro_rules! uint_impl {
         }
 
         impl_max_encoded_len!($t, {
-            length_of_length(<$t>::MAX.to_be_bytes().len()) + <$t>::MAX.to_be_bytes().len()
+            let bytes = <$t>::BITS as usize / 8;
+            bytes + length_of_length(bytes)
         });
     )+};
 }
@@ -184,16 +184,17 @@ impl<T: Encodable> Encodable for alloc::vec::Vec<T> {
 }
 
 macro_rules! deref_impl {
-    ($([$($gen:tt)*] $t:ty),+ $(,)?) => {$(
+    ($($(#[$attr:meta])* [$($gen:tt)*] $t:ty),+ $(,)?) => {$(
+        $(#[$attr])*
         impl<$($gen)*> Encodable for $t {
-            #[inline]
-            fn encode(&self, out: &mut dyn BufMut) {
-                (**self).encode(out)
-            }
-
             #[inline]
             fn length(&self) -> usize {
                 (**self).length()
+            }
+
+            #[inline]
+            fn encode(&self, out: &mut dyn BufMut) {
+                (**self).encode(out)
             }
         }
     )+};
@@ -203,6 +204,10 @@ deref_impl! {
     [] alloc::string::String,
     [] Bytes,
     [] BytesMut,
+    #[cfg(feature = "smol_str")]
+    [] smol_str::SmolStr,
+    #[cfg(feature = "arrayvec")]
+    [const N: usize] ArrayVec<u8, N>,
     [T: ?Sized + Encodable] &T,
     [T: ?Sized + Encodable] &mut T,
     [T: ?Sized + Encodable] alloc::boxed::Box<T>,
@@ -217,46 +222,53 @@ mod std_support {
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
     impl Encodable for IpAddr {
-        fn encode(&self, out: &mut dyn BufMut) {
-            match self {
-                IpAddr::V4(ip) => ip.encode(out),
-                IpAddr::V6(ip) => ip.encode(out),
-            }
-        }
-
+        #[inline]
         fn length(&self) -> usize {
             match self {
                 IpAddr::V4(ip) => ip.length(),
                 IpAddr::V6(ip) => ip.length(),
             }
         }
+
+        #[inline]
+        fn encode(&self, out: &mut dyn BufMut) {
+            match self {
+                IpAddr::V4(ip) => ip.encode(out),
+                IpAddr::V6(ip) => ip.encode(out),
+            }
+        }
     }
 
     impl Encodable for Ipv4Addr {
-        fn encode(&self, out: &mut dyn BufMut) {
-            Encodable::encode(&self.octets()[..], out)
+        #[inline]
+        fn length(&self) -> usize {
+            self.octets().length()
         }
 
-        fn length(&self) -> usize {
-            Encodable::length(&self.octets()[..])
+        #[inline]
+        fn encode(&self, out: &mut dyn BufMut) {
+            self.octets().encode(out)
         }
     }
 
     impl Encodable for Ipv6Addr {
-        fn encode(&self, out: &mut dyn BufMut) {
-            Encodable::encode(&self.octets()[..], out)
+        #[inline]
+        fn length(&self) -> usize {
+            self.octets().length()
         }
 
-        fn length(&self) -> usize {
-            Encodable::length(&self.octets()[..])
+        #[inline]
+        fn encode(&self, out: &mut dyn BufMut) {
+            self.octets().encode(out)
         }
     }
 }
 
-fn rlp_list_header<E, K>(v: &[K]) -> Header
+#[inline]
+fn rlp_list_header<T, E>(v: &[T]) -> Header
 where
-    E: Encodable + ?Sized,
-    K: Borrow<E>,
+    T: Borrow<E>,
+    E: ?Sized + Encodable,
 {
     let mut h = Header {
         list: true,
@@ -269,47 +281,53 @@ where
 }
 
 /// Calculate the length of a list.
-pub fn list_length<E, K>(v: &[K]) -> usize
+pub fn list_length<T, E>(list: &[T]) -> usize
 where
-    E: Encodable,
-    K: Borrow<E>,
+    E: ?Sized + Encodable,
+    T: Borrow<E>,
 {
-    let payload_length = rlp_list_header(v).payload_length;
+    let payload_length = rlp_list_header(list).payload_length;
     length_of_length(payload_length) + payload_length
 }
 
 /// Encode a list of items.
-pub fn encode_list<E: Encodable>(v: &[E], out: &mut dyn BufMut) {
-    let h = rlp_list_header(v);
+pub fn encode_list<T, E>(list: &[T], out: &mut dyn BufMut)
+where
+    T: Borrow<E>,
+    E: ?Sized + Encodable,
+{
+    let h = rlp_list_header(list);
     h.encode(out);
-    for x in v {
-        x.borrow().encode(out);
+    for t in list {
+        t.borrow().encode(out);
     }
 }
 
 /// Encode all items from an iterator.
 ///
 /// This clones the iterator. Prefer [`encode_list`] if possible.
-pub fn encode_iter<K, I>(i: I, out: &mut dyn BufMut)
+pub fn encode_iter<I, T, E>(iter: I, out: &mut dyn BufMut)
 where
-    K: Encodable,
-    I: Iterator<Item = K> + Clone,
+    I: Iterator<Item = T> + Clone,
+    T: Borrow<E>,
+    E: ?Sized + Encodable,
 {
     let mut h = Header {
         list: true,
         payload_length: 0,
     };
-    for x in i.clone() {
-        h.payload_length += x.length();
+    for t in iter.clone() {
+        h.payload_length += t.borrow().length();
     }
 
     h.encode(out);
-    for x in i {
-        x.encode(out);
+    for t in iter {
+        t.borrow().encode(out);
     }
 }
 
 /// Encode a type with a known maximum size.
+#[cfg(feature = "arrayvec")]
 pub fn encode_fixed_size<E: MaxEncodedLen<LEN>, const LEN: usize>(v: &E) -> ArrayVec<u8, LEN> {
     let mut out = ArrayVec::from([0_u8; LEN]);
 
@@ -321,6 +339,16 @@ pub fn encode_fixed_size<E: MaxEncodedLen<LEN>, const LEN: usize>(v: &E) -> Arra
     out.truncate(final_len);
 
     out
+}
+
+/// Determine the length in bytes of the length prefix of an RLP item.
+#[inline]
+pub const fn length_of_length(payload_length: usize) -> usize {
+    if payload_length < 56 {
+        1
+    } else {
+        1 + 8 - payload_length.leading_zeros() as usize / 8
+    }
 }
 
 #[cfg(test)]
@@ -349,7 +377,7 @@ mod tests {
         out1
     }
 
-    fn encoded_iter<'a, T: Encodable + 'a>(iter: impl Iterator<Item = &'a T> + Clone) -> BytesMut {
+    fn encoded_iter<T: Encodable>(iter: impl Iterator<Item = T> + Clone) -> BytesMut {
         let mut out = BytesMut::new();
         encode_iter(iter, &mut out);
         out
@@ -360,6 +388,21 @@ mod tests {
         assert_eq!(encoded("")[..], hex!("80")[..]);
         assert_eq!(encoded("{")[..], hex!("7b")[..]);
         assert_eq!(encoded("test str")[..], hex!("887465737420737472")[..]);
+    }
+
+    #[cfg(feature = "smol_str")]
+    #[test]
+    fn rlp_smol_str() {
+        use alloc::string::ToString;
+        use smol_str::SmolStr;
+
+        assert_eq!(encoded(SmolStr::new(""))[..], hex!("80")[..]);
+        let mut b = BytesMut::new();
+        "test smol str".to_string().encode(&mut b);
+        assert_eq!(&encoded(SmolStr::new("test smol str"))[..], b.as_ref());
+        let mut b = BytesMut::new();
+        "abcdefgh".to_string().encode(&mut b);
+        assert_eq!(&encoded(SmolStr::new("abcdefgh"))[..], b.as_ref());
     }
 
     #[test]
@@ -518,7 +561,7 @@ mod tests {
 
     #[test]
     fn rlp_iter() {
-        assert_eq!(encoded_iter::<u64>([].iter()), &hex!("c0")[..]);
+        assert_eq!(encoded_iter::<u64>([].into_iter()), &hex!("c0")[..]);
         assert_eq!(
             encoded_iter([0xFFCCB5_u64, 0xFFC0B5_u64].iter()),
             &hex!("c883ffccb583ffc0b5")[..]

--- a/crates/rlp/src/encode.rs
+++ b/crates/rlp/src/encode.rs
@@ -284,8 +284,8 @@ where
 /// Calculate the length of a list.
 pub fn list_length<T, E>(list: &[T]) -> usize
 where
-    E: ?Sized + Encodable,
     T: Borrow<E>,
+    E: ?Sized + Encodable,
 {
     let payload_length = rlp_list_header(list).payload_length;
     length_of_length(payload_length) + payload_length

--- a/crates/rlp/src/error.rs
+++ b/crates/rlp/src/error.rs
@@ -1,0 +1,56 @@
+use core::fmt;
+
+/// RLP result type.
+pub type Result<T, E = Error> = core::result::Result<T, E>;
+
+/// RLP error type.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Error {
+    /// Numeric Overflow.
+    Overflow,
+    /// Leading zero disallowed.
+    LeadingZero,
+    /// Overran input while decoding.
+    InputTooShort,
+    /// Expected single byte, but got invalid value.
+    NonCanonicalSingleByte,
+    /// Expected size, but got invalid value.
+    NonCanonicalSize,
+    /// Expected a payload of a specific size, got an unexpected size.
+    UnexpectedLength,
+    /// Expected another type, got a string instead.
+    UnexpectedString,
+    /// Expected another type, got a list instead.
+    UnexpectedList,
+    /// Got an unexpected number of items in a list.
+    ListLengthMismatch {
+        /// Expected length.
+        expected: usize,
+        /// Actual length.
+        got: usize,
+    },
+    /// Custom Err.
+    Custom(&'static str),
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Overflow => f.write_str("overflow"),
+            Error::LeadingZero => f.write_str("leading zero"),
+            Error::InputTooShort => f.write_str("input too short"),
+            Error::NonCanonicalSingleByte => f.write_str("non-canonical single byte"),
+            Error::NonCanonicalSize => f.write_str("non-canonical size"),
+            Error::UnexpectedLength => f.write_str("unexpected length"),
+            Error::UnexpectedString => f.write_str("unexpected string"),
+            Error::UnexpectedList => f.write_str("unexpected list"),
+            Error::ListLengthMismatch { got, expected } => {
+                write!(f, "unexpected list length (got {got}, expected {expected})")
+            }
+            Error::Custom(err) => f.write_str(err),
+        }
+    }
+}

--- a/crates/rlp/src/header.rs
+++ b/crates/rlp/src/header.rs
@@ -1,8 +1,9 @@
-use crate::{EMPTY_LIST_CODE, EMPTY_STRING_CODE};
-use bytes::BufMut;
+use crate::{decode::static_left_pad, Error, Result, EMPTY_LIST_CODE, EMPTY_STRING_CODE};
+use bytes::{Buf, BufMut};
+use core::hint::unreachable_unchecked;
 
 /// The header of an RLP item.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Header {
     /// True if list, false otherwise.
     pub list: bool,
@@ -11,6 +12,112 @@ pub struct Header {
 }
 
 impl Header {
+    /// Decodes an RLP header from the given buffer.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer is too short or the header is invalid.
+    #[inline]
+    pub fn decode(buf: &mut &[u8]) -> Result<Self> {
+        let payload_length;
+        let mut list = false;
+        match get_next_byte(buf)? {
+            0..=0x7F => payload_length = 1,
+
+            b @ EMPTY_STRING_CODE..=0xB7 => {
+                buf.advance(1);
+                payload_length = (b - EMPTY_STRING_CODE) as usize;
+                if payload_length == 1 && get_next_byte(buf)? < EMPTY_STRING_CODE {
+                    return Err(Error::NonCanonicalSingleByte)
+                }
+            }
+
+            b @ (0xB8..=0xBF | 0xF8..=0xFF) => {
+                buf.advance(1);
+
+                list = b >= 0xF8; // second range
+                let code = if list { 0xF7 } else { 0xB7 };
+
+                // SAFETY: `b - code` is always in the range `1..=8` in the current match arm.
+                // The compiler/LLVM apparently cannot prove this because of the `|` pattern +
+                // the above `if`, since it can do it in the other arms with only 1 range.
+                let len_of_len = unsafe { b.checked_sub(code).unwrap_unchecked() } as usize;
+                if len_of_len == 0 || len_of_len > 8 {
+                    unsafe { unreachable_unchecked() }
+                }
+
+                if buf.len() < len_of_len {
+                    return Err(Error::InputTooShort)
+                }
+                // SAFETY: length checked above
+                let len = unsafe { buf.get_unchecked(..len_of_len) };
+                buf.advance(len_of_len);
+
+                let len = u64::from_be_bytes(static_left_pad(len)?);
+                payload_length =
+                    usize::try_from(len).map_err(|_| Error::Custom("Input too big"))?;
+                if payload_length < 56 {
+                    return Err(Error::NonCanonicalSize)
+                }
+            }
+
+            b @ EMPTY_LIST_CODE..=0xF7 => {
+                buf.advance(1);
+                list = true;
+                payload_length = (b - EMPTY_LIST_CODE) as usize;
+            }
+        }
+
+        if buf.remaining() < payload_length {
+            return Err(Error::InputTooShort)
+        }
+
+        Ok(Self {
+            list,
+            payload_length,
+        })
+    }
+
+    /// Decodes the next payload from the given buffer, advancing it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer is too short or the header is invalid.
+    #[inline]
+    pub fn decode_bytes<'a>(buf: &mut &'a [u8], is_list: bool) -> Result<&'a [u8]> {
+        let Self {
+            list,
+            payload_length,
+        } = Self::decode(buf)?;
+
+        if list != is_list {
+            return Err(if is_list {
+                Error::UnexpectedString
+            } else {
+                Error::UnexpectedList
+            })
+        }
+
+        // SAFETY: this is already checked in `decode`
+        if buf.remaining() < payload_length {
+            unsafe { unreachable_unchecked() }
+        }
+        let bytes = unsafe { buf.get_unchecked(..payload_length) };
+        buf.advance(payload_length);
+        Ok(bytes)
+    }
+
+    /// Decodes a string slice from the given buffer, advancing it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the buffer is too short or the header is invalid.
+    #[inline]
+    pub fn decode_str<'a>(buf: &mut &'a [u8]) -> Result<&'a str> {
+        let bytes = Self::decode_bytes(buf, false)?;
+        core::str::from_utf8(bytes).map_err(|_| Error::Custom("invalid string"))
+    }
+
     /// Encodes the header into the `out` buffer.
     #[inline]
     pub fn encode(&self, out: &mut dyn BufMut) {
@@ -35,4 +142,14 @@ impl Header {
     pub const fn length(&self) -> usize {
         crate::length_of_length(self.payload_length)
     }
+}
+
+/// Same as `buf.first().ok_or(Error::InputTooShort)`.
+#[inline(always)]
+fn get_next_byte(buf: &[u8]) -> Result<u8> {
+    if buf.is_empty() {
+        return Err(Error::InputTooShort)
+    }
+    // SAFETY: length checked above
+    Ok(*unsafe { buf.get_unchecked(0) })
 }

--- a/crates/rlp/src/lib.rs
+++ b/crates/rlp/src/lib.rs
@@ -19,19 +19,27 @@
 extern crate alloc;
 
 mod decode;
+pub use decode::{Decodable, Rlp};
+
+mod error;
+pub use error::{Error, Result};
+
 mod encode;
-mod header;
-
-pub use bytes::{Buf, BufMut};
-
-pub use decode::{Decodable, DecodeError, Rlp};
+#[cfg(feature = "arrayvec")]
+pub use encode::encode_fixed_size;
 pub use encode::{
-    const_add, encode_fixed_size, encode_iter, encode_list, length_of_length, list_length,
-    Encodable, MaxEncodedLen, MaxEncodedLenAssoc,
+    encode_iter, encode_list, length_of_length, list_length, Encodable, MaxEncodedLen,
+    MaxEncodedLenAssoc,
 };
+
+mod header;
 pub use header::Header;
 
+#[doc(no_inline)]
+pub use bytes::{self, Buf, BufMut, Bytes, BytesMut};
+
 #[cfg(feature = "derive")]
+#[doc(no_inline)]
 pub use alloy_rlp_derive::{
     RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper, RlpMaxEncodedLen,
 };
@@ -41,3 +49,14 @@ pub const EMPTY_STRING_CODE: u8 = 0x80;
 
 /// RLP prefix byte for a 0-length array.
 pub const EMPTY_LIST_CODE: u8 = 0xC0;
+
+// Not public API.
+#[doc(hidden)]
+#[inline]
+pub const fn const_add(a: usize, b: usize) -> usize {
+    a + b
+}
+
+#[doc(hidden)]
+#[deprecated(since = "0.3.0", note = "use `Error` instead")]
+pub type DecodeError = Error;

--- a/crates/rlp/src/lib.rs
+++ b/crates/rlp/src/lib.rs
@@ -52,11 +52,14 @@ pub const EMPTY_LIST_CODE: u8 = 0xC0;
 
 // Not public API.
 #[doc(hidden)]
-#[inline]
-pub const fn const_add(a: usize, b: usize) -> usize {
-    a + b
-}
-
-#[doc(hidden)]
 #[deprecated(since = "0.3.0", note = "use `Error` instead")]
 pub type DecodeError = Error;
+
+#[doc(hidden)]
+pub mod private {
+    pub use core::{
+        default::Default,
+        option::Option::{self, None, Some},
+        result::Result::{self, Err, Ok},
+    };
+}

--- a/crates/rlp/tests/derive.rs
+++ b/crates/rlp/tests/derive.rs
@@ -2,11 +2,11 @@
 
 use alloy_rlp::*;
 
-#[derive(RlpEncodable, RlpDecodable, RlpMaxEncodedLen, PartialEq, Debug)]
-pub struct MyThing(#[rlp] [u8; 12]);
-
 #[test]
 fn simple_derive() {
+    #[derive(RlpEncodable, RlpDecodable, RlpMaxEncodedLen, PartialEq, Debug)]
+    struct MyThing(#[rlp] [u8; 12]);
+
     let thing = MyThing([0; 12]);
 
     // roundtrip fidelity
@@ -20,4 +20,43 @@ fn simple_derive() {
         Err(Error::InputTooShort),
         MyThing::decode(&mut [0x8c; 11].as_ref())
     )
+}
+
+#[test]
+fn wrapper() {
+    #[derive(RlpEncodableWrapper, RlpDecodableWrapper, RlpMaxEncodedLen, PartialEq, Debug)]
+    struct Wrapper([u8; 8]);
+
+    #[derive(RlpEncodableWrapper, RlpDecodableWrapper, PartialEq, Debug)]
+    struct ConstWrapper<const N: usize>([u8; N]);
+}
+
+#[test]
+fn generics() {
+    trait LT<'a> {}
+
+    #[derive(RlpEncodable, RlpDecodable, RlpMaxEncodedLen)]
+    struct Generic<T, U: for<'a> LT<'a>, V: Default, const N: usize>(T, usize, U, V, [u8; N])
+    where
+        U: std::fmt::Display;
+
+    #[derive(RlpEncodableWrapper, RlpDecodableWrapper, RlpMaxEncodedLen)]
+    struct GenericWrapper<T>(T)
+    where
+        T: Sized;
+}
+
+#[test]
+fn opt() {
+    #[derive(RlpEncodable, RlpDecodable)]
+    #[rlp(trailing)]
+    struct Options<T>(Option<Vec<T>>);
+
+    #[derive(RlpEncodable, RlpDecodable)]
+    #[rlp(trailing)]
+    struct Options2<T> {
+        a: Option<T>,
+        #[rlp(default)]
+        b: Option<T>,
+    }
 }

--- a/crates/rlp/tests/derive.rs
+++ b/crates/rlp/tests/derive.rs
@@ -17,7 +17,7 @@ fn simple_derive() {
 
     // does not panic on short input
     assert_eq!(
-        Err(DecodeError::InputTooShort),
+        Err(Error::InputTooShort),
         MyThing::decode(&mut [0x8c; 11].as_ref())
     )
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Refactor decode and add new impls and features.

Preferably `Decodable` would have a `'de` lifetime, and `Decodable::decode`'s param would be a `&mut Decoder<'de>` struct which would allow for easier helper method access (like `Header::decode` -> `d.decode_header()?;` etc), and deserializing borrowed byte and string slices, but this would be a significant breaking change so I didn't implement this here.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- dedup decoding code by adding more static methods to `Header`, and by refactoring `Header::decode` to use a match expression.
- add `smol_str` dep + feature from `reth-rlp`
- add `arrayvec` impls + gate `encode_fixed_size` function to feature
- breaking changes to the free-standing `encode_*` functions' generics
- un-`#[doc(hide)]` and document `MaxEncodedLen`, `MaxEncodedLenAssoc`
- add a `Result` type alias for the decode error type
- update derive macros
  - added support for generics

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Breaking changes
