### PR TITLE
chore: assert_eq! on Ok instead of unwrapping where possible

### DIFF
--- a/crates/dyn-abi/src/eip712/coerce.rs
+++ b/crates/dyn-abi/src/eip712/coerce.rs
@@ -284,8 +284,8 @@ mod tests {
         let top = j.as_object().unwrap().get("message").unwrap();
 
         assert_eq!(
-            ty.coerce(top).unwrap(),
-            DynSolValue::CustomStruct {
+            ty.coerce(top),
+            Ok(DynSolValue::CustomStruct {
                 name: "Message".to_owned(),
                 prop_names: vec!["contents".to_string(), "from".to_string(), "to".to_string()],
                 tuple: vec![
@@ -337,7 +337,7 @@ mod tests {
                     }]
                     .into()
                 ]
-            }
+            })
         );
     }
 }

--- a/crates/dyn-abi/src/eip712/parser.rs
+++ b/crates/dyn-abi/src/eip712/parser.rs
@@ -136,8 +136,8 @@ mod tests {
     #[test]
     fn test_component_type() {
         assert_eq!(
-            ComponentType::try_from("Transaction(Person from,Person to,Asset tx)").unwrap(),
-            ComponentType {
+            ComponentType::try_from("Transaction(Person from,Person to,Asset tx)"),
+            Ok(ComponentType {
                 span: "Transaction(Person from,Person to,Asset tx)",
                 type_name: "Transaction",
                 props: vec![
@@ -145,15 +145,15 @@ mod tests {
                     "Person to".try_into().unwrap(),
                     "Asset tx".try_into().unwrap(),
                 ],
-            }
+            })
         );
     }
 
     #[test]
     fn test_encode_type() {
         assert_eq!(
-            EncodeType::try_from(EXAMPLE).unwrap(),
-            EncodeType {
+            EncodeType::try_from(EXAMPLE),
+            Ok(EncodeType {
                 types: vec![
                     "Transaction(Person from,Person to,Asset tx)"
                         .try_into()
@@ -161,7 +161,7 @@ mod tests {
                     "Asset(address token,uint256 amount)".try_into().unwrap(),
                     "Person(address wallet,string name)".try_into().unwrap(),
                 ]
-            }
+            })
         );
     }
 }

--- a/crates/dyn-abi/src/eip712/resolver.rs
+++ b/crates/dyn-abi/src/eip712/resolver.rs
@@ -594,9 +594,9 @@ mod tests {
             prop_names: vec!["myB".to_string()],
             tuple: vec![b.clone()],
         };
-        assert_eq!(graph.resolve("A").unwrap(), a);
-        assert_eq!(graph.resolve("B").unwrap(), b);
-        assert_eq!(graph.resolve("C").unwrap(), c);
+        assert_eq!(graph.resolve("A"), Ok(a));
+        assert_eq!(graph.resolve("B"), Ok(b));
+        assert_eq!(graph.resolve("C"), Ok(c));
     }
 
     #[test]
@@ -630,9 +630,9 @@ mod tests {
             prop_names: vec!["myB".to_string()],
             tuple: vec![b.clone()],
         };
-        assert_eq!(graph.resolve("C").unwrap(), c);
-        assert_eq!(graph.resolve("B").unwrap(), b);
-        assert_eq!(graph.resolve("A").unwrap(), a);
+        assert_eq!(graph.resolve("C"), Ok(c));
+        assert_eq!(graph.resolve("B"), Ok(b));
+        assert_eq!(graph.resolve("A"), Ok(a));
     }
 
     #[test]

--- a/crates/dyn-abi/src/resolve.rs
+++ b/crates/dyn-abi/src/resolve.rs
@@ -210,48 +210,54 @@ mod tests {
     #[test]
     fn it_parses_tuples() {
         assert_eq!(
-            parse("(bool,)").unwrap(),
-            DynSolType::Tuple(vec![DynSolType::Bool])
+            parse("(bool,)"),
+            Ok(DynSolType::Tuple(vec![DynSolType::Bool]))
         );
         assert_eq!(
-            parse("(uint256,uint256)").unwrap(),
-            DynSolType::Tuple(vec![DynSolType::Uint(256), DynSolType::Uint(256)])
+            parse("(uint256,uint256)"),
+            Ok(DynSolType::Tuple(vec![
+                DynSolType::Uint(256),
+                DynSolType::Uint(256)
+            ]))
         );
         assert_eq!(
-            parse("(uint256,uint256)[2]").unwrap(),
-            DynSolType::FixedArray(
+            parse("(uint256,uint256)[2]"),
+            Ok(DynSolType::FixedArray(
                 Box::new(DynSolType::Tuple(vec![
                     DynSolType::Uint(256),
                     DynSolType::Uint(256)
                 ])),
                 2
-            )
+            ))
         );
     }
 
     #[test]
     fn nested_tuples() {
         assert_eq!(
-            parse("(bool,(uint256,uint256))").unwrap(),
-            DynSolType::Tuple(vec![
+            parse("(bool,(uint256,uint256))"),
+            Ok(DynSolType::Tuple(vec![
                 DynSolType::Bool,
                 DynSolType::Tuple(vec![DynSolType::Uint(256), DynSolType::Uint(256)])
-            ])
+            ]))
         );
         assert_eq!(
-            parse("(((bool),),)").unwrap(),
-            DynSolType::Tuple(vec![DynSolType::Tuple(vec![DynSolType::Tuple(vec![
-                DynSolType::Bool
-            ])])])
+            parse("(((bool),),)"),
+            Ok(DynSolType::Tuple(vec![DynSolType::Tuple(vec![
+                DynSolType::Tuple(vec![DynSolType::Bool])
+            ])]))
         );
     }
 
     #[test]
     fn empty_tuples() {
-        assert_eq!(parse("()").unwrap(), DynSolType::Tuple(vec![]));
+        assert_eq!(parse("()"), Ok(DynSolType::Tuple(vec![])));
         assert_eq!(
-            parse("((),())").unwrap(),
-            DynSolType::Tuple(vec![DynSolType::Tuple(vec![]), DynSolType::Tuple(vec![])])
+            parse("((),())"),
+            Ok(DynSolType::Tuple(vec![
+                DynSolType::Tuple(vec![]),
+                DynSolType::Tuple(vec![])
+            ]))
         );
         assert_eq!(
             parse("((()))"),
@@ -263,37 +269,37 @@ mod tests {
 
     #[test]
     fn it_parses_simple_types() {
-        assert_eq!(parse("uint256").unwrap(), DynSolType::Uint(256));
-        assert_eq!(parse("uint8").unwrap(), DynSolType::Uint(8));
-        assert_eq!(parse("uint").unwrap(), DynSolType::Uint(256));
-        assert_eq!(parse("address").unwrap(), DynSolType::Address);
-        assert_eq!(parse("bool").unwrap(), DynSolType::Bool);
-        assert_eq!(parse("string").unwrap(), DynSolType::String);
-        assert_eq!(parse("bytes").unwrap(), DynSolType::Bytes);
-        assert_eq!(parse("bytes32").unwrap(), DynSolType::FixedBytes(32));
+        assert_eq!(parse("uint256"), Ok(DynSolType::Uint(256)));
+        assert_eq!(parse("uint8"), Ok(DynSolType::Uint(8)));
+        assert_eq!(parse("uint"), Ok(DynSolType::Uint(256)));
+        assert_eq!(parse("address"), Ok(DynSolType::Address));
+        assert_eq!(parse("bool"), Ok(DynSolType::Bool));
+        assert_eq!(parse("string"), Ok(DynSolType::String));
+        assert_eq!(parse("bytes"), Ok(DynSolType::Bytes));
+        assert_eq!(parse("bytes32"), Ok(DynSolType::FixedBytes(32)));
     }
 
     #[test]
     fn it_parses_complex_solidity_types() {
         assert_eq!(
-            parse("uint256[]").unwrap(),
-            DynSolType::Array(Box::new(DynSolType::Uint(256)))
+            parse("uint256[]"),
+            Ok(DynSolType::Array(Box::new(DynSolType::Uint(256))))
         );
         assert_eq!(
-            parse("uint256[2]").unwrap(),
-            DynSolType::FixedArray(Box::new(DynSolType::Uint(256)), 2)
+            parse("uint256[2]"),
+            Ok(DynSolType::FixedArray(Box::new(DynSolType::Uint(256)), 2))
         );
         assert_eq!(
-            parse("uint256[2][3]").unwrap(),
-            DynSolType::FixedArray(
+            parse("uint256[2][3]"),
+            Ok(DynSolType::FixedArray(
                 Box::new(DynSolType::FixedArray(Box::new(DynSolType::Uint(256)), 2)),
                 3
-            )
+            ))
         );
         assert_eq!(
-            parse("uint256[][][]").unwrap(),
-            DynSolType::Array(Box::new(DynSolType::Array(Box::new(DynSolType::Array(
-                Box::new(DynSolType::Uint(256))
+            parse("uint256[][][]"),
+            Ok(DynSolType::Array(Box::new(DynSolType::Array(Box::new(
+                DynSolType::Array(Box::new(DynSolType::Uint(256)))
             )))))
         );
 


### PR DESCRIPTION
Minor thing for better error messages in case of failure

A lot of times this is not possible because error types do not implement Eq, or deref coersion can't happen when comparing results (e.g. `Result<String>` vs `Result<&str>`)