### PR TITLE
fix(sol-macro): snake_case'd function names

### DIFF
--- a/crates/sol-macro/src/expand/contract.rs
+++ b/crates/sol-macro/src/expand/contract.rs
@@ -386,7 +386,7 @@ fn generate_variant_conversions(name: &Ident, variant: &Ident, ty: &Ident) -> To
 
 fn generate_variant_methods((variant, ty): (&Ident, &Ident)) -> TokenStream {
     let name = variant.unraw();
-    let name_snake = name.to_string().to_snake_case();
+    let name_snake = snakify(&name.to_string());
 
     let is_variant = format_ident!("is_{name_snake}");
     let is_variant_doc = format!("Returns `true` if `self` matches [`{name}`](Self::{name}).");
@@ -426,4 +426,23 @@ fn generate_variant_methods((variant, ty): (&Ident, &Ident)) -> TokenStream {
             }
         }
     }
+}
+
+/// `heck` doesn't treat numbers as new words, and discards leading underscores.
+fn snakify(s: &str) -> String {
+    let leading = s.chars().take_while(|c| *c == '_');
+    let mut output: Vec<char> = leading.chain(s.to_snake_case().chars()).collect();
+
+    let mut num_starts = vec![];
+    for (pos, c) in output.iter().enumerate() {
+        if pos != 0 && c.is_digit(10) && !output[pos - 1].is_digit(10) {
+            num_starts.push(pos);
+        }
+    }
+    // need to do in reverse, because after inserting, all chars after the point of
+    // insertion are off
+    for i in num_starts.into_iter().rev() {
+        output.insert(i, '_')
+    }
+    output.into_iter().collect()
 }

--- a/crates/sol-macro/src/expand/contract.rs
+++ b/crates/sol-macro/src/expand/contract.rs
@@ -435,7 +435,7 @@ fn snakify(s: &str) -> String {
 
     let mut num_starts = vec![];
     for (pos, c) in output.iter().enumerate() {
-        if pos != 0 && c.is_digit(10) && !output[pos - 1].is_digit(10) {
+        if pos != 0 && c.is_ascii_digit() && !output[pos - 1].is_ascii_digit() {
             num_starts.push(pos);
         }
     }

--- a/crates/sol-types/tests/sol.rs
+++ b/crates/sol-types/tests/sol.rs
@@ -163,6 +163,23 @@ fn empty_call() {
 }
 
 #[test]
+fn function_names() {
+    sol! {
+        contract LeadingUnderscores {
+            function f();
+            function _f();
+            function __f();
+        }
+    }
+    use LeadingUnderscores::*;
+
+    let call = LeadingUnderscoresCalls::f(fCall {});
+    assert!(call.is_f());
+    assert!(!call.is__f());
+    assert!(!call.is___f());
+}
+
+#[test]
 fn abigen_sol_multicall() {
     sol!("../syn-solidity/tests/contracts/Multicall.sol");
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`heck` doesn't treat numbers as new words, and discards leading underscores, thus:

```solidity
contract C {
  function f();
  function _f();
}
```

failed to compile because the generated `is_`... functions would have the same name for both variants.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Create a helper function for snakifying idents, taken from [`strum`](https://github.com/Peternator7/strum/blob/fcb9841a744543b993eb1645db35dbda541e9a30/strum_macros/src/macros/enum_is.rs#L48C1-L61C2)

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
