### PR TITLE
fix: add super import on generated modules

### DIFF
--- a/crates/primitives/src/utils.rs
+++ b/crates/primitives/src/utils.rs
@@ -1,8 +1,8 @@
 use crate::bits::FixedBytes;
 
-/// Simple interface to the [`keccak256`] hash function.
+/// Simple interface to the [`Keccak-256`] hash function.
 ///
-/// [`keccak256`]: https://en.wikipedia.org/wiki/SHA-3
+/// [`Keccak-256`]: https://en.wikipedia.org/wiki/SHA-3
 pub fn keccak256<T: AsRef<[u8]>>(bytes: T) -> FixedBytes<32> {
     cfg_if::cfg_if! {
         if #[cfg(all(feature = "native-keccak", not(feature = "tiny-keccak")))] {

--- a/crates/sol-macro/src/expand/contract.rs
+++ b/crates/sol-macro/src/expand/contract.rs
@@ -92,6 +92,8 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, contract: &ItemContract) -> Result<TokenS
         #(#mod_attrs)*
         #[allow(non_camel_case_types, non_snake_case, clippy::style)]
         pub mod #name {
+            use super::*;
+
             #bytecode
             #deployed_bytecode
 

--- a/crates/sol-types/tests/sol.rs
+++ b/crates/sol-types/tests/sol.rs
@@ -372,6 +372,41 @@ fn enum_variant_attrs() {
 }
 
 #[test]
+fn nested_items() {
+    // This has to be in a module (not a function) because of Rust import rules
+    mod nested {
+        alloy_sol_types::sol! {
+            #[derive(Debug, PartialEq)]
+            struct FilAddress {
+                bytes data;
+            }
+
+            #[derive(Debug, PartialEq)]
+            struct BigInt {
+                bytes val;
+                bool neg;
+            }
+
+            #[derive(Debug, PartialEq)]
+            interface InterfaceTest {
+                function f1(FilAddress memory fAddress, uint256 value) public payable;
+
+                function f2(BigInt memory b) public returns (BigInt memory);
+            }
+        }
+    }
+    use nested::{InterfaceTest::*, *};
+
+    let _ = FilAddress { data: vec![] };
+    let _ = BigInt {
+        val: vec![],
+        neg: false,
+    };
+    assert_eq!(f1Call::SIGNATURE, "f1((bytes),uint256)");
+    assert_eq!(f2Call::SIGNATURE, "f2((bytes,bool))");
+}
+
+#[test]
 #[cfg(feature = "json")]
 fn abigen_json_large_array() {
     sol!(LargeArray, "../json-abi/tests/abi/LargeArray.json");


### PR DESCRIPTION
Types are resolved, but they cannot be referenced in an inner module (contract) because of no `use super::*;`.