### PR TITLE
feat(sol-macro): expand fields with attrs

### DIFF
--- a/crates/sol-macro/src/expand/error.rs
+++ b/crates/sol-macro/src/expand/error.rs
@@ -41,7 +41,7 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, error: &ItemError) -> Result<TokenStream>
         #[allow(non_camel_case_types, non_snake_case)]
         #[derive(Clone)]
         pub struct #name {
-            #(pub #fields,)*
+            #(#fields),*
         }
 
         #[allow(non_camel_case_types, non_snake_case, clippy::style)]

--- a/crates/sol-macro/src/expand/function.rs
+++ b/crates/sol-macro/src/expand/function.rs
@@ -71,14 +71,14 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, function: &ItemFunction) -> Result<TokenS
         #[allow(non_camel_case_types, non_snake_case)]
         #[derive(Clone)]
         pub struct #call_name {
-            #(pub #call_fields,)*
+            #(#call_fields),*
         }
 
         #(#return_attrs)*
         #[allow(non_camel_case_types, non_snake_case)]
         #[derive(Clone)]
         pub struct #return_name {
-            #(pub #return_fields,)*
+            #(#return_fields),*
         }
 
         #[allow(non_camel_case_types, non_snake_case, clippy::style)]

--- a/crates/sol-macro/src/expand/mod.rs
+++ b/crates/sol-macro/src/expand/mod.rs
@@ -492,15 +492,21 @@ fn expand_fields<P>(params: &Parameters<P>) -> impl Iterator<Item = TokenStream>
     params
         .iter()
         .enumerate()
-        .map(|(i, var)| expand_field(i, &var.ty, var.name.as_ref()))
+        .map(|(i, var)| expand_field(i, &var.ty, var.name.as_ref(), var.attrs.as_ref()))
 }
 
 /// Expands a single parameter into a struct field.
-fn expand_field(i: usize, ty: &Type, name: Option<&SolIdent>) -> TokenStream {
+fn expand_field(
+    i: usize,
+    ty: &Type,
+    name: Option<&SolIdent>,
+    attrs: &Vec<Attribute>,
+) -> TokenStream {
     let name = anon_name((i, name));
     let ty = expand_type(ty);
     quote! {
-        #name: <#ty as ::alloy_sol_types::SolType>::RustType
+        #(#attrs)*
+        pub #name: <#ty as ::alloy_sol_types::SolType>::RustType
     }
 }
 

--- a/crates/sol-macro/src/expand/struct.rs
+++ b/crates/sol-macro/src/expand/struct.rs
@@ -69,7 +69,7 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, s: &ItemStruct) -> Result<TokenStream> {
         #[allow(non_camel_case_types, non_snake_case)]
         #[derive(Clone)]
         pub struct #name {
-            #(pub #fields),*
+            #(#fields),*
         }
 
         #[allow(non_camel_case_types, non_snake_case, clippy::style)]

--- a/crates/sol-types/Cargo.toml
+++ b/crates/sol-types/Cargo.toml
@@ -26,7 +26,9 @@ hex.workspace = true
 serde = { workspace = true, optional = true, features = ["derive"] }
 
 [dev-dependencies]
-alloy-primitives = { workspace = true, features = ["arbitrary"] }
+alloy-primitives = { workspace = true, features = ["arbitrary", "serde"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 
 hex-literal.workspace = true
 proptest.workspace = true

--- a/crates/sol-types/tests/sol.rs
+++ b/crates/sol-types/tests/sol.rs
@@ -294,6 +294,31 @@ fn abigen_sol_multicall() {
 }
 
 #[test]
+fn struct_derive_with_field_attrs() {
+    use serde::Serialize;
+    use serde_json::{self, Value};
+    sol! {
+        #[derive(Serialize, Default)]
+        struct MyStruct {
+            #[serde(skip)]
+            uint256 a;
+            bytes32 b;
+            address[] c;
+        }
+    }
+
+    assert_eq!(
+        serde_json::from_str::<Value>(
+            serde_json::to_string(&MyStruct::default())
+                .unwrap()
+                .as_str()
+        )
+        .unwrap()["a"],
+        Value::Null
+    );
+}
+
+#[test]
 #[cfg(feature = "json")]
 fn abigen_json_large_array() {
     sol!(LargeArray, "../json-abi/tests/abi/LargeArray.json");


### PR DESCRIPTION
## Motivation
When using a derive macro inside of the sol! macro, field attributes are not propagated to the expanded item.

## Solution
Added 'attrs' parameter to 'expand_field'
Passed 'attrs' arg to 'expand_field' in 'expand_fields'
Moved 'pub' visibility specification to 'expand_field' 

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
