### PR TITLE
fix: json-abi not using anonymous when converting to interface

### DIFF
--- a/crates/json-abi/src/to_sol.rs
+++ b/crates/json-abi/src/to_sol.rs
@@ -327,7 +327,7 @@ impl<IN: ToSol> ToSol for AbiFunction<'_, IN> {
         }
 
         if self.anonymous {
-            out.push_str("anonymous");
+            out.push_str(" anonymous");
         }
 
         out.push(';');

--- a/crates/json-abi/src/to_sol.rs
+++ b/crates/json-abi/src/to_sol.rs
@@ -209,6 +209,7 @@ impl ToSol for Event {
             inputs: &self.inputs,
             visibility: None,
             state_mutability: None,
+            anonymous: self.anonymous,
             outputs: &[],
         }
         .to_sol(out);
@@ -223,6 +224,7 @@ impl ToSol for Error {
             inputs: &self.inputs,
             visibility: None,
             state_mutability: None,
+            anonymous: false,
             outputs: &[],
         }
         .to_sol(out);
@@ -237,6 +239,7 @@ impl ToSol for Fallback {
             inputs: &[],
             visibility: Some("external"),
             state_mutability: Some(self.state_mutability),
+            anonymous: false,
             outputs: &[],
         }
         .to_sol(out);
@@ -251,6 +254,7 @@ impl ToSol for Receive {
             inputs: &[],
             visibility: Some("external"),
             state_mutability: Some(self.state_mutability),
+            anonymous: false,
             outputs: &[],
         }
         .to_sol(out);
@@ -265,6 +269,7 @@ impl ToSol for Function {
             inputs: &self.inputs,
             visibility: Some("external"),
             state_mutability: Some(self.state_mutability),
+            anonymous: false,
             outputs: &self.outputs,
         }
         .to_sol(out);
@@ -277,6 +282,7 @@ struct AbiFunction<'a, IN> {
     inputs: &'a [IN],
     visibility: Option<&'static str>,
     state_mutability: Option<StateMutability>,
+    anonymous: bool,
     outputs: &'a [Param],
 }
 
@@ -318,6 +324,10 @@ impl<IN: ToSol> ToSol for AbiFunction<'_, IN> {
                 output.to_sol(out);
             }
             out.push(')');
+        }
+
+        if self.anonymous {
+            out.push_str("anonymous");
         }
 
         out.push(';');


### PR DESCRIPTION
Hey so was seeing what would happen if I ran all of the abis ever verified on etherscan through alloy's `sol` macro and this was one of the errors I ran into.
This error occurs due to the fact that when we go to convert parsed json-abi into a interface for syn-solidity to then parse as a normalization step, the anonymous keyword on events was not getting included into the interface and was causing an error.
Heres an example:
https://etherscan.io/address/0x29c1aaa2e5bd43692f516d9a0c3d2a0f37b59053#code
![image](https://github.com/alloy-rs/core/assets/44074786/87698ccf-0a91-4bd6-82f8-e95f6c49d66d)
