### PR TITLE
fix(sol-macro): pass attributes to all generated items

### DIFF
--- a/crates/sol-macro/src/attr.rs
+++ b/crates/sol-macro/src/attr.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use heck::{ToKebabCase, ToLowerCamelCase, ToShoutySnakeCase, ToSnakeCase, ToUpperCamelCase};
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -10,12 +12,20 @@ pub fn mk_doc(s: impl quote::ToTokens) -> TokenStream {
     quote!(#[doc = #s])
 }
 
+pub fn is_doc(attr: &Attribute) -> bool {
+    attr.path().is_ident("doc")
+}
+
+pub fn is_derive(attr: &Attribute) -> bool {
+    attr.path().is_ident("derive")
+}
+
 pub fn docs(attrs: &[Attribute]) -> impl Iterator<Item = &Attribute> {
-    attrs.iter().filter(|attr| attr.path().is_ident("doc"))
+    attrs.iter().filter(|a| is_doc(a))
 }
 
 pub fn derives(attrs: &[Attribute]) -> impl Iterator<Item = &Attribute> {
-    attrs.iter().filter(|attr| attr.path().is_ident("derive"))
+    attrs.iter().filter(|a| is_derive(a))
 }
 
 pub fn derives_mapped(attrs: &[Attribute]) -> impl Iterator<Item = Path> + '_ {

--- a/crates/syn-solidity/src/item/mod.rs
+++ b/crates/syn-solidity/src/item/mod.rs
@@ -205,7 +205,7 @@ impl Item {
         }
     }
 
-    fn replace_attrs(&mut self, src: Vec<Attribute>) -> Vec<Attribute> {
+    pub fn attrs(&self) -> Option<&Vec<Attribute>> {
         match self {
             Self::Contract(ItemContract { attrs, .. })
             | Self::Function(ItemFunction { attrs, .. })
@@ -213,8 +213,31 @@ impl Item {
             | Self::Error(ItemError { attrs, .. })
             | Self::Event(ItemEvent { attrs, .. })
             | Self::Struct(ItemStruct { attrs, .. })
-            | Self::Udt(ItemUdt { attrs, .. }) => std::mem::replace(attrs, src),
-            _ => vec![],
+            | Self::Udt(ItemUdt { attrs, .. })
+            | Self::Variable(VariableDefinition { attrs, .. }) => Some(attrs),
+            Self::Import(_) | Self::Pragma(_) | Self::Using(_) => None,
+        }
+    }
+
+    pub fn attrs_mut(&mut self) -> Option<&mut Vec<Attribute>> {
+        match self {
+            Self::Contract(ItemContract { attrs, .. })
+            | Self::Function(ItemFunction { attrs, .. })
+            | Self::Enum(ItemEnum { attrs, .. })
+            | Self::Error(ItemError { attrs, .. })
+            | Self::Event(ItemEvent { attrs, .. })
+            | Self::Struct(ItemStruct { attrs, .. })
+            | Self::Udt(ItemUdt { attrs, .. })
+            | Self::Variable(VariableDefinition { attrs, .. }) => Some(attrs),
+            Self::Import(_) | Self::Pragma(_) | Self::Using(_) => None,
+        }
+    }
+
+    fn replace_attrs(&mut self, src: Vec<Attribute>) -> Vec<Attribute> {
+        if let Some(attrs) = self.attrs_mut() {
+            std::mem::replace(attrs, src)
+        } else {
+            Vec::new()
         }
     }
 }

--- a/crates/syn-solidity/src/variable/mod.rs
+++ b/crates/syn-solidity/src/variable/mod.rs
@@ -110,6 +110,7 @@ impl VariableDeclaration {
 
 #[derive(Clone)]
 pub struct VariableDefinition {
+    pub attrs: Vec<Attribute>,
     pub ty: Type,
     pub attributes: VariableAttributes,
     pub name: SolIdent,
@@ -142,6 +143,7 @@ impl fmt::Debug for VariableDefinition {
 impl Parse for VariableDefinition {
     fn parse(input: ParseStream<'_>) -> Result<Self> {
         Ok(Self {
+            attrs: Attribute::parse_outer(input)?,
             ty: input.parse()?,
             attributes: input.parse()?,
             name: input.parse()?,


### PR DESCRIPTION
Previously we just appended the attributes once to the stream, but this ignored function return structs for example