### PR TITLE
feature: unsupported message for $idents

### DIFF
--- a/crates/syn-solidity/src/ident/mod.rs
+++ b/crates/syn-solidity/src/ident/mod.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use syn::{
     ext::IdentExt,
     parse::{Parse, ParseStream},
-    Result,
+    Result, Token,
 };
 
 mod path;
@@ -105,6 +105,7 @@ impl SolIdent {
 
     /// Parses any identifier including keywords.
     pub fn parse_any(input: ParseStream<'_>) -> Result<Self> {
+        check_dollar(input)?;
         input.call(Ident::parse_any).map(Self)
     }
 
@@ -119,5 +120,13 @@ impl SolIdent {
         } else {
             Ok(None)
         }
+    }
+}
+
+fn check_dollar(input: ParseStream<'_>) -> Result<()> {
+    if input.peek(Token![$]) {
+        Err(input.error("Solidity identifiers starting with `$` are unsupported. This is a known limitation of syn-solidity."))
+    } else {
+        Ok(())
     }
 }

--- a/crates/syn-solidity/tests/ident.rs
+++ b/crates/syn-solidity/tests/ident.rs
@@ -16,3 +16,13 @@ fn ident_path() {
 fn ident_path_trailing() {
     let _e = syn::parse_str::<SolPath>("a.b.").unwrap_err();
 }
+
+#[test]
+fn ident_dollar() {
+    let id: Result<SolIdent, _> = syn::parse_str("$hello");
+    assert!(id.is_err());
+    assert!(id
+        .unwrap_err()
+        .to_string()
+        .contains("Solidity identifiers starting with `$` are unsupported."));
+}


### PR DESCRIPTION
Adds a simple error message for $-prefixed solidity idents.

## Motivation

supplement #288

## Solution

Peek for $, return an error string

This solution does not catch idents with $ in non-leading positions. But should help most users

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
