### PR TITLE
feat(dyn-abi): allow `T: Into<Cow<str>>` in `eip712_domain!`

### DIFF
--- a/crates/sol-types/src/macros.rs
+++ b/crates/sol-types/src/macros.rs
@@ -1,8 +1,7 @@
 /// Calls the given macro with all the tuples.
 #[rustfmt::skip]
 macro_rules! all_the_tuples {
-    (@double $name:ident) =>
-    {
+    (@double $name:ident) => {
         $name!((T1 U1));
         $name!((T1 U1), (T2 U2));
         $name!((T1 U1), (T2 U2), (T3 U3));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Minor improvement to the `eip712_domain!` macro.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

If an `expr` is a `literal`, then use `Cow::Borrowed`, else use `Cow::from`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
