### PR TITLE
test: move `decode_revert_reason` to alloy and add tests

### DIFF
--- a/crates/sol-types/src/lib.rs
+++ b/crates/sol-types/src/lib.rs
@@ -183,7 +183,7 @@ mod types;
 pub use types::{
     data_type as sol_data, ContractError, Encodable, EventTopic, GenericContractError, Panic,
     PanicKind, Revert, Selectors, SolCall, SolEnum, SolError, SolEvent, SolInterface, SolStruct,
-    SolType, TopicList,
+    SolType, TopicList, decode_revert_reason,
 };
 
 pub mod utils;

--- a/crates/sol-types/src/lib.rs
+++ b/crates/sol-types/src/lib.rs
@@ -181,9 +181,9 @@ mod impl_core;
 
 mod types;
 pub use types::{
-    data_type as sol_data, ContractError, Encodable, EventTopic, GenericContractError, Panic,
-    PanicKind, Revert, Selectors, SolCall, SolEnum, SolError, SolEvent, SolInterface, SolStruct,
-    SolType, TopicList, decode_revert_reason,
+    data_type as sol_data, decode_revert_reason, ContractError, Encodable, EventTopic,
+    GenericContractError, Panic, PanicKind, Revert, Selectors, SolCall, SolEnum, SolError,
+    SolEvent, SolInterface, SolStruct, SolType, TopicList,
 };
 
 pub mod utils;

--- a/crates/sol-types/src/types/error.rs
+++ b/crates/sol-types/src/types/error.rs
@@ -409,8 +409,7 @@ impl PanicKind {
 }
 
 /// Returns the revert reason from the given output data, if it's an abi encoded
-/// String. Returns `None` if the output is not long enough to contain a
-/// function selector or the content is not a valid abi encoded String.
+/// String. Returns `None` if the content is not a valid abi encoded String.
 pub fn decode_revert_reason(out: &[u8]) -> Option<String> {
     // Try to decode as a generic contract error.
     if let Ok(error) = GenericContractError::decode(out, true) {

--- a/crates/sol-types/src/types/error.rs
+++ b/crates/sol-types/src/types/error.rs
@@ -2,7 +2,10 @@ use crate::{
     token::{PackedSeqToken, TokenSeq, WordToken},
     GenericContractError, Result, SolInterface, SolType, TokenType, Word,
 };
-use alloc::{string::{String, ToString}, vec::Vec};
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use alloy_primitives::U256;
 use core::{borrow::Borrow, fmt};
 

--- a/crates/sol-types/src/types/error.rs
+++ b/crates/sol-types/src/types/error.rs
@@ -408,8 +408,9 @@ impl PanicKind {
     }
 }
 
-/// Returns the revert reason from the given output data, if it's an abi encoded
-/// String. Returns `None` if the content is not a valid abi encoded String.
+/// Returns the revert reason from the given output data. Returns `None` if the
+/// content is not a valid abi encoded String or a regular utf8 string (for
+/// Vyper reverts).
 pub fn decode_revert_reason(out: &[u8]) -> Option<String> {
     // Try to decode as a generic contract error.
     if let Ok(error) = GenericContractError::decode(out, true) {

--- a/crates/sol-types/src/types/error.rs
+++ b/crates/sol-types/src/types/error.rs
@@ -1,9 +1,9 @@
 use crate::{
     token::{PackedSeqToken, TokenSeq, WordToken},
-    Result, SolType, TokenType, Word,
+    Result, SolType, TokenType, Word, GenericContractError, SolInterface,
 };
 use alloc::{string::String, vec::Vec};
-use alloy_primitives::U256;
+use alloy_primitives::{U256, Selector};
 use core::{borrow::Borrow, fmt};
 
 /// Solidity Error (a tuple with a selector)
@@ -408,6 +408,31 @@ impl PanicKind {
     }
 }
 
+/// Returns the revert reason from the given output data, if it's an abi encoded String. Returns
+/// `None` if the output is not long enough to contain a function selector or the content is not a
+/// valid abi encoded String.
+///
+/// **Note:** it's assumed the `out` buffer starts with the call's signature
+pub fn decode_revert_reason(out: &[u8]) -> Option<String> {
+    // Ensure the output data is long enough to contain a function selector.
+    if out.len() < Selector::len_bytes() {
+        return None
+    }
+
+    // Try to decode as a generic contract error.
+    if let Ok(error) = GenericContractError::decode(out, true) {
+        return Some(error.to_string())
+    }
+
+    // If that fails, try to decode as a regular string.
+    if let Ok(decoded_string) = std::str::from_utf8(out) {
+        return Some(decoded_string.to_string())
+    }
+
+    // If both attempts fail, return None.
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -447,5 +472,27 @@ mod tests {
             &keccak256(b"Panic(uint256)")[..4],
             "Panic selector is incorrect"
         );
+    }
+
+    #[test]
+    fn test_decode_solidity_revert_reason() {
+        let revert = Revert::from("test_revert_reason");
+        let encoded = revert.encode();
+        let decoded = decode_revert_reason(&encoded).unwrap();
+        assert_eq!(decoded, String::from("revert: test_revert_reason"));
+    }
+
+    #[test]
+    fn test_decode_random_revert_reason() {
+        let revert_reason = String::from("test_revert_reason");
+        let decoded = decode_revert_reason(revert_reason.as_bytes()).unwrap();
+        assert_eq!(decoded, String::from("test_revert_reason"));
+    }
+
+    #[test]
+    fn test_decode_too_short_revert_reason() {
+        let revert_reason = String::from("");
+        let decoded = decode_revert_reason(revert_reason.as_bytes());
+        assert_eq!(decoded, None);
     }
 }

--- a/crates/sol-types/src/types/error.rs
+++ b/crates/sol-types/src/types/error.rs
@@ -411,21 +411,14 @@ impl PanicKind {
 /// Returns the revert reason from the given output data, if it's an abi encoded
 /// String. Returns `None` if the output is not long enough to contain a
 /// function selector or the content is not a valid abi encoded String.
-///
-/// **Note:** it's assumed the `out` buffer starts with the call's signature
 pub fn decode_revert_reason(out: &[u8]) -> Option<String> {
-    // Ensure the output data is long enough to contain a function selector.
-    if out.len() < Selector::len_bytes() {
-        return None
-    }
-
     // Try to decode as a generic contract error.
     if let Ok(error) = GenericContractError::decode(out, true) {
         return Some(error.to_string())
     }
 
     // If that fails, try to decode as a regular string.
-    if let Ok(decoded_string) = std::str::from_utf8(out) {
+    if let Ok(decoded_string) = core::str::from_utf8(out) {
         return Some(decoded_string.to_string())
     }
 

--- a/crates/sol-types/src/types/error.rs
+++ b/crates/sol-types/src/types/error.rs
@@ -486,9 +486,9 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_too_short_revert_reason() {
-        let revert_reason = String::from("");
-        let decoded = decode_revert_reason(revert_reason.as_bytes());
+    fn test_decode_non_utf8_revert_reason() {
+        let revert_reason = [0xFF];
+        let decoded = decode_revert_reason(&revert_reason);
         assert_eq!(decoded, None);
     }
 }

--- a/crates/sol-types/src/types/error.rs
+++ b/crates/sol-types/src/types/error.rs
@@ -2,8 +2,8 @@ use crate::{
     token::{PackedSeqToken, TokenSeq, WordToken},
     GenericContractError, Result, SolInterface, SolType, TokenType, Word,
 };
-use alloc::{string::String, vec::Vec};
-use alloy_primitives::{Selector, U256};
+use alloc::{string::{String, ToString}, vec::Vec};
+use alloy_primitives::U256;
 use core::{borrow::Borrow, fmt};
 
 /// Solidity Error (a tuple with a selector)

--- a/crates/sol-types/src/types/error.rs
+++ b/crates/sol-types/src/types/error.rs
@@ -1,9 +1,9 @@
 use crate::{
     token::{PackedSeqToken, TokenSeq, WordToken},
-    Result, SolType, TokenType, Word, GenericContractError, SolInterface,
+    GenericContractError, Result, SolInterface, SolType, TokenType, Word,
 };
 use alloc::{string::String, vec::Vec};
-use alloy_primitives::{U256, Selector};
+use alloy_primitives::{Selector, U256};
 use core::{borrow::Borrow, fmt};
 
 /// Solidity Error (a tuple with a selector)
@@ -408,9 +408,9 @@ impl PanicKind {
     }
 }
 
-/// Returns the revert reason from the given output data, if it's an abi encoded String. Returns
-/// `None` if the output is not long enough to contain a function selector or the content is not a
-/// valid abi encoded String.
+/// Returns the revert reason from the given output data, if it's an abi encoded
+/// String. Returns `None` if the output is not long enough to contain a
+/// function selector or the content is not a valid abi encoded String.
 ///
 /// **Note:** it's assumed the `out` buffer starts with the call's signature
 pub fn decode_revert_reason(out: &[u8]) -> Option<String> {

--- a/crates/sol-types/src/types/mod.rs
+++ b/crates/sol-types/src/types/mod.rs
@@ -4,7 +4,7 @@ mod r#enum;
 pub use r#enum::SolEnum;
 
 mod error;
-pub use error::{Panic, PanicKind, Revert, SolError, decode_revert_reason};
+pub use error::{decode_revert_reason, Panic, PanicKind, Revert, SolError};
 
 mod event;
 pub use event::{EventTopic, SolEvent, TopicList};

--- a/crates/sol-types/src/types/mod.rs
+++ b/crates/sol-types/src/types/mod.rs
@@ -4,7 +4,7 @@ mod r#enum;
 pub use r#enum::SolEnum;
 
 mod error;
-pub use error::{Panic, PanicKind, Revert, SolError};
+pub use error::{Panic, PanicKind, Revert, SolError, decode_revert_reason};
 
 mod event;
 pub use event::{EventTopic, SolEvent, TopicList};


### PR DESCRIPTION
Related to paradigmxyz/reth#4789

I moved `decode_revert_reason` function here and also add tests:

1. first test is for properly decoding a solidity revert reason
2. second one is properly decoding a random revert reason (should fit for vyper revert reasons)
3. last one to test that too short reason fail since `out.len() < Selector::len_bytes()`

Actually the last test makes me wonder if it is ok to put that `if` sentence in the first line of the function as it could happen that a vyper revert reason is actually shorter than 4 bytes but still valid.

Let me know WDYT.

Also, before I can delete this function from Reth, this PR needs to be merged. Otherwise in Reth there are errors because `decode_revert_reason` does not have any definition.