### PR TITLE
doc: add note regarding ruint::uint macro

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -51,8 +51,9 @@ pub use utils::keccak256;
 pub use ::hex;
 #[doc(no_inline)]
 pub use hex_literal::{self, hex};
-/// Re-export of `ruint::uint` for convenience. Note that users of the [`uint`]
-/// macro must also add `ruint` to their `Cargo.toml` as a dependency.
+/// Re-export of [`ruint::uint`] for convenience. Note that users of this macro
+/// must also add [`ruint`] to their `Cargo.toml` as a dependency.
+#[doc(inline)]
 pub use ruint::uint;
 #[doc(no_inline)]
 pub use ruint::{self, Uint};

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -51,8 +51,11 @@ pub use utils::keccak256;
 pub use ::hex;
 #[doc(no_inline)]
 pub use hex_literal::{self, hex};
+/// Re-export of `ruint::uint` for convenience. Note that users of the [`uint`]
+/// macro must also add `ruint` to their `Cargo.toml` as a dependency.
+pub use ruint::uint;
 #[doc(no_inline)]
-pub use ruint::{self, uint, Uint};
+pub use ruint::{self, Uint};
 #[doc(no_inline)]
 pub use tiny_keccak::{self, Hasher, Keccak};
 


### PR DESCRIPTION
Document correct usage of `ruint::uint` macro

## Motivation

https://github.com/recmo/uint/issues/307

## Solution

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
