### PR TITLE
feat(primitives): left and right padding conversions

### DIFF
--- a/crates/primitives/src/bits/fixed.rs
+++ b/crates/primitives/src/bits/fixed.rs
@@ -471,12 +471,12 @@ impl<const N: usize> FixedBytes<N> {
     ///
     /// # Panics
     ///
-    /// If `src.len() > N`
+    /// Panics if `src.len() > N`.
     #[track_caller]
     #[inline]
     pub fn left_padding_from(value: &[u8]) -> Self {
         let len = value.len();
-        assert!(len <= N, "slice is too large. Expected <={} bytes, got {}", N, len);
+        assert!(len <= N, "slice is too large. Expected <={N} bytes, got {len}");
         let mut bytes = Self::ZERO;
         bytes[N - len..].copy_from_slice(value);
         bytes
@@ -491,10 +491,12 @@ impl<const N: usize> FixedBytes<N> {
     ///
     /// # Panics
     ///
-    /// If `src.len() > N`
+    /// Panics if `src.len() > N`.
+    #[track_caller]
+    #[inline]
     pub fn right_padding_from(value: &[u8]) -> Self {
         let len = value.len();
-        assert!(len <= N, "slice is too large. Expected <={} bytes, got {}", N, len);
+        assert!(len <= N, "slice is too large. Expected <={N} bytes, got {len}");
         let mut bytes = Self::ZERO;
         bytes[..len].copy_from_slice(value);
         bytes

--- a/crates/primitives/src/bits/fixed.rs
+++ b/crates/primitives/src/bits/fixed.rs
@@ -462,6 +462,44 @@ impl<const N: usize> FixedBytes<N> {
         Self::try_from(value).unwrap()
     }
 
+    /// Create a new [`FixedBytes`] from the given slice `src`, left-padding it
+    /// with zeroes if necessary.
+    ///
+    /// # Note
+    ///
+    /// The given bytes are interpreted in big endian order.
+    ///
+    /// # Panics
+    ///
+    /// If `src.len() > N`
+    #[track_caller]
+    #[inline]
+    pub fn left_padding_from(value: &[u8]) -> Self {
+        let len = value.len();
+        assert!(len <= N, "slice is too large. Expected <={} bytes, got {}", N, len);
+        let mut bytes = Self::ZERO;
+        bytes[N - len..].copy_from_slice(value);
+        bytes
+    }
+
+    /// Create a new [`FixedBytes`] from the given slice `src`, right-padding it
+    /// with zeroes if necessary.
+    ///
+    /// # Note
+    ///
+    /// The given bytes are interpreted in big endian order.
+    ///
+    /// # Panics
+    ///
+    /// If `src.len() > N`
+    pub fn right_padding_from(value: &[u8]) -> Self {
+        let len = value.len();
+        assert!(len <= N, "slice is too large. Expected <={} bytes, got {}", N, len);
+        let mut bytes = Self::ZERO;
+        bytes[..len].copy_from_slice(value);
+        bytes
+    }
+
     /// Returns a slice containing the entire array. Equivalent to `&s[..]`.
     #[inline]
     pub const fn as_slice(&self) -> &[u8] {
@@ -607,5 +645,37 @@ mod tests {
             "{:X}", "0123456789abcdef" => "0123456789ABCDEF";
             "{:#X}", "0123456789abcdef" => "0x0123456789ABCDEF";
         }
+    }
+
+    #[test]
+    fn left_padding_from() {
+        assert_eq!(FixedBytes::<4>::left_padding_from(&[0x01, 0x23]), fixed_bytes!("00000123"));
+
+        assert_eq!(
+            FixedBytes::<4>::left_padding_from(&[0x01, 0x23, 0x45, 0x67]),
+            fixed_bytes!("01234567")
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "slice is too large. Expected <=4 bytes, got 5")]
+    fn left_padding_from_too_large() {
+        FixedBytes::<4>::left_padding_from(&[0x01, 0x23, 0x45, 0x67, 0x89]);
+    }
+
+    #[test]
+    fn right_padding_from() {
+        assert_eq!(FixedBytes::<4>::right_padding_from(&[0x01, 0x23]), fixed_bytes!("01230000"));
+
+        assert_eq!(
+            FixedBytes::<4>::right_padding_from(&[0x01, 0x23, 0x45, 0x67]),
+            fixed_bytes!("01234567")
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "slice is too large. Expected <=4 bytes, got 5")]
+    fn right_padding_from_too_large() {
+        FixedBytes::<4>::right_padding_from(&[0x01, 0x23, 0x45, 0x67, 0x89]);
     }
 }

--- a/crates/primitives/src/bits/macros.rs
+++ b/crates/primitives/src/bits/macros.rs
@@ -225,6 +225,38 @@ macro_rules! wrap_fixed_bytes {
                 Self($crate::FixedBytes::from_slice(src))
             }
 
+            /// Create a new [`FixedBytes`] from the given slice `src`, left-padding it
+            /// with zeroes if necessary.
+            ///
+            /// # Note
+            ///
+            /// The given bytes are interpreted in big endian order.
+            ///
+            /// # Panics
+            ///
+            /// Panics if `src.len() > N`.
+            #[track_caller]
+            #[inline]
+            pub fn left_padding_from(value: &[u8]) -> Self {
+                Self($crate::FixedBytes::left_padding_from(value))
+            }
+
+            /// Create a new [`FixedBytes`] from the given slice `src`, right-padding it
+            /// with zeroes if necessary.
+            ///
+            /// # Note
+            ///
+            /// The given bytes are interpreted in big endian order.
+            ///
+            /// # Panics
+            ///
+            /// Panics if `src.len() > N`.
+            #[track_caller]
+            #[inline]
+            pub fn right_padding_from(value: &[u8]) -> Self {
+                Self($crate::FixedBytes::right_padding_from(value))
+            }
+
             /// Returns the inner bytes array.
             #[inline]
             pub const fn into_array(self) -> [u8; $n] {

--- a/crates/primitives/src/bits/macros.rs
+++ b/crates/primitives/src/bits/macros.rs
@@ -211,7 +211,7 @@ macro_rules! wrap_fixed_bytes {
             $crate::impl_getrandom!();
             $crate::impl_rand!();
 
-            /// Create a new fixed-hash from the given slice `src`.
+            /// Create a new byte array from the given slice `src`.
             ///
             /// # Note
             ///
@@ -225,7 +225,7 @@ macro_rules! wrap_fixed_bytes {
                 Self($crate::FixedBytes::from_slice(src))
             }
 
-            /// Create a new [`FixedBytes`] from the given slice `src`, left-padding it
+            /// Create a new byte array from the given slice `src`, left-padding it
             /// with zeroes if necessary.
             ///
             /// # Note
@@ -241,7 +241,7 @@ macro_rules! wrap_fixed_bytes {
                 Self($crate::FixedBytes::left_padding_from(value))
             }
 
-            /// Create a new [`FixedBytes`] from the given slice `src`, right-padding it
+            /// Create a new byte array from the given slice `src`, right-padding it
             /// with zeroes if necessary.
             ///
             /// # Note


### PR DESCRIPTION
## Motivation

Current `try_from` and `from_slice` requires exact length. These convenience functions provide variants that support shorter slices by left- or right-padding to the correct length

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
