### PR TITLE
dep: pin anstyle to 1.65 compat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,4 @@ tiny-keccak = "2.0"
 # but are only used by dev-dependencies so we can just pin them
 clap = "~4.3"
 clap_lex = "<=0.5.0"
+anstyle = "=1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,8 @@ ruint = { version = "1.10.1", default-features = false, features = ["alloc"] }
 ruint-macro = { version = "1", default-features = false }
 tiny-keccak = "2.0"
 
-# These dependencies have higher a MSRV (clap@4.4.0, clap_lex@0.5.1),
+# This crates are dependencies of criterion, with a higher MSRV
+# (clap@4.4.0, clap_lex@0.5.1, anstyle@1.0.3),
 # but are only used by dev-dependencies so we can just pin them
 clap = "~4.3"
 clap_lex = "<=0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,4 +66,4 @@ tiny-keccak = "2.0"
 # but are only used by dev-dependencies so we can just pin them
 clap = "~4.3"
 clap_lex = "<=0.5.0"
-anstyle = "=1.0.1"
+anstyle = "<=1.0.2"

--- a/crates/dyn-abi/Cargo.toml
+++ b/crates/dyn-abi/Cargo.toml
@@ -38,12 +38,15 @@ proptest = { workspace = true, optional = true }
 
 [dev-dependencies]
 hex-literal.workspace = true
-clap.workspace = true
-clap_lex.workspace = true
 criterion.workspace = true
 ethabi = "18"
 rand = "0.8"
 serde_json = { workspace = true }
+
+# MSRV support
+clap.workspace = true
+clap_lex.workspace = true
+anstyle.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/json-abi/Cargo.toml
+++ b/crates/json-abi/Cargo.toml
@@ -21,10 +21,13 @@ serde_json = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json.workspace = true
-clap.workspace = true
-clap_lex.workspace = true
 criterion.workspace = true
 ethabi = "18"
+
+# MSRV support
+clap.workspace = true
+clap_lex.workspace = true
+anstyle.workspace = true
 
 [features]
 default = ["std"]


### PR DESCRIPTION

## Motivation

anstyle requires 1.70 as of 1.0.3.

## Solution


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
