### PR TITLE
feat: native keccak feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ proc-macro2 = "1.0"
 quote = "1.0"
 syn = "2.0"
 
+cfg-if = "1.0.0"
 derive_more = "0.99"
 hex-literal = "0.4"
 strum = { version = "0.25", features = ["derive"] }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -49,6 +49,7 @@ serde_json.workspace = true
 [features]
 default = ["std"]
 std = ["bytes/std", "hex/std", "alloy-rlp?/std", "proptest?/std", "serde?/std"]
+native-keccak = []
 getrandom = ["dep:getrandom"]
 rlp = ["dep:alloy-rlp", "ruint/alloy-rlp"]
 serde = ["dep:serde", "bytes/serde", "hex/serde", "ruint/serde"]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -27,6 +27,7 @@ tiny-keccak = { workspace = true, features = ["keccak"] }
 
 # macros
 derive_more.workspace = true
+cfg-if.workspace = true
 
 # rlp
 alloy-rlp = { workspace = true, optional = true }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -49,6 +49,7 @@ serde_json.workspace = true
 [features]
 default = ["std"]
 std = ["bytes/std", "hex/std", "alloy-rlp?/std", "proptest?/std", "serde?/std"]
+tiny-keccak = []
 native-keccak = []
 getrandom = ["dep:getrandom"]
 rlp = ["dep:alloy-rlp", "ruint/alloy-rlp"]

--- a/crates/primitives/src/utils.rs
+++ b/crates/primitives/src/utils.rs
@@ -1,6 +1,6 @@
 use crate::bits::FixedBytes;
 
-#[cfg(feature = "native-keccak")]
+#[cfg(all(feature = "native-keccak", not(feature = "tiny-keccak")))]
 #[link(wasm_import_module = "vm_hooks")]
 extern "C" {
     /// When targeting VMs with native keccak hooks, the `native-keccak` feature
@@ -22,7 +22,7 @@ extern "C" {
 ///
 /// [`keccak256`]: https://en.wikipedia.org/wiki/SHA-3
 pub fn keccak256<T: AsRef<[u8]>>(bytes: T) -> FixedBytes<32> {
-    #[cfg(not(feature = "native-keccak"))]
+    #[cfg(any(feature = "tiny-keccak", not(feature = "native-keccak")))]
     fn keccak256(bytes: &[u8]) -> FixedBytes<32> {
         use tiny_keccak::{Hasher, Keccak};
 
@@ -33,7 +33,7 @@ pub fn keccak256<T: AsRef<[u8]>>(bytes: T) -> FixedBytes<32> {
         output.into()
     }
 
-    #[cfg(feature = "native-keccak")]
+    #[cfg(all(feature = "native-keccak", not(feature = "tiny-keccak")))]
     fn keccak256(bytes: &[u8]) -> FixedBytes<32> {
         let mut output = [0u8; 32];
 

--- a/crates/primitives/src/utils.rs
+++ b/crates/primitives/src/utils.rs
@@ -5,11 +5,13 @@ use crate::bits::FixedBytes;
 extern "C" {
     /// When targeting VMs with native keccak hooks, the `native-keccak` feature
     /// can be enabled to import and use the host environment's implementation
-    /// of [`keccak256`] in place of [`tiny_keccak`].
+    /// of [`keccak256`] in place of [`tiny_keccak`]. This is overridden when
+    /// the `tiny-keccak` feature is enabled.
     ///
     /// # SAFETY
     ///
-    /// The VM accepts the preimage by pointer and length, and writes the 32-byte hash.
+    /// The VM accepts the preimage by pointer and length, and writes the
+    /// 32-byte hash.
     /// - `bytes` must point to an input buffer at least `len` long.
     /// - `output` must point to a buffer that is at least 32-bytes long.
     ///
@@ -22,24 +24,32 @@ extern "C" {
 ///
 /// [`keccak256`]: https://en.wikipedia.org/wiki/SHA-3
 pub fn keccak256<T: AsRef<[u8]>>(bytes: T) -> FixedBytes<32> {
-    #[cfg(any(feature = "tiny-keccak", not(feature = "native-keccak")))]
-    fn keccak256(bytes: &[u8]) -> FixedBytes<32> {
-        use tiny_keccak::{Hasher, Keccak};
+    cfg_if::cfg_if! {
+        if #[cfg(all(feature = "native-keccak", not(feature = "tiny-keccak")))] {
+            /// Calls an external native keccak hook when `native-keccak` is enabled.
+            /// This is overridden when `tiny-keccak` is enabled.
+            fn keccak256(bytes: &[u8]) -> FixedBytes<32> {
+                let mut output = [0u8; 32];
 
-        let mut output = [0u8; 32];
-        let mut hasher = Keccak::v256();
-        hasher.update(bytes);
-        hasher.finalize(&mut output);
-        output.into()
-    }
+                // SAFETY: The output is 32-bytes, and the input comes from a slice.
+                unsafe { native_keccak256(bytes.as_ptr(), bytes.len(), output.as_mut_ptr()) };
+                output.into()
+            }
+        } else {
+            /// Calls [`tiny-keccak`] when the `tiny-keccak` feature is enabled or
+            /// when no particular keccak feature flag is specified.
+            ///
+            /// [`tiny_keccak`]: https://docs.rs/tiny-keccak/latest/tiny_keccak/
+            fn keccak256(bytes: &[u8]) -> FixedBytes<32> {
+                use tiny_keccak::{Hasher, Keccak};
 
-    #[cfg(all(feature = "native-keccak", not(feature = "tiny-keccak")))]
-    fn keccak256(bytes: &[u8]) -> FixedBytes<32> {
-        let mut output = [0u8; 32];
-
-        // SAFETY: The output is 32-bytes, and the input comes from a slice.
-        unsafe { native_keccak256(bytes.as_ptr(), bytes.len(), output.as_mut_ptr()) };
-        output.into()
+                let mut output = [0u8; 32];
+                let mut hasher = Keccak::v256();
+                hasher.update(bytes);
+                hasher.finalize(&mut output);
+                output.into()
+            }
+        }
     }
 
     keccak256(bytes.as_ref())

--- a/crates/primitives/src/utils.rs
+++ b/crates/primitives/src/utils.rs
@@ -1,15 +1,44 @@
 use crate::bits::FixedBytes;
-use tiny_keccak::{Hasher, Keccak};
+
+#[cfg(feature = "native-keccak")]
+#[link(wasm_import_module = "vm_hooks")]
+extern "C" {
+    /// When targeting VMs with native keccak hooks, the `native-keccak` feature
+    /// can be enabled to import and use the host environment's implementation
+    /// of [`keccak256`] in place of [`tiny_keccak`].
+    ///
+    /// # SAFETY
+    ///
+    /// The VM accepts the preimage by pointer and length, and writes the 32-byte hash.
+    /// - `bytes` must point to an input buffer at least `len` long.
+    /// - `output` must point to a buffer that is at least 32-bytes long.
+    ///
+    /// [`keccak256`]: https://en.wikipedia.org/wiki/SHA-3
+    /// [`tiny_keccak`]: https://docs.rs/tiny-keccak/latest/tiny_keccak/
+    fn native_keccak256(bytes: *const u8, len: usize, output: *mut u8);
+}
 
 /// Simple interface to the [`keccak256`] hash function.
 ///
 /// [`keccak256`]: https://en.wikipedia.org/wiki/SHA-3
 pub fn keccak256<T: AsRef<[u8]>>(bytes: T) -> FixedBytes<32> {
+    #[cfg(not(feature = "native-keccak"))]
     fn keccak256(bytes: &[u8]) -> FixedBytes<32> {
+        use tiny_keccak::{Hasher, Keccak};
+
         let mut output = [0u8; 32];
         let mut hasher = Keccak::v256();
         hasher.update(bytes);
         hasher.finalize(&mut output);
+        output.into()
+    }
+
+    #[cfg(feature = "native-keccak")]
+    fn keccak256(bytes: &[u8]) -> FixedBytes<32> {
+        let mut output = [0u8; 32];
+
+        // SAFETY: The output is 32-bytes, and the input comes from a slice.
+        unsafe { native_keccak256(bytes.as_ptr(), bytes.len(), output.as_mut_ptr()) };
         output.into()
     }
 


### PR DESCRIPTION
# Background
As outlined in Paradigm's [introduction of Alloy](https://www.paradigm.xyz/2023/06/alloy), avoiding fragmentation of the Rust ecosystem on Ethereum means that everyone should use a consistent set of primitive types. As Rust expands into new Ethereum domains like smart contract development, generality will be key for this shared dependency.

The [`alloy_primatives`](https://docs.rs/alloy-primitives/latest/alloy_primitives/) crate included here does this very well, but could be made even better for upcoming Rust-enabled Ethereum smart contract environments like [Arbitrum Stylus](https://offchain.medium.com/hello-stylus-6b18fecc3a22). 

In addition to providing types, the crate currently pulls in `tiny_keccak`. This makes sense for most existing platforms, but in code running on top of VMs it's reasonable to accelerate common operations through so-called "host I/Os" or "traps". For example, the Stylus model includes a trap for `keccak256`.
```rs
#[link(wasm_import_module = "vm_hooks")]
extern "C" {
    fn native_keccak256(bytes: *const u8, len: usize, output: *mut u8);
}
```

Because host I/O operations run the function natively, we can get the native performance of `tiny_keccak` in a VM setting without any of the contribution to binary size. Though the example here is from Stylus, this reasoning applies to other VMs that might want to add hooks for operations like keccak. Anyone can expose a hook in their VM fulfilling `native_keccak256` above and accelerate hashing.

# Solution

This small PR introduces a new feature flag, `native-keccak`, that when enabled substitutes `tiny_keccak` for an `extern` import. Since the feature is not enabled by default, this change is 100% backward compatible.

Though the changes are to private functions, I've tried to include exhaustive documentation. Please let me know if there's anything I've missed in opening this PR and I'll be happy to make changes.