### PR TITLE
chore: use winnow `separated` instead of `separated0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ rand = { version = "0.8", default-features = false }
 ruint = { version = "1.11.0", default-features = false, features = ["alloc"] }
 ruint-macro = { version = "1", default-features = false }
 tiny-keccak = "2.0"
-winnow = { version = "0.5", default-features = false, features = ["alloc"] }
+winnow = { version = "0.5.19", default-features = false, features = ["alloc"] }

--- a/crates/sol-type-parser/src/utils.rs
+++ b/crates/sol-type-parser/src/utils.rs
@@ -5,7 +5,7 @@ use alloc::{string::String, vec::Vec};
 use core::{slice, str};
 use winnow::{
     ascii::space0,
-    combinator::{cut_err, delimited, opt, preceded, separated0, terminated},
+    combinator::{cut_err, delimited, opt, preceded, separated, terminated},
     error::{AddContext, ParserError, StrContext, StrContextValue},
     stream::Accumulate,
     trace::trace,
@@ -99,7 +99,7 @@ where
         name,
         delimited(
             (char_parser(open), space0),
-            cut_err(separated0(f, (char_parser(delim), space0))),
+            cut_err(separated(0.., f, (char_parser(delim), space0))),
             (opt(delim), space0, cut_err(char_parser(close))),
         ),
     )

--- a/crates/sol-types/src/abi/encoder.rs
+++ b/crates/sol-types/src/abi/encoder.rs
@@ -208,7 +208,7 @@ pub fn encode_sequence<'a, T: TokenSeq<'a>>(token: &T) -> Vec<u8> {
 ///
 /// Same as [`core::array::from_ref`].
 #[inline(always)]
-fn tuple_from_ref<T>(s: &T) -> &(T,) {
+const fn tuple_from_ref<T>(s: &T) -> &(T,) {
     // SAFETY: Converting `&T` to `&(T,)` is sound.
     unsafe { &*(s as *const T).cast::<(T,)>() }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`separated0` and `separated1` are now deprecated.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
