### PR TITLE
fix: rand default-features typo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ itoa = "1"
 once_cell = "1"
 proptest = "1"
 proptest-derive = "0.4"
-rand = { version = "0.8", default-feature = false }
+rand = { version = "0.8", default-features = false }
 ruint = { version = "1.10.1", default-features = false, features = ["alloc"] }
 ruint-macro = { version = "1", default-features = false }
 tiny-keccak = "2.0"


### PR DESCRIPTION
Don't know why this doesn't throw a warning or error