### PR TITLE
feat: add parsing support for JSON items

### DIFF
--- a/crates/dyn-abi/Cargo.toml
+++ b/crates/dyn-abi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "alloy-dyn-abi"
 description = "Run-time ABI and EIP-712 implementations"
-keywords = ["ethereum", "abi", "encoding", "EVM", "solidity"]
+keywords = ["ethereum", "abi", "encoding", "evm", "solidity"]
 categories = ["no-std", "encoding", "cryptography::cryptocurrencies"]
 homepage = "https://github.com/alloy-rs/core/tree/main/crates/dyn-abi"
 

--- a/crates/dyn-abi/src/eip712/resolver.rs
+++ b/crates/dyn-abi/src/eip712/resolver.rs
@@ -46,7 +46,7 @@ impl PropertyDef {
         N: Into<String>,
     {
         let type_name = type_name.into();
-        TypeSpecifier::try_from(type_name.as_str())?;
+        TypeSpecifier::parse(type_name.as_str())?;
         Ok(Self::new_unchecked(type_name, name))
     }
 
@@ -121,7 +121,7 @@ impl TypeDef {
     #[inline]
     pub fn new<S: Into<String>>(type_name: S, props: Vec<PropertyDef>) -> Result<Self> {
         let type_name = type_name.into();
-        RootType::try_from(type_name.as_str())?;
+        RootType::parse(type_name.as_str())?;
         Ok(Self { type_name, props })
     }
 

--- a/crates/dyn-abi/src/token.rs
+++ b/crates/dyn-abi/src/token.rs
@@ -161,7 +161,7 @@ impl<'a> DynToken<'a> {
                     return Ok(())
                 }
 
-                // This appears to be an unclarity in the solidity spec. The
+                // This appears to be an unclarity in the Solidity spec. The
                 // spec specifies that offsets are relative to the beginning of
                 // `enc(X)`. But known-good test vectors have it relative to the
                 // word AFTER the array size

--- a/crates/dyn-abi/src/ty.rs
+++ b/crates/dyn-abi/src/ty.rs
@@ -148,7 +148,7 @@ impl DynSolType {
     /// ```
     #[inline]
     pub fn parse(s: &str) -> Result<Self> {
-        TypeSpecifier::try_from(s)
+        TypeSpecifier::parse(s)
             .map_err(Error::TypeParser)
             .and_then(|t| t.resolve())
     }
@@ -439,7 +439,7 @@ impl DynSolType {
         }
     }
 
-    /// The Solidity type name. This returns the solidity type corresponding to
+    /// The Solidity type name. This returns the Solidity type corresponding to
     /// this value, if it is known. A type will not be known if the value
     /// contains an empty sequence, e.g. `T[0]`.
     pub fn sol_type_name(&self) -> Cow<'_, str> {

--- a/crates/dyn-abi/src/value.rs
+++ b/crates/dyn-abi/src/value.rs
@@ -168,7 +168,7 @@ impl From<U256> for DynSolValue {
 }
 
 impl DynSolValue {
-    /// The Solidity type. This returns the solidity type corresponding to this
+    /// The Solidity type. This returns the Solidity type corresponding to this
     /// value, if it is known. A type will not be known if the value contains
     /// an empty sequence, e.g. `T[0]`.
     pub fn as_type(&self) -> Option<DynSolType> {
@@ -297,7 +297,7 @@ impl DynSolValue {
         true
     }
 
-    /// The Solidity type name. This returns the solidity type corresponding to
+    /// The Solidity type name. This returns the Solidity type corresponding to
     /// this value, if it is known. A type will not be known if the value
     /// contains an empty sequence, e.g. `T[0]`.
     pub fn sol_type_name(&self) -> Option<Cow<'_, str>> {

--- a/crates/json-abi/Cargo.toml
+++ b/crates/json-abi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "alloy-json-abi"
 description = "Full Ethereum JSON-ABI implementation"
-keywords = ["ethereum", "abi", "serialization"]
+keywords = ["ethereum", "abi", "json", "serde", "serialization"]
 categories = ["encoding", "cryptography::cryptocurrencies"]
 homepage = "https://github.com/alloy-rs/core/tree/main/crates/json-abi"
 

--- a/crates/json-abi/src/abi.rs
+++ b/crates/json-abi/src/abi.rs
@@ -111,7 +111,7 @@ impl JsonAbi {
         serde_json::from_str(json)
     }
 
-    /// Loads contract from a JSON [Reader](std::io::Reader).
+    /// Loads contract from a JSON [Reader](std::io::Read).
     ///
     /// This is a convenience wrapper around [`serde_json::from_str`].
     #[cfg(all(feature = "std", feature = "serde_json"))]

--- a/crates/json-abi/src/abi.rs
+++ b/crates/json-abi/src/abi.rs
@@ -1,10 +1,7 @@
 use crate::{AbiItem, Constructor, Error, Event, Fallback, Function, Receive};
-use alloc::{
-    collections::{btree_map, btree_map::Values},
-    string::String,
-    vec::Vec,
-};
+use alloc::{collections::btree_map, string::String, vec::Vec};
 use alloy_primitives::Bytes;
+use alloy_sol_type_parser::{Error as ParserError, Result as ParserResult};
 use btree_map::BTreeMap;
 use core::{fmt, iter, iter::Flatten};
 use serde::{
@@ -12,6 +9,28 @@ use serde::{
     ser::SerializeSeq,
     Deserialize, Deserializer, Serialize,
 };
+
+macro_rules! set_if_none {
+    ($opt:expr, $val:expr) => { set_if_none!(stringify!($opt) => $opt, $val) };
+    (@serde $opt:expr, $val:expr) => { set_if_none!(serde::de::Error::duplicate_field(stringify!($opt)) => $opt, $val) };
+    ($name:expr => $opt:expr, $val:expr) => {{
+        if $opt.is_some() {
+            return Err($name)
+        }
+        $opt = Some($val);
+    }};
+}
+
+macro_rules! entry_and_push {
+    ($map:expr, $v:expr) => {
+        $map.entry($v.name.clone())
+            .or_default()
+            .push($v.into_owned())
+    };
+}
+
+type FlattenValues<'a, V> = Flatten<btree_map::Values<'a, String, Vec<V>>>;
+type FlattenIntoValues<V> = Flatten<btree_map::IntoValues<String, Vec<V>>>;
 
 /// The JSON contract ABI, as specified in the [Solidity ABI spec][ref].
 ///
@@ -32,6 +51,16 @@ pub struct JsonAbi {
     pub errors: BTreeMap<String, Vec<Error>>,
 }
 
+impl<'a> FromIterator<AbiItem<'a>> for JsonAbi {
+    fn from_iter<T: IntoIterator<Item = AbiItem<'a>>>(iter: T) -> Self {
+        let mut abi = Self::new();
+        for item in iter {
+            let _ = abi.insert_item(item);
+        }
+        abi
+    }
+}
+
 impl JsonAbi {
     /// Creates an empty ABI object.
     #[inline]
@@ -39,15 +68,52 @@ impl JsonAbi {
         Self::default()
     }
 
-    /// Parse the ABI json from a `str`. This is a convenience wrapper around
-    /// [`serde_json::from_str`].
+    /// Parse a [Human-Readable ABI] string into a JSON object.
+    ///
+    /// [Human-Readable ABI]: https://docs.ethers.org/v5/api/utils/abi/formats/#abi-formats--human-readable-abi
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use alloy_json_abi::JsonAbi;
+    /// assert_eq!(JsonAbi::parse([])?, JsonAbi::new());
+    ///
+    /// let abi = JsonAbi::parse([
+    ///     "constructor(string symbol, string name)",
+    ///     "function transferFrom(address from, address to, uint value)",
+    ///     "function balanceOf(address owner)(uint balance)",
+    ///     "event Transfer(address indexed from, address indexed to, address value)",
+    ///     "error InsufficientBalance(account owner, uint balance)",
+    ///     "function addPerson(tuple(string, uint16) person)",
+    ///     "function addPeople(tuple(string, uint16)[] person)",
+    ///     "function getPerson(uint id)(tuple(string, uint16))",
+    ///     "event PersonAdded(uint indexed id, tuple(string, uint16) person)",
+    /// ])?;
+    /// assert_eq!(abi.len(), 9);
+    /// # Ok::<(), alloy_sol_type_parser::Error>(())
+    /// ```
+    pub fn parse<'a, I: IntoIterator<Item = &'a str>>(strings: I) -> ParserResult<Self> {
+        let mut abi = Self::new();
+        for string in strings {
+            let item = AbiItem::parse(string)?;
+            abi.insert_item(item)
+                .map_err(|s| ParserError::_new("duplicate JSON ABI field: ", &s))?;
+        }
+        Ok(abi)
+    }
+
+    /// Parse a JSON string into an ABI object.
+    ///
+    /// This is a convenience wrapper around [`serde_json::from_str`].
     #[cfg(feature = "serde_json")]
     #[inline]
     pub fn from_json_str(json: &str) -> Result<Self, serde_json::Error> {
         serde_json::from_str(json)
     }
 
-    /// Loads contract from json
+    /// Loads contract from a JSON [Reader](std::io::Reader).
+    ///
+    /// This is a convenience wrapper around [`serde_json::from_str`].
     #[cfg(all(feature = "std", feature = "serde_json"))]
     pub fn load<T: std::io::Read>(mut reader: T) -> Result<Self, serde_json::Error> {
         // https://docs.rs/serde_json/latest/serde_json/fn.from_reader.html
@@ -155,7 +221,7 @@ impl JsonAbi {
         out.push('}');
     }
 
-    /// Creates constructor call builder.
+    /// Returns this contract's constructor.
     #[inline]
     pub const fn constructor(&self) -> Option<&Constructor> {
         self.constructor.as_ref()
@@ -181,20 +247,33 @@ impl JsonAbi {
 
     /// Iterates over all the functions of the contract in arbitrary order.
     #[inline]
-    pub fn functions(&self) -> Flatten<Values<'_, String, Vec<Function>>> {
+    pub fn functions(&self) -> FlattenValues<'_, Function> {
         self.functions.values().flatten()
     }
 
     /// Iterates over all the events of the contract in arbitrary order.
     #[inline]
-    pub fn events(&self) -> Flatten<Values<'_, String, Vec<Event>>> {
+    pub fn events(&self) -> FlattenValues<'_, Event> {
         self.events.values().flatten()
     }
 
     /// Iterates over all the errors of the contract in arbitrary order.
     #[inline]
-    pub fn errors(&self) -> Flatten<Values<'_, String, Vec<Error>>> {
+    pub fn errors(&self) -> FlattenValues<'_, Error> {
         self.errors.values().flatten()
+    }
+
+    /// Inserts an item into the ABI.
+    fn insert_item(&mut self, item: AbiItem<'_>) -> Result<(), &'static str> {
+        match item {
+            AbiItem::Constructor(c) => set_if_none!(self.constructor, c.into_owned()),
+            AbiItem::Fallback(f) => set_if_none!(self.fallback, f.into_owned()),
+            AbiItem::Receive(r) => set_if_none!(self.receive, r.into_owned()),
+            AbiItem::Function(f) => entry_and_push!(self.functions, f),
+            AbiItem::Event(e) => entry_and_push!(self.events, e),
+            AbiItem::Error(e) => entry_and_push!(self.errors, e),
+        };
+        Ok(())
     }
 }
 
@@ -267,8 +346,6 @@ macro_rules! iter_impl {
     };
 }
 
-type FlattenValues<'a, V> = Flatten<btree_map::Values<'a, String, Vec<V>>>;
-
 /// An iterator over all of the items in the ABI.
 ///
 /// This `struct` is created by [`JsonAbi::items`]. See its documentation for
@@ -291,8 +368,6 @@ impl<'a> Iterator for Items<'a> {
 }
 
 iter_impl!(traits Items<'_>);
-
-type FlattenIntoValues<V> = Flatten<btree_map::IntoValues<String, Vec<V>>>;
 
 /// An iterator over all of the items in the ABI.
 ///
@@ -334,24 +409,6 @@ impl Serialize for JsonAbi {
     }
 }
 
-macro_rules! set_if_none {
-    ($opt:expr, $val:expr) => { set_if_none!(stringify!($opt) => $opt, $val) };
-    ($name:expr => $opt:expr, $val:expr) => {{
-        if $opt.is_some() {
-            return Err(serde::de::Error::duplicate_field($name))
-        }
-        $opt = Some($val);
-    }};
-}
-
-macro_rules! entry_and_push {
-    ($map:expr, $v:expr) => {
-        $map.entry($v.name.clone())
-            .or_default()
-            .push($v.into_owned())
-    };
-}
-
 struct JsonAbiVisitor;
 
 impl<'de> Visitor<'de> for JsonAbiVisitor {
@@ -363,16 +420,10 @@ impl<'de> Visitor<'de> for JsonAbiVisitor {
     }
 
     fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
-        let mut abi = JsonAbi::default();
+        let mut abi = JsonAbi::new();
         while let Some(item) = seq.next_element()? {
-            match item {
-                AbiItem::Constructor(c) => set_if_none!(abi.constructor, c.into_owned()),
-                AbiItem::Fallback(f) => set_if_none!(abi.fallback, f.into_owned()),
-                AbiItem::Receive(r) => set_if_none!(abi.receive, r.into_owned()),
-                AbiItem::Function(f) => entry_and_push!(abi.functions, f),
-                AbiItem::Event(e) => entry_and_push!(abi.events, e),
-                AbiItem::Error(e) => entry_and_push!(abi.errors, e),
-            }
+            abi.insert_item(item)
+                .map_err(serde::de::Error::duplicate_field)?;
         }
         Ok(abi)
     }
@@ -444,21 +495,21 @@ impl<'de> Visitor<'de> for ContractAbiObjectVisitor {
 
         while let Some(key) = map.next_key::<&str>()? {
             match key {
-                "abi" => set_if_none!(abi, map.next_value()?),
+                "abi" => set_if_none!(@serde abi, map.next_value()?),
                 "evm" => {
                     let evm = map.next_value::<EvmObj>()?;
                     if let Some(bytes) = evm.bytecode {
-                        set_if_none!(bytecode, bytes.bytes());
+                        set_if_none!(@serde bytecode, bytes.bytes());
                     }
                     if let Some(bytes) = evm.deployed_bytecode {
-                        set_if_none!(deployed_bytecode, bytes.bytes());
+                        set_if_none!(@serde deployed_bytecode, bytes.bytes());
                     }
                 }
                 "byteCode" | "bytecode" | "bin" => {
-                    set_if_none!(bytecode, map.next_value::<Bytecode>()?.bytes());
+                    set_if_none!(@serde bytecode, map.next_value::<Bytecode>()?.bytes());
                 }
                 "deployedBytecode" | "deployedbytecode" | "runtimeBin" | "runtimebin" => {
-                    set_if_none!(deployed_bytecode, map.next_value::<Bytecode>()?.bytes());
+                    set_if_none!(@serde deployed_bytecode, map.next_value::<Bytecode>()?.bytes());
                 }
                 _ => {
                     map.next_value::<serde::de::IgnoredAny>()?;

--- a/crates/json-abi/src/internal_type.rs
+++ b/crates/json-abi/src/internal_type.rs
@@ -3,7 +3,7 @@ use alloy_sol_type_parser::TypeSpecifier;
 use core::fmt;
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
-/// The contract internal type. This could be a regular solidity type, a
+/// The contract internal type. This could be a regular Solidity type, a
 /// user-defined type, an enum, a struct, a contract, or an address payable.
 ///
 /// The internal type represents the Solidity definition of the type, stripped
@@ -163,14 +163,13 @@ impl InternalType {
     #[inline]
     pub fn struct_specifier(&self) -> Option<TypeSpecifier<'_>> {
         self.as_struct()
-            .and_then(|s| TypeSpecifier::try_from(s.1).ok())
+            .and_then(|s| TypeSpecifier::parse(s.1).ok())
     }
 
     /// Return a [`TypeSpecifier`] describing the enum if this type is an enum.
     #[inline]
     pub fn enum_specifier(&self) -> Option<TypeSpecifier<'_>> {
-        self.as_enum()
-            .and_then(|s| TypeSpecifier::try_from(s.1).ok())
+        self.as_enum().and_then(|s| TypeSpecifier::parse(s.1).ok())
     }
 
     /// Return a [`TypeSpecifier`] describing the contract if this type is a
@@ -178,17 +177,16 @@ impl InternalType {
     #[inline]
     pub fn contract_specifier(&self) -> Option<TypeSpecifier<'_>> {
         self.as_contract()
-            .and_then(|s| TypeSpecifier::try_from(s).ok())
+            .and_then(|s| TypeSpecifier::parse(s).ok())
     }
 
     /// Return a [`TypeSpecifier`] describing the other if this type is an
-    /// other. An "other" specifier indicates EITHER a regular solidity type OR
+    /// other. An "other" specifier indicates EITHER a regular Solidity type OR
     /// a user-defined type. It is not possible to distinguish between the two
     /// without additional context.
     #[inline]
     pub fn other_specifier(&self) -> Option<TypeSpecifier<'_>> {
-        self.as_other()
-            .and_then(|s| TypeSpecifier::try_from(s.1).ok())
+        self.as_other().and_then(|s| TypeSpecifier::parse(s.1).ok())
     }
 
     #[inline]

--- a/crates/json-abi/src/item.rs
+++ b/crates/json-abi/src/item.rs
@@ -368,7 +368,7 @@ impl FromStr for Constructor {
 }
 
 impl Constructor {
-    /// Parses a Solidity event signature string:
+    /// Parses a Solidity constructor string:
     /// `constructor($($inputs),*) $(anonymous)?`
     ///
     /// Note:

--- a/crates/json-abi/src/lib.rs
+++ b/crates/json-abi/src/lib.rs
@@ -59,7 +59,7 @@ pub enum StateMutability {
     View,
     /// Nonpayable functions promise not to receive Ether.
     NonPayable,
-    /// Payable functions make no promises
+    /// Payable functions make no promises.
     Payable,
 }
 

--- a/crates/json-abi/src/utils.rs
+++ b/crates/json-abi/src/utils.rs
@@ -1,6 +1,7 @@
 use crate::{EventParam, Param};
 use alloc::{string::String, vec::Vec};
 use alloy_primitives::Selector;
+use alloy_sol_type_parser::{ParameterSpecifier, TypeSpecifier, TypeStem};
 use core::{fmt::Write, num::NonZeroUsize};
 
 /// Capacity to allocate per [Param].
@@ -16,7 +17,6 @@ macro_rules! validate_identifier {
         }
     };
 }
-use alloy_sol_type_parser::{ParameterSpecifier, TypeSpecifier, TypeStem};
 pub(crate) use validate_identifier;
 
 /// `($($params),*)`
@@ -72,17 +72,15 @@ pub(crate) fn selector(preimage: &str) -> Selector {
     }
 }
 
+type Ret<T> = alloy_sol_type_parser::Result<(String, Vec<T>, Vec<T>, bool)>;
+
 #[inline]
-pub(crate) fn parse_sig<const O: bool>(
-    s: &str,
-) -> alloy_sol_type_parser::Result<(String, Vec<Param>, Vec<Param>, bool)> {
+pub(crate) fn parse_sig<const O: bool>(s: &str) -> Ret<Param> {
     alloy_sol_type_parser::__internal_parse_signature::<O, _, _>(s, |p| mk_param(p.name, p.ty))
 }
 
 #[inline]
-pub(crate) fn parse_event_sig(
-    s: &str,
-) -> alloy_sol_type_parser::Result<(String, Vec<EventParam>, Vec<EventParam>, bool)> {
+pub(crate) fn parse_event_sig(s: &str) -> Ret<EventParam> {
     alloy_sol_type_parser::__internal_parse_signature::<false, _, _>(s, mk_eparam)
 }
 

--- a/crates/json-abi/src/utils.rs
+++ b/crates/json-abi/src/utils.rs
@@ -1,6 +1,7 @@
 use crate::{EventParam, Param};
-use alloc::string::String;
+use alloc::{string::String, vec::Vec};
 use alloy_primitives::Selector;
+use core::{fmt::Write, num::NonZeroUsize};
 
 /// Capacity to allocate per [Param].
 const PARAM: usize = 32;
@@ -15,6 +16,7 @@ macro_rules! validate_identifier {
         }
     };
 }
+use alloy_sol_type_parser::{ParameterSpecifier, TypeSpecifier, TypeStem};
 pub(crate) use validate_identifier;
 
 /// `($($params),*)`
@@ -70,14 +72,75 @@ pub(crate) fn selector(preimage: &str) -> Selector {
     }
 }
 
+#[inline]
+pub(crate) fn parse_sig<const O: bool>(
+    s: &str,
+) -> alloy_sol_type_parser::Result<(String, Vec<Param>, Vec<Param>, bool)> {
+    alloy_sol_type_parser::__internal_parse_signature::<O, _, _>(s, |p| mk_param(p.name, p.ty))
+}
+
+#[inline]
+pub(crate) fn parse_event_sig(
+    s: &str,
+) -> alloy_sol_type_parser::Result<(String, Vec<EventParam>, Vec<EventParam>, bool)> {
+    alloy_sol_type_parser::__internal_parse_signature::<false, _, _>(s, mk_eparam)
+}
+
+pub(crate) fn mk_param(name: Option<&str>, ty: TypeSpecifier<'_>) -> Param {
+    let name = name.unwrap_or_default().into();
+    let internal_type = None;
+    match ty.stem {
+        TypeStem::Root(s) => Param {
+            name,
+            ty: ty_string(s.span(), &ty.sizes),
+            components: vec![],
+            internal_type,
+        },
+        TypeStem::Tuple(t) => Param {
+            name,
+            ty: ty_string("tuple", &ty.sizes),
+            components: t.types.into_iter().map(|ty| mk_param(None, ty)).collect(),
+            internal_type,
+        },
+    }
+}
+
+pub(crate) fn mk_eparam(spec: ParameterSpecifier<'_>) -> EventParam {
+    let p = mk_param(spec.name, spec.ty);
+    EventParam {
+        name: p.name,
+        ty: p.ty,
+        indexed: spec.indexed,
+        components: p.components,
+        internal_type: p.internal_type,
+    }
+}
+
+fn ty_string(s: &str, sizes: &[Option<NonZeroUsize>]) -> String {
+    let mut ty = String::with_capacity(s.len() + sizes.len() * 4);
+    ty.push_str(s);
+    for size in sizes {
+        ty.push('[');
+        if let Some(size) = size {
+            write!(ty, "{size}").unwrap();
+        }
+        ty.push(']');
+    }
+    ty
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn param(kind: &str) -> Param {
-        crate::Param {
-            name: "param".into(),
+        param2(kind, "param")
+    }
+
+    fn param2(kind: &str, name: &str) -> Param {
+        Param {
             ty: kind.into(),
+            name: name.into(),
             internal_type: None,
             components: vec![],
         }
@@ -143,5 +206,102 @@ mod tests {
             event_signature("foo", &[eparam("bool"), eparam("string")]),
             "foo(bool,string)"
         );
+    }
+
+    #[test]
+    fn test_item_parse() {
+        assert_eq!(
+            parse_sig::<true>("foo()"),
+            Ok(("foo".into(), vec![], vec![], false))
+        );
+        assert_eq!(
+            parse_sig::<true>("foo()()"),
+            Ok(("foo".into(), vec![], vec![], false))
+        );
+        assert_eq!(
+            parse_sig::<true>("foo(,) \t ()"),
+            Ok(("foo".into(), vec![], vec![], false))
+        );
+        assert_eq!(
+            parse_sig::<true>("foo(,)  (,)"),
+            Ok(("foo".into(), vec![], vec![], false))
+        );
+
+        assert_eq!(
+            parse_sig::<false>("foo()"),
+            Ok(("foo".into(), vec![], vec![], false))
+        );
+        parse_sig::<false>("foo()()").unwrap_err();
+        parse_sig::<false>("foo(,)()").unwrap_err();
+        parse_sig::<false>("foo(,)(,)").unwrap_err();
+
+        assert_eq!(
+            parse_sig::<false>("foo()anonymous"),
+            Ok(("foo".into(), vec![], vec![], true))
+        );
+        assert_eq!(
+            parse_sig::<false>("foo()\t anonymous"),
+            Ok(("foo".into(), vec![], vec![], true))
+        );
+
+        assert_eq!(
+            parse_sig::<true>("foo()anonymous"),
+            Ok(("foo".into(), vec![], vec![], true))
+        );
+        assert_eq!(
+            parse_sig::<true>("foo()\t anonymous"),
+            Ok(("foo".into(), vec![], vec![], true))
+        );
+
+        assert_eq!(
+            parse_sig::<true>("foo() \t ()anonymous"),
+            Ok(("foo".into(), vec![], vec![], true))
+        );
+        assert_eq!(
+            parse_sig::<true>("foo()()anonymous"),
+            Ok(("foo".into(), vec![], vec![], true))
+        );
+        assert_eq!(
+            parse_sig::<true>("foo()()\t anonymous"),
+            Ok(("foo".into(), vec![], vec![], true))
+        );
+
+        assert_eq!(
+            parse_sig::<false>("foo(uint256 param)"),
+            Ok(("foo".into(), vec![param("uint256")], vec![], false))
+        );
+        assert_eq!(
+            parse_sig::<false>("bar(uint256 param)"),
+            Ok(("bar".into(), vec![param("uint256")], vec![], false))
+        );
+        assert_eq!(
+            parse_sig::<false>("baz(uint256 param, bool param)"),
+            Ok((
+                "baz".into(),
+                vec![param("uint256"), param("bool")],
+                vec![],
+                false
+            ))
+        );
+
+        assert_eq!(
+            parse_sig::<true>("f(a b)(c d)"),
+            Ok((
+                "f".into(),
+                vec![param2("a", "b")],
+                vec![param2("c", "d")],
+                false
+            ))
+        );
+
+        assert_eq!(
+            parse_sig::<true>("toString(uint number)(string s)"),
+            Ok((
+                "toString".into(),
+                vec![param2("uint", "number")],
+                vec![param2("string", "s")],
+                false
+            ))
+        )
     }
 }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "alloy-primitives"
 description = "Ethereum primitive types"
-keywords = ["ethereum", "ethers", "revm", "reth"]
+keywords = ["ethers", "primitives", "ethereum", "revm", "reth"]
 categories = ["no-std", "data-structures", "cryptography::cryptocurrencies"]
 homepage = "https://github.com/alloy-rs/core/tree/main/crates/primitives"
 

--- a/crates/sol-type-parser/Cargo.toml
+++ b/crates/sol-type-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "alloy-sol-type-parser"
-description = "Solidity type specifier string parser"
-keywords = ["ethereum", "abi", "EVM", "solidity"]
+description = "Simple and light-weight Solidity type strings parser"
+keywords = ["ethereum", "abi", "evm", "solidity", "parser"]
 categories = ["no-std", "cryptography::cryptocurrencies"]
 homepage = "https://github.com/alloy-rs/core/tree/main/crates/sol-type-parser"
 

--- a/crates/sol-type-parser/README.md
+++ b/crates/sol-type-parser/README.md
@@ -1,17 +1,15 @@
 # alloy-sol-type-parser
 
-Solidity type string parsing.
+Simple and light-weight Solidity type strings parser.
 
-We do not recommend most users use this crate directly. This library provides a
-simple parser for working with Solidity type encoded as strings. It is
-primarily a dependency for the user-facing APIs in [`alloy-json-abi`] and
-[`alloy-dyn-abi`]. Please see the documentation for those crates for
-more information.
+This library is primarily a dependency for the user-facing APIs in
+[`alloy-json-abi`] and [`alloy-dyn-abi`]. Please see the documentation for
+those crates for more information.
 
-This parser generally follows the [solidity spec], however, it supports only a
+This parser generally follows the [Solidity spec], however, it supports only a
 subset of possible types, chosen to support ABI coding.
 
-[solidity spec]: https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityParser.typeName
+[Solidity spec]: https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityParser.typeName
 [`alloy-json-abi`]: https://docs.rs/alloy-json-abi/latest/alloy_json_abi/
 [`alloy-dyn-abi`]: https://docs.rs/alloy-dyn-abi/latest/alloy_dyn_abi/
 
@@ -28,7 +26,7 @@ use alloy_sol_type_parser::TypeSpecifier;
 use core::num::NonZeroUsize;
 
 // Parse a type specifier from a string
-let my_type = TypeSpecifier::try_from("uint8[2][]").unwrap();
+let my_type = TypeSpecifier::parse("uint8[2][]").unwrap();
 
 // Read the total span
 assert_eq!(
@@ -48,14 +46,14 @@ assert_eq!(
 );
 
 // Type specifiers also work for complex tuples!
-let my_tuple = TypeSpecifier::try_from("(uint8,(uint8[],bool))[39]").unwrap();
+let my_tuple = TypeSpecifier::parse("(uint8,(uint8[],bool))[39]").unwrap();
 assert_eq!(
     my_tuple.stem.span(),
     "(uint8,(uint8[],bool))"
 );
 
 // Types are NOT resolved, so you can parse custom structs just by name.
-let my_struct = TypeSpecifier::try_from("MyStruct").unwrap();
+let my_struct = TypeSpecifier::parse("MyStruct").unwrap();
 ```
 
 ### Why not support `parse()`?
@@ -63,25 +61,26 @@ let my_struct = TypeSpecifier::try_from("MyStruct").unwrap();
 The `core::str::FromStr` trait is not implemented for `TypeSpecifier` because
 of lifetime constraints. Unfortunately, it is impossible to implement this for
 a type with a lifetime dependent on the input str. Instead, we recommend using
-`TryFrom::try_from`.
+the `parse` associated functions, or `TryFrom::<&str>::try_from` if a trait is
+needed.
 
 ### Why not use `syn`?
 
 This is NOT a full syntax library, and is not intended to be used as a
-replacement for [`alloy-syn-solidity`]. This crate is intended to be used for
+replacement for [`syn-solidity`]. This crate is intended to be used for
 parsing type strings present in existing ecosystem tooling, and nothing else.
 It is not intended to be used for parsing Solidity source code.
 
 This crate is useful for:
 
-- syntax-checking abi json files
+- syntax-checking JSON ABI files
 - providing known-good input to [`alloy-dyn-abi`]
 - porting ethers.js code to rust
 
 It is NOT useful for:
 
 - parsing Solidity source code
-- generating rust code from Solidity source code
+- generating Rust code from Solidity source code
 - generating Solidity source code from rust code
 
-[`alloy-syn-solidity`]: https://docs.rs/alloy-syn-solidity/latest/alloy_syn_solidity/
+[`syn-solidity`]: https://docs.rs/syn-solidity/latest/syn_solidity/

--- a/crates/sol-type-parser/src/error.rs
+++ b/crates/sol-type-parser/src/error.rs
@@ -1,4 +1,4 @@
-use alloc::string::String;
+use alloc::boxed::Box;
 use core::fmt;
 
 /// Type string parsing result
@@ -57,12 +57,12 @@ impl Error {
     #[inline(never)]
     #[cold]
     fn new_(s: &str, e: &dyn fmt::Display) -> Self {
-        Self(Repr(format!("{s}{e}")))
+        Self(Repr(format!("{s}{e}").into_boxed_str()))
     }
 }
 
 #[derive(Clone, PartialEq, Eq)]
-struct Repr(String);
+struct Repr(Box<str>);
 
 impl fmt::Display for Repr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/sol-type-parser/src/error.rs
+++ b/crates/sol-type-parser/src/error.rs
@@ -26,12 +26,12 @@ impl fmt::Display for Error {
 impl Error {
     /// Instantiate a new error.
     pub fn new(s: impl fmt::Display) -> Self {
-        Self::new_("", &s)
+        Self::_new("", &s)
     }
 
     /// Instantiate a new parser error.
     pub(crate) fn parser(e: impl fmt::Display) -> Self {
-        Self::new_(
+        Self::_new(
             if cfg!(feature = "std") {
                 "parser error:\n"
             } else {
@@ -44,19 +44,21 @@ impl Error {
     /// Instantiate an invalid type string error. Invalid type string errors are
     /// for type strings that are not valid type strings. E.g. "uint256))))[".
     pub fn invalid_type_string(ty: impl fmt::Display) -> Self {
-        Self::new_("invalid type string: ", &ty)
+        Self::_new("invalid type string: ", &ty)
     }
 
     /// Instantiate an invalid size error. Invalid size errors are for valid
     /// primitive types with invalid sizes. E.g. `"uint7"` or `"bytes1337"` or
     /// `"string[aaaaaa]"`.
     pub fn invalid_size(ty: impl fmt::Display) -> Self {
-        Self::new_("invalid size for type: ", &ty)
+        Self::_new("invalid size for type: ", &ty)
     }
 
+    // Not public API.
+    #[doc(hidden)]
     #[inline(never)]
     #[cold]
-    fn new_(s: &str, e: &dyn fmt::Display) -> Self {
+    pub fn _new(s: &str, e: &dyn fmt::Display) -> Self {
         Self(Repr(format!("{s}{e}").into_boxed_str()))
     }
 }

--- a/crates/sol-type-parser/src/error.rs
+++ b/crates/sol-type-parser/src/error.rs
@@ -1,10 +1,10 @@
 use alloc::boxed::Box;
 use core::fmt;
 
-/// Type string parsing result
+/// Parser result
 pub type Result<T, E = Error> = core::result::Result<T, E>;
 
-/// A type string parsing error.
+/// Parser error.
 #[derive(Clone, PartialEq, Eq)]
 pub struct Error(Repr);
 

--- a/crates/sol-type-parser/src/lib.rs
+++ b/crates/sol-type-parser/src/lib.rs
@@ -24,7 +24,7 @@ use core::{slice, str};
 use ident::parse_identifier;
 use winnow::{
     ascii::space0,
-    combinator::{cut_err, delimited, opt, preceded, separated0},
+    combinator::{cut_err, delimited, opt, preceded, separated0, terminated},
     error::{AddContext, ParserError, StrContext, StrContextValue},
     stream::Accumulate,
     trace::trace,
@@ -117,6 +117,14 @@ pub(crate) fn opt_ws_ident<'a>(input: &mut &'a str) -> PResult<Option<&'a str>> 
 }
 
 // Not public API.
+#[doc(hidden)]
+#[inline]
+pub fn __internal_parse_item<'a>(s: &mut &'a str) -> Result<&'a str> {
+    trace("item", terminated(parse_identifier, space0))
+        .parse_next(s)
+        .map_err(Error::parser)
+}
+
 #[doc(hidden)]
 pub fn __internal_parse_signature<'a, const OUT: bool, F: Fn(ParameterSpecifier<'a>) -> T, T>(
     s: &'a str,

--- a/crates/sol-type-parser/src/lib.rs
+++ b/crates/sol-type-parser/src/lib.rs
@@ -138,7 +138,12 @@ pub fn __internal_parse_signature<'a, const OUT: bool, F: Fn(ParameterSpecifier<
             |i: &mut _| {
                 if OUT {
                     preceded(
-                        (space0, opt(str_parser(":")), space0),
+                        (
+                            space0,
+                            opt(str_parser(":")),
+                            opt(str_parser("returns")),
+                            space0,
+                        ),
                         opt(tuple_parser(ParameterSpecifier::parser.map(&f))),
                     )
                     .parse_next(i)

--- a/crates/sol-type-parser/src/lib.rs
+++ b/crates/sol-type-parser/src/lib.rs
@@ -19,11 +19,16 @@
 #[macro_use]
 extern crate alloc;
 
+use alloc::{string::String, vec::Vec};
 use core::{slice, str};
+use ident::parse_identifier;
 use winnow::{
+    ascii::space0,
+    combinator::{cut_err, delimited, opt, preceded, separated0},
     error::{AddContext, ParserError, StrContext, StrContextValue},
+    stream::Accumulate,
     trace::trace,
-    Parser,
+    PResult, Parser,
 };
 
 /// Errors.
@@ -50,6 +55,10 @@ pub use tuple::TupleSpecifier;
 mod type_spec;
 pub use type_spec::TypeSpecifier;
 
+/// Parameter specifier.
+mod parameter;
+pub use parameter::{ParameterSpecifier, Parameters};
+
 #[inline]
 pub(crate) fn spanned<'a, O, E>(
     mut f: impl Parser<&'a str, O, E>,
@@ -71,9 +80,10 @@ pub(crate) fn spanned<'a, O, E>(
 }
 
 #[inline]
-pub(crate) fn str_parser<'a, E: ParserError<&'a str> + AddContext<&'a str, StrContext>>(
-    s: &'static str,
-) -> impl Parser<&'a str, &'a str, E> {
+pub(crate) fn str_parser<'a, E>(s: &'static str) -> impl Parser<&'a str, &'a str, E>
+where
+    E: ParserError<&'a str> + AddContext<&'a str, StrContext>,
+{
     #[cfg(feature = "debug")]
     let name = format!("str={s:?}");
     #[cfg(not(feature = "debug"))]
@@ -82,4 +92,56 @@ pub(crate) fn str_parser<'a, E: ParserError<&'a str> + AddContext<&'a str, StrCo
         name,
         s.context(StrContext::Expected(StrContextValue::StringLiteral(s))),
     )
+}
+
+/// `( $( ${f()} ),* $(,)? )`
+pub(crate) fn tuple_parser<'a, O1, O2, E>(
+    f: impl Parser<&'a str, O1, E>,
+) -> impl Parser<&'a str, O2, E>
+where
+    O2: Accumulate<O1>,
+    E: ParserError<&'a str> + AddContext<&'a str, StrContext>,
+{
+    trace(
+        "tuple",
+        delimited(
+            (str_parser("("), space0),
+            cut_err(separated0(f, (str_parser(","), space0))),
+            (opt(","), space0, cut_err(str_parser(")"))),
+        ),
+    )
+}
+
+pub(crate) fn opt_ws_ident<'a>(input: &mut &'a str) -> PResult<Option<&'a str>> {
+    preceded(space0, opt(parse_identifier)).parse_next(input)
+}
+
+// Not public API.
+#[doc(hidden)]
+pub fn __internal_parse_signature<'a, const OUT: bool, F: Fn(ParameterSpecifier<'a>) -> T, T>(
+    s: &'a str,
+    f: F,
+) -> Result<(String, Vec<T>, Vec<T>, bool)> {
+    trace(
+        "signature",
+        (
+            RootType::parser.map(|x| x.span().into()),
+            preceded(space0, tuple_parser(ParameterSpecifier::parser.map(&f))),
+            |i: &mut _| {
+                if OUT {
+                    preceded(
+                        (space0, opt(str_parser(":")), space0),
+                        opt(tuple_parser(ParameterSpecifier::parser.map(&f))),
+                    )
+                    .parse_next(i)
+                    .map(Option::unwrap_or_default)
+                } else {
+                    Ok(vec![])
+                }
+            },
+            preceded(space0, opt(str_parser("anonymous")).map(|x| x.is_some())),
+        ),
+    )
+    .parse(s)
+    .map_err(Error::parser)
 }

--- a/crates/sol-type-parser/src/lib.rs
+++ b/crates/sol-type-parser/src/lib.rs
@@ -138,12 +138,7 @@ pub fn __internal_parse_signature<'a, const OUT: bool, F: Fn(ParameterSpecifier<
             |i: &mut _| {
                 if OUT {
                     preceded(
-                        (
-                            space0,
-                            opt(str_parser(":")),
-                            opt(str_parser("returns")),
-                            space0,
-                        ),
+                        (space0, opt(":"), opt("returns"), space0),
                         opt(tuple_parser(ParameterSpecifier::parser.map(&f))),
                     )
                     .parse_next(i)
@@ -152,7 +147,7 @@ pub fn __internal_parse_signature<'a, const OUT: bool, F: Fn(ParameterSpecifier<
                     Ok(vec![])
                 }
             },
-            preceded(space0, opt(str_parser("anonymous")).map(|x| x.is_some())),
+            preceded(space0, opt("anonymous").map(|x| x.is_some())),
         ),
     )
     .parse(s)

--- a/crates/sol-type-parser/src/lib.rs
+++ b/crates/sol-type-parser/src/lib.rs
@@ -57,7 +57,7 @@ pub use type_spec::TypeSpecifier;
 
 /// Parameter specifier.
 mod parameter;
-pub use parameter::{ParameterSpecifier, Parameters};
+pub use parameter::{ParameterSpecifier, Parameters, Storage};
 
 #[inline]
 pub(crate) fn spanned<'a, O, E>(

--- a/crates/sol-type-parser/src/parameter.rs
+++ b/crates/sol-type-parser/src/parameter.rs
@@ -3,6 +3,8 @@ use alloc::vec::Vec;
 use core::fmt;
 use winnow::{trace::trace, PResult, Parser};
 
+// TODO: Parse visibility and state mutability
+
 /// Represents a function parameter.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ParameterSpecifier<'a> {
@@ -127,6 +129,7 @@ impl core::str::FromStr for Storage {
 }
 
 impl fmt::Display for Storage {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }

--- a/crates/sol-type-parser/src/parameter.rs
+++ b/crates/sol-type-parser/src/parameter.rs
@@ -1,0 +1,202 @@
+use crate::{opt_ws_ident, spanned, tuple_parser, Error, Result, TypeSpecifier};
+use alloc::vec::Vec;
+use winnow::{trace::trace, PResult, Parser};
+
+/// Represents a function parameter.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ParameterSpecifier<'a> {
+    /// The full span of the specifier.
+    pub span: &'a str,
+    /// The type of the parameter.
+    pub ty: TypeSpecifier<'a>,
+    /// Whether the parameter indexed.
+    pub indexed: bool,
+    /// The name of the parameter.
+    pub name: Option<&'a str>,
+}
+
+impl<'a> TryFrom<&'a str> for ParameterSpecifier<'a> {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(value: &'a str) -> Result<Self> {
+        Self::parse(value)
+    }
+}
+
+impl<'a> ParameterSpecifier<'a> {
+    /// Parse a parameter from a string.
+    #[inline]
+    pub fn parse(input: &'a str) -> Result<Self> {
+        Self::parser.parse(input).map_err(Error::parser)
+    }
+
+    pub(crate) fn parser(input: &mut &'a str) -> PResult<Self> {
+        trace(
+            "ParameterSpecifier",
+            spanned(|input: &mut &'a str| {
+                let ty = TypeSpecifier::parser(input)?;
+                let mut indexed = false;
+                let mut name = opt_ws_ident(input)?;
+                // TODO: ?
+                // if let Some("storage" | "memory" | "calldata") = name {
+                //     name = opt_ws_ident(input)?;
+                // }
+                if let Some("indexed") = name {
+                    indexed = true;
+                    name = opt_ws_ident(input)?;
+                }
+                Ok((ty, indexed, name))
+            }),
+        )
+        .parse_next(input)
+        .map(|(span, (ty, indexed, name))| Self {
+            span,
+            ty,
+            indexed,
+            name,
+        })
+    }
+}
+
+/// Represents a list of function parameters.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Parameters<'a> {
+    /// The full span of the specifier.
+    pub span: &'a str,
+    /// The parameters.
+    pub params: Vec<ParameterSpecifier<'a>>,
+}
+
+impl<'a> TryFrom<&'a str> for Parameters<'a> {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(value: &'a str) -> Result<Self> {
+        Self::parse(value)
+    }
+}
+
+impl<'a> Parameters<'a> {
+    /// Parse a parameter list from a string.
+    #[inline]
+    pub fn parse(input: &'a str) -> Result<Self> {
+        Self::parser.parse(input).map_err(Error::parser)
+    }
+
+    pub(crate) fn parser(input: &mut &'a str) -> PResult<Self> {
+        trace(
+            "Parameters",
+            spanned(tuple_parser(ParameterSpecifier::parser)),
+        )
+        .parse_next(input)
+        .map(|(span, params)| Self { span, params })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_param() {
+        assert_eq!(
+            ParameterSpecifier::parse("bool name"),
+            Ok(ParameterSpecifier {
+                span: "bool name",
+                ty: TypeSpecifier::parse("bool").unwrap(),
+                indexed: false,
+                name: Some("name"),
+            })
+        );
+
+        assert_eq!(
+            ParameterSpecifier::parse("bool indexed name"),
+            Ok(ParameterSpecifier {
+                span: "bool indexed name",
+                ty: TypeSpecifier::parse("bool").unwrap(),
+                indexed: true,
+                name: Some("name"),
+            })
+        );
+
+        assert_eq!(
+            ParameterSpecifier::parse("bool2    indexed \t name"),
+            Ok(ParameterSpecifier {
+                span: "bool2    indexed \t name",
+                ty: TypeSpecifier::parse("bool2").unwrap(),
+                indexed: true,
+                name: Some("name"),
+            })
+        );
+
+        ParameterSpecifier::parse("a b ").unwrap_err();
+        ParameterSpecifier::parse(" a b ").unwrap_err();
+        ParameterSpecifier::parse(" a b").unwrap_err();
+    }
+
+    #[test]
+    fn parse_params() {
+        assert_eq!(
+            Parameters::parse("()"),
+            Ok(Parameters {
+                span: "()",
+                params: vec![]
+            })
+        );
+        assert_eq!(
+            Parameters::parse("(,)"),
+            Ok(Parameters {
+                span: "(,)",
+                params: vec![]
+            })
+        );
+        assert_eq!(
+            Parameters::parse("(, )"),
+            Ok(Parameters {
+                span: "(, )",
+                params: vec![]
+            })
+        );
+        assert_eq!(
+            Parameters::parse("( , )"),
+            Ok(Parameters {
+                span: "( , )",
+                params: vec![]
+            })
+        );
+
+        assert_eq!(
+            Parameters::parse("(\tuint256   , \t)"),
+            Ok(Parameters {
+                span: "(\tuint256   , \t)",
+                params: vec![ParameterSpecifier {
+                    span: "uint256   ",
+                    ty: TypeSpecifier::parse("uint256").unwrap(),
+                    indexed: false,
+                    name: None,
+                }]
+            })
+        );
+        assert_eq!(
+            Parameters::parse("( \t uint256 \ta,\t bool b, \t)"),
+            Ok(Parameters {
+                span: "( \t uint256 \ta,\t bool b, \t)",
+                params: vec![
+                    ParameterSpecifier {
+                        span: "uint256 \ta",
+                        ty: TypeSpecifier::parse("uint256").unwrap(),
+                        indexed: false,
+                        name: Some("a"),
+                    },
+                    ParameterSpecifier {
+                        span: "bool b",
+                        ty: TypeSpecifier::parse("bool").unwrap(),
+                        indexed: false,
+                        name: Some("b"),
+                    }
+                ]
+            })
+        );
+    }
+}

--- a/crates/sol-type-parser/src/parameter.rs
+++ b/crates/sol-type-parser/src/parameter.rs
@@ -265,4 +265,59 @@ mod tests {
             })
         );
     }
+
+    #[test]
+    fn parse_storage() {
+        assert_eq!(
+            ParameterSpecifier::parse("foo storag"),
+            Ok(ParameterSpecifier {
+                span: "foo storag",
+                ty: TypeSpecifier::parse("foo").unwrap(),
+                storage: None,
+                indexed: false,
+                name: Some("storag")
+            })
+        );
+        assert_eq!(
+            ParameterSpecifier::parse("foo storage"),
+            Ok(ParameterSpecifier {
+                span: "foo storage",
+                ty: TypeSpecifier::parse("foo").unwrap(),
+                storage: Some(Storage::Storage),
+                indexed: false,
+                name: None
+            })
+        );
+        assert_eq!(
+            ParameterSpecifier::parse("foo storage bar"),
+            Ok(ParameterSpecifier {
+                span: "foo storage bar",
+                ty: TypeSpecifier::parse("foo").unwrap(),
+                storage: Some(Storage::Storage),
+                indexed: false,
+                name: "bar".into()
+            })
+        );
+        assert_eq!(
+            ParameterSpecifier::parse("foo memory bar"),
+            Ok(ParameterSpecifier {
+                span: "foo memory bar",
+                ty: TypeSpecifier::parse("foo").unwrap(),
+                storage: Some(Storage::Memory),
+                indexed: false,
+                name: "bar".into()
+            })
+        );
+        assert_eq!(
+            ParameterSpecifier::parse("foo calldata bar"),
+            Ok(ParameterSpecifier {
+                span: "foo calldata bar",
+                ty: TypeSpecifier::parse("foo").unwrap(),
+                storage: Some(Storage::Calldata),
+                indexed: false,
+                name: "bar".into()
+            })
+        );
+        ParameterSpecifier::parse("foo storag bar").unwrap_err();
+    }
 }

--- a/crates/sol-type-parser/src/root.rs
+++ b/crates/sol-type-parser/src/root.rs
@@ -9,17 +9,17 @@ use winnow::{trace::trace, PResult, Parser};
 ///
 /// ```
 /// # use alloy_sol_type_parser::RootType;
-/// let root_type = RootType::try_from("uint256")?;
+/// let root_type = RootType::parse("uint256")?;
 /// assert_eq!(root_type.span(), "uint256");
 ///
 /// // Allows unknown types
-/// assert_eq!(RootType::try_from("MyStruct")?.span(), "MyStruct");
+/// assert_eq!(RootType::parse("MyStruct")?.span(), "MyStruct");
 ///
 /// // No sequences
-/// assert!(RootType::try_from("uint256[2]").is_err());
+/// assert!(RootType::parse("uint256[2]").is_err());
 ///
 /// // No tuples
-/// assert!(RootType::try_from("(uint256,uint256)").is_err());
+/// assert!(RootType::parse("(uint256,uint256)").is_err());
 /// # Ok::<_, alloy_sol_type_parser::Error>(())
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/sol-type-parser/src/stem.rs
+++ b/crates/sol-type-parser/src/stem.rs
@@ -7,20 +7,17 @@ use winnow::{trace::trace, PResult, Parser};
 ///
 /// ```
 /// # use alloy_sol_type_parser::{TypeStem, RootType, TupleSpecifier};
-/// let stem = TypeStem::try_from("uint256")?;
+/// let stem = TypeStem::parse("uint256")?;
 /// assert_eq!(stem.span(), "uint256");
 /// assert!(matches!(stem, TypeStem::Root(_)));
-/// assert_eq!(
-///     stem.as_root(),
-///     Some(&RootType::try_from("uint256").unwrap())
-/// );
+/// assert_eq!(stem.as_root(), Some(&RootType::parse("uint256").unwrap()));
 ///
-/// let stem = TypeStem::try_from("(uint256,bool)")?;
+/// let stem = TypeStem::parse("(uint256,bool)")?;
 /// assert_eq!(stem.span(), "(uint256,bool)");
 /// assert!(matches!(stem, TypeStem::Tuple(_)));
 /// assert_eq!(
 ///     stem.as_tuple(),
-///     Some(&TupleSpecifier::try_from("(uint256,bool)").unwrap())
+///     Some(&TupleSpecifier::parse("(uint256,bool)").unwrap())
 /// );
 /// # Ok::<_, alloy_sol_type_parser::Error>(())
 /// ```

--- a/crates/sol-type-parser/src/type_spec.rs
+++ b/crates/sol-type-parser/src/type_spec.rs
@@ -249,4 +249,54 @@ mod test {
         TypeSpecifier::parse(&format!("a[{}]", usize::MAX)).unwrap();
         TypeSpecifier::parse(&format!("a[{}0]", usize::MAX)).unwrap_err();
     }
+
+    #[test]
+    fn try_basic_solidity() {
+        assert_eq!(
+            TypeSpecifier::parse("uint256")
+                .unwrap()
+                .try_basic_solidity(),
+            Ok(())
+        );
+        assert_eq!(
+            TypeSpecifier::parse("uint256[]")
+                .unwrap()
+                .try_basic_solidity(),
+            Ok(())
+        );
+        assert_eq!(
+            TypeSpecifier::parse("(uint256,uint256)")
+                .unwrap()
+                .try_basic_solidity(),
+            Ok(())
+        );
+        assert_eq!(
+            TypeSpecifier::parse("(uint256,uint256)[2]")
+                .unwrap()
+                .try_basic_solidity(),
+            Ok(())
+        );
+        assert_eq!(
+            TypeSpecifier::parse("tuple(uint256,uint256)")
+                .unwrap()
+                .try_basic_solidity(),
+            Ok(())
+        );
+        assert_eq!(
+            TypeSpecifier::parse("tuple(address,bytes,(bool,(string,uint256)[][3]))[2]")
+                .unwrap()
+                .try_basic_solidity(),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn not_basic_solidity() {
+        assert_eq!(
+            TypeSpecifier::parse("MyStruct")
+                .unwrap()
+                .try_basic_solidity(),
+            Err(Error::invalid_type_string("MyStruct"))
+        );
+    }
 }

--- a/crates/sol-types/src/abi/token.rs
+++ b/crates/sol-types/src/abi/token.rs
@@ -332,7 +332,7 @@ impl<'de, T: TokenType<'de>> TokenType<'de> for DynSeqToken<T> {
     fn decode_from(dec: &mut Decoder<'de>) -> Result<Self> {
         let mut child = dec.take_indirection()?;
         let len = child.take_u32()? as usize;
-        // This appears to be an unclarity in the solidity spec. The spec
+        // This appears to be an unclarity in the Solidity spec. The spec
         // specifies that offsets are relative to the first word of
         // `enc(X)`. But known-good test vectors ha vrelative to the
         // word AFTER the array size


### PR DESCRIPTION
Add `FromStr` and `parse` associated functions to `json-abi` items and params.

Supersedes #310
Closes #291
