### PR TITLE
feat(syn-solidity): visitor hooks for statements and expressions

### DIFF
--- a/crates/syn-solidity/src/stmt/for.rs
+++ b/crates/syn-solidity/src/stmt/for.rs
@@ -16,7 +16,7 @@ use syn::{
 pub struct StmtFor {
     pub for_token: Token![for],
     pub paren_token: Paren,
-    pub init: Box<ForInitStmt>,
+    pub init: ForInitStmt,
     pub cond: Option<Box<Expr>>,
     pub semi_token: Token![;],
     pub post: Option<Box<Expr>>,

--- a/crates/syn-solidity/src/stmt/var_decl.rs
+++ b/crates/syn-solidity/src/stmt/var_decl.rs
@@ -15,7 +15,7 @@ use syn::{
 /// <https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityParser.variableDeclarationStatement>
 #[derive(Clone)]
 pub struct StmtVarDecl {
-    pub declaration: Box<VarDeclDecl>,
+    pub declaration: VarDeclDecl,
     pub assignment: Option<(Token![=], Expr)>,
     pub semi_token: Token![;],
 }
@@ -43,7 +43,7 @@ impl Parse for StmtVarDecl {
         let semi_token = input.parse()?;
 
         Ok(Self {
-            declaration: Box::new(declaration),
+            declaration,
             assignment,
             semi_token,
         })


### PR DESCRIPTION
Added missing hooks for all statements and expressions types

## Motivation

See #236 

## Solution

Implemented all the hooks inside the make_visitor macro

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes (removed some useless box)
