### PR TITLE
feat: add human-readable ABI parser

### DIFF
--- a/crates/json-abi/src/item.rs
+++ b/crates/json-abi/src/item.rs
@@ -1,4 +1,9 @@
-use crate::{param::Param, utils::*, EventParam, InternalType, StateMutability};
+use crate::{
+    alloc::{borrow::ToOwned, string::ToString},
+    param::Param,
+    utils::*,
+    EventParam, InternalType, StateMutability,
+};
 use alloc::{borrow::Cow, string::String, vec::Vec};
 use alloy_primitives::{keccak256, Selector, B256};
 use alloy_sol_type_parser::{TypeSpecifier, TypeStem};

--- a/crates/json-abi/src/item.rs
+++ b/crates/json-abi/src/item.rs
@@ -397,10 +397,10 @@ impl Error {
 
 fn parse_params(params: &str) -> Result<Vec<Param>, String> {
     let mut result = vec![];
-    let mut iter = params.chars().peekable();
+    let iter = params.chars().peekable();
     let mut buffer = String::new();
     let mut nesting_level = 0;
-    while let Some(ch) = iter.next() {
+    for ch in iter {
         match ch {
             '(' => {
                 nesting_level += 1;
@@ -413,7 +413,7 @@ fn parse_params(params: &str) -> Result<Vec<Param>, String> {
             ',' => {
                 if nesting_level == 0 {
                     // This comma is not inside a tuple, so it separates parameters
-                    let param = parse_param(&buffer.trim())?;
+                    let param = parse_param(buffer.trim())?;
                     result.push(param);
                     buffer.clear();
                 } else {
@@ -429,7 +429,7 @@ fn parse_params(params: &str) -> Result<Vec<Param>, String> {
     }
 
     if !buffer.is_empty() {
-        let param = parse_param(&buffer.trim())?;
+        let param = parse_param(buffer.trim())?;
         result.push(param);
     }
     Ok(result)
@@ -443,7 +443,7 @@ fn parse_param(param_str: &str) -> Result<Param, String> {
     // `uint256 arg1, uint256 arg2`
     //              ^
     //              |----> this whitespace is not allowed!
-    let mut iter = param_str.split(" ");
+    let mut iter = param_str.split(' ');
     let ty_str = iter.next().ok_or("Incorrect format used")?;
     let name = iter.next().ok_or("Incorrect format used")?;
 


### PR DESCRIPTION
Closes #291 

This is a draft just to let you know how I'm trying to solve it @DaniPopes.

Right now I implemented a `parse` method only for `Error` but the code is easily re-usable.
Also now all my code is inside `item.rs` but I can move most of the real parser logic inside `alloy-sol-type-parser` as you suggest in the issue description (maybe in a new file inside of that?)

I also add some tests so that you can see how it works. Also these tests are in the `item.rs` file but I can move them somewhere else.

PS: of course the CI gives error because I used `println!` in the tests just to have a quick view of how the parsing work. Later I can delete them or change them with the use of `assert`