### PR TITLE
fix(sol-macro): encode UDVTs as their underlying type in EIP-712

### DIFF
--- a/crates/dyn-abi/src/eip712/resolver.rs
+++ b/crates/dyn-abi/src/eip712/resolver.rs
@@ -325,7 +325,7 @@ impl Resolver {
         let type_name = type_def.type_name.to_owned();
         // Insert the edges into the graph
         {
-            let entry = self.edges.entry(type_name.clone()).or_insert_with(Vec::new);
+            let entry = self.edges.entry(type_name.clone()).or_default();
             type_def
                 .props
                 .iter()

--- a/crates/sol-types/src/types/struct.rs
+++ b/crates/sol-types/src/types/struct.rs
@@ -82,13 +82,9 @@ pub trait SolStruct: 'static {
             return root_type
         }
 
-        components.sort();
+        components.sort_unstable();
         components.dedup();
-        Cow::Owned(
-            core::iter::once(root_type)
-                .chain(components)
-                .collect::<crate::private::String>(),
-        )
+        Cow::Owned(core::iter::once(root_type).chain(components).collect())
     }
 
     /// EIP-712 `typeHash`

--- a/crates/sol-types/src/types/udt.rs
+++ b/crates/sol-types/src/types/udt.rs
@@ -11,7 +11,6 @@ macro_rules! define_udt {
         underlying: $underlying:ty,
         type_check: $path:path,
     ) => {
-
         $(#[$outer])*
         /// This struct is a Solidity user-defined value type. It wraps
         /// an underlying type.
@@ -90,6 +89,23 @@ macro_rules! define_udt {
             fn encode_packed_to(rust: &Self::RustType, out: &mut $crate::private::Vec<u8>)
             {
                 <$underlying as $crate::SolType>::encode_packed_to(rust, out)
+            }
+        }
+
+        impl $crate::EventTopic for $name {
+            #[inline]
+            fn topic_preimage_length(rust: &Self::RustType) -> usize {
+                <$underlying as $crate::EventTopic>::topic_preimage_length(rust)
+            }
+
+            #[inline]
+            fn encode_topic_preimage(rust: &Self::RustType, out: &mut $crate::private::Vec<u8>) {
+                <$underlying as $crate::EventTopic>::encode_topic_preimage(rust, out)
+            }
+
+            #[inline]
+            fn encode_topic(rust: &Self::RustType) -> $crate::token::WordToken {
+                <$underlying as $crate::EventTopic>::encode_topic(rust)
             }
         }
     };

--- a/crates/sol-types/tests/sol.rs
+++ b/crates/sol-types/tests/sol.rs
@@ -283,12 +283,33 @@ fn abigen_json_large_array() {
     );
 }
 
-// TODO
-// #[test]
-// #[cfg(feature = "json")]
-// fn abigen_json_seaport() {
-//     sol!(Seaport, "../json-abi/tests/abi/Seaport.json");
-// }
+#[test]
+#[cfg(feature = "json")]
+fn abigen_json_seaport() {
+    use alloy_sol_types::SolStruct;
+    use std::borrow::Cow;
+    use Seaport::*;
+
+    sol!(Seaport, "../json-abi/tests/abi/Seaport.json");
+
+    // BasicOrderType is a uint8 UDVT
+    let _ = BasicOrderType::from(0u8);
+
+    // BasicOrderParameters is a struct that contains UDVTs (basicOrderType) and a
+    // struct array. The only component should be the struct of the struct array.
+    let root_type = "BasicOrderParameters(address considerationToken,uint256 considerationIdentifier,uint256 considerationAmount,address offerer,address zone,address offerToken,uint256 offerIdentifier,uint256 offerAmount,uint8 basicOrderType,uint256 startTime,uint256 endTime,bytes32 zoneHash,uint256 salt,bytes32 offererConduitKey,bytes32 fulfillerConduitKey,uint256 totalOriginalAdditionalRecipients,AdditionalRecipient[] additionalRecipients,bytes signature)";
+    let component = "AdditionalRecipient(uint256 amount,address recipient)";
+
+    assert_eq!(BasicOrderParameters::eip712_root_type(), root_type);
+    assert_eq!(
+        BasicOrderParameters::eip712_components(),
+        [Cow::Borrowed(component)]
+    );
+    assert_eq!(
+        <BasicOrderParameters as SolStruct>::eip712_encode_type(),
+        root_type.to_string() + component
+    );
+}
 
 #[test]
 fn eip712_encode_type_nesting() {

--- a/crates/syn-solidity/src/type/mod.rs
+++ b/crates/syn-solidity/src/type/mod.rs
@@ -263,6 +263,7 @@ impl Type {
         matches!(self, Self::Custom(_))
     }
 
+    /// Recurses into this type and returns whether it contains a custom type.
     pub fn has_custom(&self) -> bool {
         match self {
             Self::Custom(_) => true,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Fixes #219

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Check for `UDVT`s when computing struct eip712 root type and signature.
Also implement `EventTopic` for `UDVT`s declared with the macro, as it is also needed.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
