### PR TITLE
feat: encode and decode for fixed bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ syn-solidity = { version = "0.4.2", path = "crates/syn-solidity", default-featur
 serde = { version = "1.0", default-features = false, features = ["alloc"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 
+# ssz
+ethereum_ssz = { version = "0.5.3" }
+
 # macros
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -35,6 +35,10 @@ alloy-rlp = { workspace = true, optional = true }
 # serde
 serde = { workspace = true, optional = true, features = ["derive"] }
 
+# ssz
+ethereum_ssz = { workspace = true, optional = true}
+
+
 # getrandom
 getrandom = { workspace = true, optional = true }
 
@@ -60,7 +64,7 @@ std = [
     "alloy-rlp?/std",
     "proptest?/std",
     "rand?/std",
-    "serde?/std",
+    "serde?/std"
 ]
 tiny-keccak = []
 native-keccak = []
@@ -68,6 +72,7 @@ getrandom = ["dep:getrandom"]
 rand = ["dep:rand", "getrandom", "ruint/rand"]
 rlp = ["dep:alloy-rlp", "ruint/alloy-rlp"]
 serde = ["dep:serde", "bytes/serde", "hex/serde", "ruint/serde"]
+ssz = ["dep:serde", "dep:ethereum_ssz"]
 arbitrary = [
     "std",
     "ruint/arbitrary",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -64,7 +64,7 @@ std = [
     "alloy-rlp?/std",
     "proptest?/std",
     "rand?/std",
-    "serde?/std"
+    "serde?/std",
 ]
 tiny-keccak = []
 native-keccak = []
@@ -72,7 +72,7 @@ getrandom = ["dep:getrandom"]
 rand = ["dep:rand", "getrandom", "ruint/rand"]
 rlp = ["dep:alloy-rlp", "ruint/alloy-rlp"]
 serde = ["dep:serde", "bytes/serde", "hex/serde", "ruint/serde"]
-ssz = ["dep:serde", "dep:ethereum_ssz"]
+ssz = ["dep:ethereum_ssz"]
 arbitrary = [
     "std",
     "ruint/arbitrary",

--- a/crates/primitives/src/bits/mod.rs
+++ b/crates/primitives/src/bits/mod.rs
@@ -18,3 +18,6 @@ mod rlp;
 
 #[cfg(feature = "serde")]
 mod serde;
+
+#[cfg(feature = "ssz")]
+mod ssz;

--- a/crates/primitives/src/bits/ssz.rs
+++ b/crates/primitives/src/bits/ssz.rs
@@ -1,0 +1,51 @@
+use crate::FixedBytes;
+use ssz::{Decode, DecodeError, Encode};
+
+impl<const N: usize> Encode for FixedBytes<N> {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn ssz_bytes_len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn ssz_append(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&self.0);
+    }
+    fn as_ssz_bytes(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+}
+
+impl<const N: usize> Decode for FixedBytes<N> {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+        if bytes.len() != N {
+            return Err(DecodeError::InvalidByteLength { len: bytes.len(), expected: N });
+        }
+
+        // Try to convert the slice into an array of size N
+        let fixed_array: [u8; N] = bytes
+            .try_into()
+            .map_err(|_| DecodeError::InvalidByteLength { len: bytes.len(), expected: N })?;
+
+        // Assuming FixedBytes<N> implements From<[u8; N]>
+        Ok(FixedBytes::<N>::from(fixed_array))
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_decode() {
+        const EXPECTED: FixedBytes<4> = fixed_bytes!("01234567");
+        let encoded = EXPECTED.as_ssz_bytes();
+        let actual = FixedBytes::<4>::from_ssz_bytes(&encoded).unwrap();
+        assert_eq!(EXPECTED, actual);
+    }
+}

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -22,7 +22,6 @@ extern crate alloc;
 // Used in Serde tests.
 #[cfg(test)]
 use {bincode as _, serde as _, serde_json as _};
-
 pub mod aliases;
 #[doc(no_inline)]
 pub use aliases::{
@@ -105,6 +104,9 @@ pub mod private {
 
     #[cfg(feature = "rlp")]
     pub use alloy_rlp;
+
+    #[cfg(feature = "ssz")]
+    pub use ssz;
 
     #[cfg(feature = "serde")]
     pub use serde;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
I found my self needing to wrap alloy primitives types and implement SSZ on it. I thought it could be useful to have those trait implementations downstream.


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Implementing SSZ as a conditional flag for alloy primitives.

- [x] Fixed bytes
- [ ] Bytes
- [ ] Address
- [ ] U64
- [ ] U256
- [ ] Bloom

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
