### PR TITLE
fix(sol-macro): don't panic when encountering functions without names

### DIFF
--- a/crates/sol-macro/src/expand/function.rs
+++ b/crates/sol-macro/src/expand/function.rs
@@ -30,8 +30,14 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, function: &ItemFunction) -> Result<TokenS
         attrs,
         arguments,
         returns,
+        name: Some(_),
         ..
-    } = function;
+    } = function
+    else {
+        // ignore functions without names (constructors, modifiers...)
+        return Ok(quote!())
+    };
+
     cx.assert_resolved(arguments)?;
     if let Some(returns) = returns {
         cx.assert_resolved(&returns.returns)?;

--- a/crates/sol-macro/src/expand/mod.rs
+++ b/crates/sol-macro/src/expand/mod.rs
@@ -175,7 +175,7 @@ impl ExpCtxt<'_> {
             .functions
             .values()
             .flatten()
-            .map(|f| f.name().clone())
+            .flat_map(|f| f.name.clone())
             .collect();
         let mut overloads_map = std::mem::take(&mut self.function_overloads);
 
@@ -236,10 +236,12 @@ impl<'ast> Visit<'ast> for ExpCtxt<'ast> {
     }
 
     fn visit_item_function(&mut self, function: &'ast ItemFunction) {
-        self.functions
-            .entry(function.name().as_string())
-            .or_default()
-            .push(function);
+        if let Some(name) = &function.name {
+            self.functions
+                .entry(name.as_string())
+                .or_default()
+                .push(function);
+        }
         ast::visit::visit_item_function(self, function);
     }
 }

--- a/crates/syn-solidity/src/item/function.rs
+++ b/crates/syn-solidity/src/item/function.rs
@@ -76,6 +76,12 @@ impl ItemFunction {
         }
     }
 
+    /// Returns the name of the function.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the function has no name. This is the case when `kind` is not
+    /// `Function`.
     pub fn name(&self) -> &SolIdent {
         match &self.name {
             Some(name) => name,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Fixes #184 
Ref #157, this just avoids panicking and doesn't generate anything. We would need to support fallbacks and receive functions as separate structs in sol-type but I'm not sure if this is that useful. cc @prestwich 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
