### PR TITLE
refactor: rewrite type parser with `winnow`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             - uses: Swatinem/rust-cache@v2
             # Only run tests on latest stable and above
             - name: check
-              if: ${{ matrix.rust == '1.65' }} # MSRV
+              if: ${{ matrix.flags != '--all-features' && matrix.rust == '1.65' }} # MSRV
               run: cargo check --workspace ${{ matrix.flags }}
             - name: test
               if: ${{ matrix.rust != '1.65' }} # MSRV

--- a/crates/dyn-abi/benches/types.rs
+++ b/crates/dyn-abi/benches/types.rs
@@ -20,14 +20,14 @@ fn parse(c: &mut Criterion) {
 
     g.bench_function("keywords", |b| {
         b.iter(|| {
-            let kw = KEYWORDS.choose(rng).unwrap();
-            DynSolType::parse(black_box(*kw)).unwrap()
+            let kw = *KEYWORDS.choose(rng).unwrap();
+            DynSolType::parse(black_box(kw)).unwrap()
         });
     });
     g.bench_function("complex", |b| {
         b.iter(|| {
-            let complex = COMPLEX.choose(rng).unwrap();
-            DynSolType::parse(black_box(*complex)).unwrap()
+            let complex = *COMPLEX.choose(rng).unwrap();
+            DynSolType::parse(black_box(complex)).unwrap()
         });
     });
 

--- a/crates/dyn-abi/src/resolve.rs
+++ b/crates/dyn-abi/src/resolve.rs
@@ -113,7 +113,6 @@ impl ResolveSolType for TypeStem<'_> {
 }
 
 impl ResolveSolType for TypeSpecifier<'_> {
-    #[inline]
     fn resolve(&self) -> Result<DynSolType> {
         self.stem
             .resolve()
@@ -122,12 +121,14 @@ impl ResolveSolType for TypeSpecifier<'_> {
 }
 
 impl ResolveSolType for Param {
+    #[inline]
     fn resolve(&self) -> Result<DynSolType> {
         resolve_param(&self.ty, &self.components, self.internal_type())
     }
 }
 
 impl ResolveSolType for EventParam {
+    #[inline]
     fn resolve(&self) -> Result<DynSolType> {
         resolve_param(&self.ty, &self.components, self.internal_type())
     }
@@ -198,20 +199,12 @@ mod tests {
 
     #[test]
     fn extra_close_parens() {
-        let test_str = "bool,uint256))";
-        assert_eq!(
-            parse(test_str),
-            Err(alloy_sol_type_parser::Error::invalid_type_string(test_str).into())
-        );
+        parse("bool,uint256))").unwrap_err();
     }
 
     #[test]
     fn extra_open_parents() {
-        let test_str = "(bool,uint256";
-        assert_eq!(
-            parse(test_str),
-            Err(alloy_sol_type_parser::Error::invalid_type_string(test_str).into())
-        );
+        parse("(bool,uint256").unwrap_err();
     }
 
     #[test]

--- a/crates/dyn-abi/src/resolve.rs
+++ b/crates/dyn-abi/src/resolve.rs
@@ -298,7 +298,7 @@ mod tests {
         );
 
         assert_eq!(
-            parse("tuple(address,bytes, (bool, (string, uint256)[][3]))[2]"),
+            parse("tuple(address,bytes,(bool,(string,uint256)[][3]))[2]"),
             Ok(DynSolType::FixedArray(
                 Box::new(DynSolType::Tuple(vec![
                     DynSolType::Address,
@@ -352,7 +352,7 @@ mod tests {
             Ok(())
         );
         assert_eq!(
-            TypeSpecifier::try_from("tuple(address,bytes, (bool, (string, uint256)[][3]))[2]")
+            TypeSpecifier::try_from("tuple(address,bytes,(bool,(string,uint256)[][3]))[2]")
                 .unwrap()
                 .try_basic_solidity(),
             Ok(())

--- a/crates/dyn-abi/src/ty.rs
+++ b/crates/dyn-abi/src/ty.rs
@@ -134,22 +134,6 @@ impl FromStr for DynSolType {
 }
 
 impl DynSolType {
-    /// Wrap in an array of the specified size
-    pub(crate) fn array_wrap(self, size: Option<NonZeroUsize>) -> Self {
-        match size {
-            Some(size) => Self::FixedArray(Box::new(self), size.get()),
-            None => Self::Array(Box::new(self)),
-        }
-    }
-
-    /// Iteratively wrap in arrays.
-    pub(crate) fn array_wrap_from_iter(
-        self,
-        iter: impl IntoIterator<Item = Option<NonZeroUsize>>,
-    ) -> Self {
-        iter.into_iter().fold(self, Self::array_wrap)
-    }
-
     /// Parses a Solidity type name string into a [`DynSolType`].
     ///
     /// # Examples
@@ -167,6 +151,24 @@ impl DynSolType {
         TypeSpecifier::try_from(s)
             .map_err(Error::TypeParser)
             .and_then(|t| t.resolve())
+    }
+
+    /// Wrap in an array of the specified size
+    #[inline]
+    pub(crate) fn array_wrap(self, size: Option<NonZeroUsize>) -> Self {
+        match size {
+            Some(size) => Self::FixedArray(Box::new(self), size.get()),
+            None => Self::Array(Box::new(self)),
+        }
+    }
+
+    /// Iteratively wrap in arrays.
+    #[inline]
+    pub(crate) fn array_wrap_from_iter(
+        self,
+        iter: impl IntoIterator<Item = Option<NonZeroUsize>>,
+    ) -> Self {
+        iter.into_iter().fold(self, Self::array_wrap)
     }
 
     /// Fallible cast to the contents of a variant.

--- a/crates/sol-type-parser/Cargo.toml
+++ b/crates/sol-type-parser/Cargo.toml
@@ -18,7 +18,9 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+winnow = { version = "0.5", default-features = false, features = ["alloc"] }
 
 [features]
 default = ["std"]
-std = []
+std = ["winnow/std"]
+debug = ["winnow/debug"]

--- a/crates/sol-type-parser/Cargo.toml
+++ b/crates/sol-type-parser/Cargo.toml
@@ -23,4 +23,4 @@ winnow = { version = "0.5", default-features = false, features = ["alloc"] }
 [features]
 default = ["std"]
 std = ["winnow/std"]
-debug = ["winnow/debug"]
+debug = ["std", "winnow/debug"] # WARNING: Bumps MSRV to at least 1.70

--- a/crates/sol-type-parser/Cargo.toml
+++ b/crates/sol-type-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alloy-sol-type-parser"
-description = "Solidity type specifier string parsing."
+description = "Solidity type specifier string parser"
 keywords = ["ethereum", "abi", "EVM", "solidity"]
 categories = ["no-std", "cryptography::cryptocurrencies"]
 homepage = "https://github.com/alloy-rs/core/tree/main/crates/sol-type-parser"

--- a/crates/sol-type-parser/README.md
+++ b/crates/sol-type-parser/README.md
@@ -48,10 +48,10 @@ assert_eq!(
 );
 
 // Type specifiers also work for complex tuples!
-let my_tuple = TypeSpecifier::try_from("(uint8, (uint8[], bool))[39]").unwrap();
+let my_tuple = TypeSpecifier::try_from("(uint8,(uint8[],bool))[39]").unwrap();
 assert_eq!(
     my_tuple.stem.span(),
-    "(uint8, (uint8[], bool))"
+    "(uint8,(uint8[],bool))"
 );
 
 // Types are NOT resolved, so you can parse custom structs just by name.

--- a/crates/sol-type-parser/src/error.rs
+++ b/crates/sol-type-parser/src/error.rs
@@ -1,43 +1,71 @@
-use alloc::string::{String, ToString};
+use alloc::string::String;
 use core::fmt;
 
 /// Type string parsing result
-pub type Result<T> = core::result::Result<T, Error>;
+pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 /// A type string parsing error.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Error {
-    /// Invalid type string, extra chars, or invalid structure.
-    InvalidTypeString(String),
-    /// Invalid size for a primitive type (intX, uintX, or bytesX).
-    InvalidSize(String),
+#[derive(Clone, PartialEq, Eq)]
+pub struct Error(Repr);
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Error").field(&self.0 .0).finish()
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
 }
 
 impl Error {
+    /// Instantiate a new error.
+    pub fn new(s: impl fmt::Display) -> Self {
+        Self::new_("", &s)
+    }
+
+    /// Instantiate a new parser error.
+    pub(crate) fn parser(e: impl fmt::Display) -> Self {
+        Self::new_(
+            if cfg!(feature = "std") {
+                "parser error:\n"
+            } else {
+                "parser error: "
+            },
+            &e,
+        )
+    }
+
     /// Instantiate an invalid type string error. Invalid type string errors are
     /// for type strings that are not valid type strings. E.g. "uint256))))[".
-    #[inline(always)]
-    pub fn invalid_type_string(ty: impl ToString) -> Self {
-        Self::InvalidTypeString(ty.to_string())
+    pub fn invalid_type_string(ty: impl fmt::Display) -> Self {
+        Self::new_("invalid type string: ", &ty)
     }
 
     /// Instantiate an invalid size error. Invalid size errors are for valid
     /// primitive types with invalid sizes. E.g. `"uint7"` or `"bytes1337"` or
     /// `"string[aaaaaa]"`.
-    #[inline(always)]
-    pub fn invalid_size(ty: impl ToString) -> Self {
-        Self::InvalidSize(ty.to_string())
+    pub fn invalid_size(ty: impl fmt::Display) -> Self {
+        Self::new_("invalid size for type: ", &ty)
+    }
+
+    #[inline(never)]
+    #[cold]
+    fn new_(s: &str, e: &dyn fmt::Display) -> Self {
+        Self(Repr(format!("{s}{e}")))
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+#[derive(Clone, PartialEq, Eq)]
+struct Repr(String);
 
-impl fmt::Display for Error {
+impl fmt::Display for Repr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::InvalidTypeString(s) => write!(f, "Invalid type string: {s}"),
-            Self::InvalidSize(ty) => write!(f, "Invalid size for type: {ty}"),
-        }
+        f.write_str(&self.0)
     }
 }

--- a/crates/sol-type-parser/src/ident.rs
+++ b/crates/sol-type-parser/src/ident.rs
@@ -1,3 +1,8 @@
+use winnow::{
+    error::{ErrMode, ErrorKind, ParserError},
+    PResult,
+};
+
 /// The regular expression for a Solidity identfier.
 ///
 /// <https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityLexer.Identifier>
@@ -32,4 +37,64 @@ pub fn is_valid_identifier<S: AsRef<str>>(s: S) -> bool {
     }
 
     is_valid_identifier(s.as_ref())
+}
+
+#[inline]
+pub(crate) fn parse_identifier<'a>(input: &mut &'a str) -> PResult<&'a str> {
+    let mut chars = input.chars();
+    if let Some(first) = chars.next() {
+        if is_id_start(first) {
+            // 1 for the first character, we know it's ASCII
+            let len = 1 + chars.take_while(|c| is_id_continue(*c)).count();
+            // SAFETY: Only ASCII characters are valid in identifiers
+            unsafe {
+                let ident = input.get_unchecked(..len);
+                *input = input.get_unchecked(len..);
+                return Ok(ident)
+            }
+        }
+    }
+    Err(ErrMode::from_error_kind(input, ErrorKind::Fail))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_identifier() {
+        ident_test("foo", Ok("foo"), "");
+        ident_test("foo ", Ok("foo"), " ");
+        ident_test("$foo", Ok("$foo"), "");
+        ident_test("foo$", Ok("foo$"), "");
+        ident_test("foo2$", Ok("foo2$"), "");
+        ident_test("foo 2$", Ok("foo"), " 2$");
+        ident_test("_foo 2$", Ok("_foo"), " 2$");
+
+        ident_test("èfoo", Err(()), "èfoo");
+        ident_test("fèoo", Ok("f"), "èoo");
+        ident_test("foèo", Ok("fo"), "èo");
+        ident_test("fooè", Ok("foo"), "è");
+
+        ident_test("3foo", Err(()), "3foo");
+        ident_test("f3oo", Ok("f3oo"), "");
+        ident_test("fo3o", Ok("fo3o"), "");
+        ident_test("foo3", Ok("foo3"), "");
+    }
+
+    #[track_caller]
+    fn ident_test(mut input: &str, expected: Result<&str, ()>, output: &str) {
+        assert_eq!(
+            parse_identifier(&mut input).map_err(drop),
+            expected,
+            "result mismatch"
+        );
+        if let Ok(expected) = expected {
+            assert!(
+                is_valid_identifier(expected),
+                "expected is not a valid ident"
+            );
+        }
+        assert_eq!(input, output, "output mismatch");
+    }
 }

--- a/crates/sol-type-parser/src/root.rs
+++ b/crates/sol-type-parser/src/root.rs
@@ -1,5 +1,6 @@
-use crate::{is_valid_identifier, Error, Result};
+use crate::{ident::parse_identifier, is_valid_identifier, Error, Result};
 use core::fmt;
+use winnow::{trace::trace, PResult, Parser};
 
 /// A root type, with no array suffixes. Corresponds to a single, non-sequence
 /// type. This is the most basic type specifier.
@@ -58,12 +59,18 @@ impl fmt::Display for RootType<'_> {
 impl<'a> RootType<'a> {
     /// Parse a root type from a string.
     #[inline]
-    pub fn parse(value: &'a str) -> Result<Self> {
-        if is_valid_identifier(value) {
-            Ok(Self(value))
+    pub fn parse(input: &'a str) -> Result<Self> {
+        if is_valid_identifier(input) {
+            Ok(Self(input))
         } else {
-            Err(Error::invalid_type_string(value))
+            Err(Error::invalid_type_string(input))
         }
+    }
+
+    pub(crate) fn parser(input: &mut &'a str) -> PResult<Self> {
+        trace("RootType", parse_identifier)
+            .parse_next(input)
+            .map(Self)
     }
 
     /// The string underlying this type. The type name.

--- a/crates/sol-type-parser/src/type_spec.rs
+++ b/crates/sol-type-parser/src/type_spec.rs
@@ -1,6 +1,12 @@
-use crate::{Error, Result, TypeStem};
+use crate::{spanned, str_parser, Error, Result, TypeStem};
 use alloc::vec::Vec;
 use core::num::NonZeroUsize;
+use winnow::{
+    ascii::digit0,
+    combinator::{cut_err, delimited, opt, repeat},
+    trace::trace,
+    PResult, Parser,
+};
 
 /// Represents a type-name. Consists of an identifier and optional array sizes.
 ///
@@ -77,64 +83,34 @@ impl AsRef<str> for TypeSpecifier<'_> {
 
 impl<'a> TypeSpecifier<'a> {
     /// Parse a type specifier from a string.
-    pub fn parse(span: &'a str) -> Result<Self> {
-        let span = span.trim();
-        let err = || Error::invalid_type_string(span);
+    #[inline]
+    pub fn parse(input: &'a str) -> Result<Self> {
+        Self::parser.parse(input).map_err(Error::parser)
+    }
 
-        // i is the start of the array sizes
-        let (i, is_tuple) = if let Some(i) = span.rfind(')') {
-            // ')' is 1 byte
-            (i + 1, true)
-        } else {
-            (span.find('[').unwrap_or(span.len()), false)
-        };
-        // spit_at_unchecked(i)
-        let (l, r) = unsafe { (span.get_unchecked(..i), span.get_unchecked(i..)) };
-        // avoids double check in `TypeStem::parse`
-        let stem = if is_tuple {
-            l.try_into().map(TypeStem::Tuple)
-        } else {
-            l.try_into().map(TypeStem::Root)
-        }?;
-
-        let mut sizes = vec![];
-        let mut chars = r.char_indices();
-        while let Some((i, next)) = chars.next() {
-            match next {
-                '[' => {
-                    let mut j = 0;
-                    let mut closed = false;
-                    for (idx, c) in chars.by_ref() {
-                        match c {
-                            ']' => {
-                                closed = true;
-                                break
-                            }
-                            c if c.is_ascii_digit() => j = idx,
-                            c if c.is_whitespace() => continue,
-                            _ => return Err(err()),
-                        }
-                    }
-                    if !closed {
-                        return Err(err())
-                    }
-                    let size = if j == 0 {
-                        None
-                    } else {
-                        // i and j are the index of '[' and the last digit respectively,
-                        // '[' and ASCII digits are 1 byte
-                        let s = unsafe { r.get_unchecked(i + 1..j + 1) };
-                        // end is trimmed in the loop above
-                        Some(s.trim_start().parse().map_err(|_| err())?)
-                    };
-                    sizes.push(size);
-                }
-                c if c.is_whitespace() => continue,
-                _ => return Err(err()),
-            }
-        }
-
-        Ok(Self { span, stem, sizes })
+    pub(crate) fn parser(input: &mut &'a str) -> PResult<Self> {
+        trace(
+            "TypeSpecifier",
+            spanned(|input: &mut &'a str| {
+                let stem = TypeStem::parser(input)?;
+                let sizes = if input.starts_with('[') {
+                    repeat(
+                        1..,
+                        delimited(
+                            str_parser("["),
+                            opt(cut_err(digit0).parse_to()),
+                            cut_err(str_parser("]")),
+                        ),
+                    )
+                    .parse_next(input)?
+                } else {
+                    Vec::new()
+                };
+                Ok((stem, sizes))
+            }),
+        )
+        .parse_next(input)
+        .map(|(span, (stem, sizes))| Self { span, stem, sizes })
     }
 
     /// Returns the type stem as a string.
@@ -170,66 +146,66 @@ mod test {
     #[test]
     fn parse_test() {
         assert_eq!(
-            TypeSpecifier::parse("uint256").unwrap(),
-            TypeSpecifier {
+            TypeSpecifier::parse("uint256"),
+            Ok(TypeSpecifier {
                 span: "uint256",
                 stem: TypeStem::parse("uint256").unwrap(),
                 sizes: vec![],
-            }
+            })
         );
 
         assert_eq!(
-            TypeSpecifier::parse("uint256[2]").unwrap(),
-            TypeSpecifier {
+            TypeSpecifier::parse("uint256[2]"),
+            Ok(TypeSpecifier {
                 span: "uint256[2]",
                 stem: TypeStem::parse("uint256").unwrap(),
                 sizes: vec![NonZeroUsize::new(2)],
-            }
+            })
         );
 
         assert_eq!(
-            TypeSpecifier::parse("uint256[2][]").unwrap(),
-            TypeSpecifier {
+            TypeSpecifier::parse("uint256[2][]"),
+            Ok(TypeSpecifier {
                 span: "uint256[2][]",
                 stem: TypeStem::parse("uint256").unwrap(),
                 sizes: vec![NonZeroUsize::new(2), None],
-            }
+            })
         );
 
         assert_eq!(
-            TypeSpecifier::parse("(uint256,uint256)").unwrap(),
-            TypeSpecifier {
+            TypeSpecifier::parse("(uint256,uint256)"),
+            Ok(TypeSpecifier {
                 span: "(uint256,uint256)",
                 stem: TypeStem::Tuple(TupleSpecifier::parse("(uint256,uint256)").unwrap()),
                 sizes: vec![],
-            }
+            })
         );
 
         assert_eq!(
-            TypeSpecifier::parse("(uint256,uint256)[2]").unwrap(),
-            TypeSpecifier {
+            TypeSpecifier::parse("(uint256,uint256)[2]"),
+            Ok(TypeSpecifier {
                 span: "(uint256,uint256)[2]",
                 stem: TypeStem::Tuple(TupleSpecifier::parse("(uint256,uint256)").unwrap()),
                 sizes: vec![NonZeroUsize::new(2)],
-            }
+            })
         );
 
         assert_eq!(
-            TypeSpecifier::parse("MyStruct").unwrap(),
-            TypeSpecifier {
+            TypeSpecifier::parse("MyStruct"),
+            Ok(TypeSpecifier {
                 span: "MyStruct",
                 stem: TypeStem::parse("MyStruct").unwrap(),
                 sizes: vec![],
-            }
+            })
         );
 
         assert_eq!(
-            TypeSpecifier::parse("MyStruct[2]").unwrap(),
-            TypeSpecifier {
+            TypeSpecifier::parse("MyStruct[2]"),
+            Ok(TypeSpecifier {
                 span: "MyStruct[2]",
                 stem: TypeStem::parse("MyStruct").unwrap(),
                 sizes: vec![NonZeroUsize::new(2)],
-            }
+            })
         );
     }
 

--- a/crates/sol-type-parser/src/type_spec.rs
+++ b/crates/sol-type-parser/src/type_spec.rs
@@ -210,7 +210,43 @@ mod test {
     }
 
     #[test]
-    fn a_type_named_tuple() {
-        TypeSpecifier::parse("tuple").unwrap();
+    fn sizes() {
+        TypeSpecifier::parse("a[").unwrap_err();
+        TypeSpecifier::parse("a[][").unwrap_err();
+
+        assert_eq!(
+            TypeSpecifier::parse("a[]"),
+            Ok(TypeSpecifier {
+                span: "a[]",
+                stem: TypeStem::parse("a").unwrap(),
+                sizes: vec![None],
+            }),
+        );
+
+        assert_eq!(
+            TypeSpecifier::parse("a[1]"),
+            Ok(TypeSpecifier {
+                span: "a[1]",
+                stem: TypeStem::parse("a").unwrap(),
+                sizes: vec![NonZeroUsize::new(1)],
+            }),
+        );
+
+        TypeSpecifier::parse("a[0]").unwrap_err();
+
+        TypeSpecifier::parse("a[ ]").unwrap_err();
+        TypeSpecifier::parse("a[  ]").unwrap_err();
+        TypeSpecifier::parse("a[ 0]").unwrap_err();
+        TypeSpecifier::parse("a[0 ]").unwrap_err();
+
+        TypeSpecifier::parse("a[a]").unwrap_err();
+        TypeSpecifier::parse("a[ a]").unwrap_err();
+        TypeSpecifier::parse("a[a ]").unwrap_err();
+
+        TypeSpecifier::parse("a[ 1]").unwrap_err();
+        TypeSpecifier::parse("a[1 ]").unwrap_err();
+
+        TypeSpecifier::parse(&format!("a[{}]", usize::MAX)).unwrap();
+        TypeSpecifier::parse(&format!("a[{}0]", usize::MAX)).unwrap_err();
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Easier to expand in the future.

Performance is slightly better, but most of this is probably because of dropped white space support:

```clojure
parse/keywords          time:   [43.696 ns 43.795 ns 43.931 ns]                           
                        change: [-10.604% -10.130% -9.6426%] (p = 0.00 < 0.05)
                        Performance has improved.
parse/complex           time:   [1.3464 µs 1.3520 µs 1.3588 µs]                           
                        change: [-34.803% -34.511% -34.196%] (p = 0.00 < 0.05)
                        Performance has improved.
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
