### PR TITLE
fix bincode serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ alloy-rlp = { version = "0.3.0", default-features = false }
 alloy-rlp-derive = { version = "0.3.0", default-features = false }
 arbitrary = "1.3"
 arrayvec = { version = "0.7", default-features = false }
+bincode = "1.3"
 bytes = { version = "1.4", default-features = false }
 criterion = "0.5"
 derive_arbitrary = "1.3"

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -45,6 +45,7 @@ proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
 [dev-dependencies]
+bincode.workspace = true
 serde_json.workspace = true
 serde = { workspace = true, features = ["derive"] }
 

--- a/crates/primitives/src/bits/serde.rs
+++ b/crates/primitives/src/bits/serde.rs
@@ -18,58 +18,82 @@ impl<const N: usize> Serialize for FixedBytes<N> {
 
 impl<'de, const N: usize> Deserialize<'de> for FixedBytes<N> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        struct FixedVisitor<const N: usize>;
+        if deserializer.is_human_readable() {
+            struct FixedVisitor<const N: usize>;
 
-        impl<'de, const N: usize> Visitor<'de> for FixedVisitor<N> {
-            type Value = FixedBytes<N>;
+            impl<'de, const N: usize> Visitor<'de> for FixedVisitor<N> {
+                type Value = FixedBytes<N>;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(
-                    formatter,
+                fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    write!(
+                        formatter,
                     "{} bytes, represented as a hex string of length {}, an array of u8, or raw bytes",
-                    N,
-                    N * 2
-                )
-            }
-
-            fn visit_bytes<E: de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
-                <[u8; N]>::try_from(v)
-                    .map(FixedBytes)
-                    .map_err(de::Error::custom)
-            }
-
-            fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
-                let mut bytes = [0u8; N];
-
-                bytes.iter_mut().enumerate().try_for_each(|(i, b)| {
-                    *b = seq.next_element()?.ok_or_else(|| {
-                        de::Error::invalid_length(i, &format!("exactly {} bytes", N).as_str())
-                    })?;
-                    Ok(())
-                })?;
-
-                if let Ok(Some(_)) = seq.next_element::<u8>() {
-                    return Err(de::Error::invalid_length(
-                        N + 1,
-                        &format!("exactly {} bytes", N).as_str(),
-                    ))
+                        N,
+                        N * 2
+                    )
                 }
 
-                Ok(FixedBytes(bytes))
+                fn visit_bytes<E: de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+                    <[u8; N]>::try_from(v)
+                        .map(FixedBytes)
+                        .map_err(de::Error::custom)
+                }
+
+                fn visit_seq<A: de::SeqAccess<'de>>(
+                    self,
+                    mut seq: A,
+                ) -> Result<Self::Value, A::Error> {
+                    let mut bytes = [0u8; N];
+
+                    bytes.iter_mut().enumerate().try_for_each(|(i, b)| {
+                        *b = seq.next_element()?.ok_or_else(|| {
+                            de::Error::invalid_length(i, &format!("exactly {} bytes", N).as_str())
+                        })?;
+                        Ok(())
+                    })?;
+
+                    if let Ok(Some(_)) = seq.next_element::<u8>() {
+                        return Err(de::Error::invalid_length(
+                            N + 1,
+                            &format!("exactly {} bytes", N).as_str(),
+                        ))
+                    }
+
+                    Ok(FixedBytes(bytes))
+                }
+
+                fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                    <FixedBytes<N> as hex::FromHex>::from_hex(v).map_err(de::Error::custom)
+                }
             }
 
-            fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
-                <FixedBytes<N> as hex::FromHex>::from_hex(v).map_err(de::Error::custom)
+            deserializer.deserialize_any(FixedVisitor::<N>)
+        } else {
+            struct FixedVisitor<const N: usize>;
+
+            impl<'de, const N: usize> Visitor<'de> for FixedVisitor<N> {
+                type Value = FixedBytes<N>;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    formatter.write_str("byte array")
+                }
+
+                fn visit_bytes<E: de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+                    <[u8; N]>::try_from(v)
+                        .map(FixedBytes)
+                        .map_err(de::Error::custom)
+                }
             }
+
+            deserializer.deserialize_bytes(FixedVisitor::<N>)
         }
-
-        deserializer.deserialize_any(FixedVisitor::<N>)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bincode as _;
     use serde::Deserialize;
     #[derive(Debug, Deserialize)]
     struct TestCase<const N: usize> {
@@ -82,6 +106,13 @@ mod tests {
         let ser = serde_json::to_string(&bytes).unwrap();
         assert_eq!(ser, "\"0x000000000123456789abcdef\"");
         assert_eq!(serde_json::from_str::<FixedBytes<12>>(&ser).unwrap(), bytes);
+
+        let val = serde_json::to_value(&bytes).unwrap();
+        assert_eq!(val, serde_json::json! {"0x000000000123456789abcdef"});
+        assert_eq!(
+            serde_json::from_value::<FixedBytes<12>>(val).unwrap(),
+            bytes
+        );
     }
 
     #[test]
@@ -100,5 +131,13 @@ mod tests {
             serde_json::from_value::<TestCase<4>>(json.clone()).unwrap_err()
         )
         .contains("invalid length 5, expected exactly 4 bytes"),);
+    }
+
+    #[test]
+    fn test_bincode_roundtrip() {
+        let bytes = FixedBytes([0, 0, 0, 0, 1, 35, 69, 103, 137, 171, 205, 239]);
+
+        let bin = bincode::serialize(&bytes).unwrap();
+        assert_eq!(bincode::deserialize::<FixedBytes<12>>(&bin).unwrap(), bytes);
     }
 }

--- a/crates/primitives/src/bits/serde.rs
+++ b/crates/primitives/src/bits/serde.rs
@@ -25,11 +25,11 @@ impl<'de, const N: usize> Deserialize<'de> for FixedBytes<N> {
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(
-                        formatter,
+                    formatter,
                     "{} bytes, represented as a hex string of length {}, an array of u8, or raw bytes",
-                        N,
-                        N * 2
-                    )
+                    N,
+                    N * 2
+                )
             }
 
             fn visit_bytes<E: de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {

--- a/crates/primitives/src/bytes/serde.rs
+++ b/crates/primitives/src/bytes/serde.rs
@@ -60,7 +60,7 @@ impl<'de> serde::Deserialize<'de> for Bytes {
             deserializer.deserialize_any(BytesVisitor)
         } else {
             struct BytesVisitor;
-            
+
             impl<'de> Visitor<'de> for BytesVisitor {
                 type Value = Bytes;
 


### PR DESCRIPTION
## Motivation

Fixes `bincode` deserialization of `FixedBytes` and `Bytes`.

## Solution

Distinguish between `is_human_readable` and not also in the deserialization. If it is not human readable (e.g. `bincode`) allow only bytes instead of also strings.
This fixes #221 .

Added tests for the `bincode` roundtrip that previously failed.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
