### PR TITLE
chore: don't pass debug feature to winnow

### DIFF
--- a/crates/sol-type-parser/Cargo.toml
+++ b/crates/sol-type-parser/Cargo.toml
@@ -23,4 +23,4 @@ winnow = { version = "0.5", default-features = false, features = ["alloc"] }
 [features]
 default = ["std"]
 std = ["winnow/std"]
-debug = ["std", "winnow/debug"] # WARNING: Bumps MSRV to at least 1.70
+debug = ["std"] # intentionally doesn't enable `winnow/debug`


### PR DESCRIPTION
For some reason prints don't get captured by libtest so running `test --all-features` floods your terminal