### PR TITLE
chore(sol-types): rewrite encodable impl generics

### DIFF
--- a/crates/sol-types/src/types/data_type.rs
+++ b/crates/sol-types/src/types/data_type.rs
@@ -291,25 +291,25 @@ impl SolType for Bytes {
 /// Array - `T[]`
 pub struct Array<T: SolType>(PhantomData<T>);
 
-impl<T, U> Encodable<Array<T>> for [U]
+impl<T, U> Encodable<Array<U>> for [T]
 where
-    T: SolType,
-    U: Encodable<T>,
+    T: Encodable<U>,
+    U: SolType,
 {
     #[inline]
-    fn to_tokens(&self) -> DynSeqToken<T::TokenType<'_>> {
+    fn to_tokens(&self) -> DynSeqToken<U::TokenType<'_>> {
         DynSeqToken(self.iter().map(|r| r.to_tokens()).collect())
     }
 }
 
-impl<T, U> Encodable<Array<T>> for Vec<U>
+impl<T, U> Encodable<Array<U>> for Vec<T>
 where
-    T: SolType,
-    U: Encodable<T>,
+    T: Encodable<U>,
+    U: SolType,
 {
     #[inline]
-    fn to_tokens(&self) -> DynSeqToken<T::TokenType<'_>> {
-        <[U] as Encodable<Array<T>>>::to_tokens(self)
+    fn to_tokens(&self) -> DynSeqToken<U::TokenType<'_>> {
+        <[T] as Encodable<Array<U>>>::to_tokens(self)
     }
 }
 
@@ -463,15 +463,15 @@ where
 /// FixedArray - `T[M]`
 pub struct FixedArray<T, const N: usize>(PhantomData<T>);
 
-impl<T, U, const N: usize> Encodable<FixedArray<T, N>> for [U; N]
+impl<T, U, const N: usize> Encodable<FixedArray<U, N>> for [T; N]
 where
-    T: SolType,
-    U: Borrow<T::RustType>,
+    T: Encodable<U>,
+    U: SolType,
 {
     #[inline]
-    fn to_tokens(&self) -> <FixedArray<T, N> as SolType>::TokenType<'_> {
+    fn to_tokens(&self) -> <FixedArray<U, N> as SolType>::TokenType<'_> {
         FixedSeqToken::<_, N>(core::array::from_fn(|i| {
-            Encodable::<T>::to_tokens(self[i].borrow())
+            Encodable::<U>::to_tokens(&self[i])
         }))
     }
 }

--- a/crates/sol-types/src/types/event/topic.rs
+++ b/crates/sol-types/src/types/event/topic.rs
@@ -122,17 +122,17 @@ impl EventTopic for Bytes {
 
 // Complex types - preimage encoding and hash: iter each element
 macro_rules! array_impl {
-    ($T:ident) => {
+    ($ty:ident) => {
         #[inline]
         fn topic_preimage_length(rust: &Self::RustType) -> usize {
-            rust.iter().map($T::topic_preimage_length).sum()
+            rust.iter().map($ty::topic_preimage_length).sum()
         }
 
         #[inline]
         fn encode_topic_preimage(rust: &Self::RustType, out: &mut Vec<u8>) {
             out.reserve(Self::topic_preimage_length(rust));
             for t in rust {
-                $T::encode_topic_preimage(t, out);
+                $ty::encode_topic_preimage(t, out);
             }
         }
 
@@ -154,21 +154,21 @@ impl<T: EventTopic, const N: usize> EventTopic for FixedArray<T, N> {
 }
 
 macro_rules! tuple_impls {
-    ($count:literal $($t:ident),+) => {
+    ($count:literal $($ty:ident),+) => {
         #[allow(non_snake_case)]
-        impl<$($t: EventTopic,)+> EventTopic for ($($t,)+) {
+        impl<$($ty: EventTopic,)+> EventTopic for ($($ty,)+) {
             #[inline]
             fn topic_preimage_length(rust: &Self::RustType) -> usize {
-                let ($($t,)+) = rust;
-                0usize $( + <$t>::topic_preimage_length($t) )+
+                let ($($ty,)+) = rust;
+                0usize $( + <$ty>::topic_preimage_length($ty) )+
             }
 
             #[inline]
             fn encode_topic_preimage(rust: &Self::RustType, out: &mut Vec<u8>) {
-                let b @ ($($t,)+) = rust;
+                let b @ ($($ty,)+) = rust;
                 out.reserve(Self::topic_preimage_length(b));
                 $(
-                    <$t>::encode_topic_preimage($t, out);
+                    <$ty>::encode_topic_preimage($ty, out);
                 )+
             }
 


### PR DESCRIPTION
Encode `T`s into `U`s, not the opposite