### PR TITLE
feat: enable ruint ssz when primitives ssz

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ pretty_assertions = "1.4"
 proptest = "1"
 proptest-derive = "0.4"
 rand = { version = "0.8", default-features = false }
-ruint = { version = "1.11.0", default-features = false, features = ["alloc"] }
+ruint = { version = "1.11.1", default-features = false, features = ["alloc"] }
 ruint-macro = { version = "1", default-features = false }
 tiny-keccak = "2.0"
 winnow = { version = "0.5.19", default-features = false, features = ["alloc"] }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -71,7 +71,7 @@ getrandom = ["dep:getrandom"]
 rand = ["dep:rand", "getrandom", "ruint/rand"]
 rlp = ["dep:alloy-rlp", "ruint/alloy-rlp"]
 serde = ["dep:serde", "bytes/serde", "hex/serde", "ruint/serde"]
-ssz = ["dep:ethereum_ssz", "std"]
+ssz = ["dep:ethereum_ssz", "std", "ruint/ssz"]
 arbitrary = [
     "std",
     "dep:arbitrary",


### PR DESCRIPTION
Enables ruint ssz feature when alloy-primitives SSZ feature is enabled

Blocked by release of ruint@1.11.1 https://github.com/recmo/uint/pull/345