### PR TITLE
fix: correct encodeType expansion for nested structs

### DIFF
--- a/crates/sol-macro/src/expand/struct.rs
+++ b/crates/sol-macro/src/expand/struct.rs
@@ -40,22 +40,7 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, s: &ItemStruct) -> Result<TokenStream> {
         .map(|f| (expand_type(&f.ty), f.name.as_ref().unwrap()))
         .unzip();
 
-    let encoded_type = fields.eip712_signature(name.as_string());
-    let encode_type_impl = if fields.iter().any(|f| f.ty.is_custom()) {
-        quote! {
-            {
-                let mut encoded = String::from(#encoded_type);
-                #(
-                    if let Some(s) = <#field_types as ::alloy_sol_types::SolType>::eip712_encode_type() {
-                        encoded.push_str(&s);
-                    }
-                )*
-                encoded
-            }
-        }
-    } else {
-        quote!(#encoded_type)
-    };
+    let eip712_encode_type_fns: TokenStream = expand_encode_type_fns(fields, name);
 
     let tokenize_impl = expand_tokenize_func(fields.iter());
 
@@ -109,9 +94,7 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, s: &ItemStruct) -> Result<TokenStream> {
                     #tokenize_impl
                 }
 
-                fn eip712_encode_type() -> ::alloy_sol_types::private::Cow<'static, str> {
-                    #encode_type_impl.into()
-                }
+                #eip712_encode_type_fns
 
                 fn eip712_encode_data(&self) -> Vec<u8> {
                     #encode_data_impl
@@ -150,4 +133,58 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, s: &ItemStruct) -> Result<TokenStream> {
         };
     };
     Ok(tokens)
+}
+
+fn expand_encode_type_fns(
+    fields: &ast::Parameters<syn::token::Semi>,
+    name: &ast::SolIdent,
+) -> TokenStream {
+    let components_impl = expand_eip712_components(fields);
+    let root_type_impl = fields.eip712_signature(name.as_string());
+
+    let encode_type_impl_opt: Option<TokenStream> = if fields.iter().any(|f| f.ty.is_custom()) {
+        None
+    } else {
+        Some(quote! {
+            fn eip712_encode_type() -> ::alloy_sol_types::private::Cow<'static, str> {
+                Self::eip712_root_type()
+            }
+        })
+    };
+
+    quote! {
+        fn eip712_components() -> ::alloy_sol_types::private::Vec<::alloy_sol_types::private::Cow<'static, str>> {
+            #components_impl
+        }
+
+        fn eip712_root_type() -> ::alloy_sol_types::private::Cow<'static, str> {
+            #root_type_impl.into()
+        }
+
+        #encode_type_impl_opt
+    }
+}
+
+fn expand_eip712_components(fields: &ast::Parameters<syn::token::Semi>) -> TokenStream {
+    let bits: Vec<TokenStream> = fields
+        .iter()
+        .filter(|f| f.ty.is_custom())
+        .map(|field| {
+            let ty = expand_type(&field.ty);
+            quote! {
+                components.push(<#ty>::eip712_root_type());
+                components.extend(<#ty>::eip712_components());
+            }
+        })
+        .collect();
+
+    if bits.is_empty() {
+        quote! {vec![]}
+    } else {
+        quote! {
+            let mut components = vec![];
+            #(#bits)*
+            components
+        }
+    }
 }

--- a/crates/sol-types/src/types/struct.rs
+++ b/crates/sol-types/src/types/struct.rs
@@ -40,7 +40,7 @@ pub trait SolStruct: 'static {
 
     /// The struct name.
     ///
-    /// Used in [`eip712_encode_type`][SolStruct::eip712_encode_type].
+    /// Used in [`eip712_encode_type`][SolType::sol_type_name].
     const NAME: &'static str;
 
     // TODO: avoid clones here
@@ -63,9 +63,29 @@ pub trait SolStruct: 'static {
         self.tokenize().total_words() * Word::len_bytes()
     }
 
+    /// Returns component EIP-712 types. These types are used to construct
+    /// the `encodeType` string. These are the types of the struct's fields,
+    /// and should not include the root type.
+    fn eip712_components() -> Vec<Cow<'static, str>>;
+
+    /// Return the root EIP-712 type. This type is used to construct the
+    /// `encodeType` string.
+    fn eip712_root_type() -> Cow<'static, str>;
+
     /// EIP-712 `encodeType`
     /// <https://eips.ethereum.org/EIPS/eip-712#definition-of-encodetype>
-    fn eip712_encode_type() -> Cow<'static, str>;
+    fn eip712_encode_type() -> Cow<'static, str> {
+        let mut components = Self::eip712_components();
+        components.sort();
+        components.dedup();
+
+        Cow::Owned(
+            std::iter::once(Self::eip712_root_type())
+                .chain(components.into_iter())
+                .collect::<Vec<_>>()
+                .join(""),
+        )
+    }
 
     /// EIP-712 `typeHash`
     /// <https://eips.ethereum.org/EIPS/eip-712#rationale-for-typehash>

--- a/crates/sol-types/tests/sol.rs
+++ b/crates/sol-types/tests/sol.rs
@@ -282,3 +282,38 @@ fn abigen_json() {
         "callWithLongArray(uint64[128])"
     );
 }
+
+#[test]
+fn eip712_encode_type_nesting() {
+    sol! {
+        struct A {
+            uint256 a;
+        }
+
+        struct B {
+            bytes32 b;
+        }
+
+        struct C {
+            A a;
+            B b;
+        }
+
+        struct D {
+            C c;
+            A a;
+            B b;
+        }
+    }
+
+    assert_eq!(A::eip712_encode_type().unwrap(), "A(uint256 a)");
+    assert_eq!(B::eip712_encode_type().unwrap(), "B(bytes32 b)");
+    assert_eq!(
+        C::eip712_encode_type().unwrap(),
+        "C(A a,B b)A(uint256 a)B(bytes32 b)"
+    );
+    assert_eq!(
+        D::eip712_encode_type().unwrap(),
+        "D(C c,A a,B b)A(uint256 a)B(bytes32 b)C(A a,B b)"
+    );
+}


### PR DESCRIPTION

## Motivation

#201 

## Solution

- introduce `eip712_root_type` and `eip712_component_types` to get typestrings on the fly
- sort, dedup, and append typestring in default impl of `eip712_encode_type`

This is a bit clunky. I don't love it

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
