### PR TITLE
chore(dyn-abi): make `resolve` module private

### DIFF
--- a/crates/dyn-abi/src/lib.rs
+++ b/crates/dyn-abi/src/lib.rs
@@ -46,7 +46,7 @@ pub use value::DynSolValue;
 mod token;
 pub use token::DynToken;
 
-pub mod resolve;
+mod resolve;
 pub use resolve::ResolveSolType;
 
 #[cfg(feature = "eip712")]


### PR DESCRIPTION
Only has the one trait we export anyway