### PR TITLE
chore: bump ruint to 1.10.1 + alloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,6 @@ itoa = "1"
 once_cell = "1"
 proptest = "1"
 proptest-derive = "0.3"
-ruint = { version = "1.9.0", default-features = false }
+ruint = { version = "1.10.1", default-features = false, features = ["alloc"] }
 ruint-macro = { version = "1", default-features = false }
 tiny-keccak = "2.0"


### PR DESCRIPTION
## Motivation

Alloy use of ruint broken in 1.10.0

Closes #212

## Solution

This depends on release of ruint @ 1.10.1

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
