### PR TITLE
feat(sol-types): add empty `bytes` and `string` specialization

### DIFF
--- a/crates/sol-types/src/abi/mod.rs
+++ b/crates/sol-types/src/abi/mod.rs
@@ -44,3 +44,24 @@ pub use decoder::{decode, decode_params, decode_sequence, Decoder};
 
 pub mod token;
 pub use token::{Token, TokenSeq};
+
+/// The ABI encoding of an empty byte array (`bytes` or `string`).
+pub const EMPTY_BYTES: &[u8; 64] = &alloy_primitives::hex!(
+    "0000000000000000000000000000000000000000000000000000000000000020" // offset, points to the next word
+    "0000000000000000000000000000000000000000000000000000000000000000" // length, 0
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{SolType, SolValue};
+
+    #[test]
+    fn empty_bytes() {
+        assert_eq!(EMPTY_BYTES.len(), 64);
+        assert_eq!(EMPTY_BYTES[..], crate::sol_data::String::abi_encode("")[..]);
+        assert_eq!(EMPTY_BYTES[..], crate::sol_data::Bytes::abi_encode(b"")[..]);
+        assert_eq!(EMPTY_BYTES[..], "".abi_encode());
+        assert_eq!(EMPTY_BYTES[..], b"".abi_encode());
+    }
+}

--- a/crates/sol-types/src/types/value.rs
+++ b/crates/sol-types/src/types/value.rs
@@ -196,6 +196,8 @@ impl_sol_value! {
     [const N: usize] FixedBytes<N> => sol_data::FixedBytes<N> [where ByteCount<N>: SupportedFixedBytes];
     [const N: usize] [u8; N] => sol_data::FixedBytes<N> [where ByteCount<N>: SupportedFixedBytes];
 
+    // `bytes` and `string` are specialized below.
+
     // Generic
     [T: SolValue] Vec<T> => sol_data::Array<T::SolType> [];
     [T: SolValue] [T] => sol_data::Array<T::SolType> [];

--- a/crates/sol-types/src/types/value.rs
+++ b/crates/sol-types/src/types/value.rs
@@ -195,12 +195,6 @@ impl_sol_value! {
     [] Function => sol_data::Function [];
     [const N: usize] FixedBytes<N> => sol_data::FixedBytes<N> [where ByteCount<N>: SupportedFixedBytes];
     [const N: usize] [u8; N] => sol_data::FixedBytes<N> [where ByteCount<N>: SupportedFixedBytes];
-    [] String => sol_data::String [];
-    [] str => sol_data::String [];
-    [] Bytes => sol_data::Bytes [];
-
-    [] Vec<u8> => sol_data::Bytes [];
-    [] [u8] => sol_data::Bytes [];
 
     // Generic
     [T: SolValue] Vec<T> => sol_data::Array<T::SolType> [];
@@ -224,6 +218,60 @@ impl SolValue for () {
 }
 
 all_the_tuples!(tuple_impls);
+
+// Empty `bytes` and `string` specialization
+impl SolValue for str {
+    type SolType = sol_data::String;
+
+    #[inline]
+    fn abi_encode(&self) -> Vec<u8> {
+        if self.is_empty() {
+            crate::abi::EMPTY_BYTES.to_vec()
+        } else {
+            <Self::SolType as SolType>::abi_encode(self)
+        }
+    }
+}
+
+impl SolValue for [u8] {
+    type SolType = sol_data::Bytes;
+
+    #[inline]
+    fn abi_encode(&self) -> Vec<u8> {
+        if self.is_empty() {
+            crate::abi::EMPTY_BYTES.to_vec()
+        } else {
+            <Self::SolType as SolType>::abi_encode(self)
+        }
+    }
+}
+
+impl SolValue for String {
+    type SolType = sol_data::String;
+
+    #[inline]
+    fn abi_encode(&self) -> Vec<u8> {
+        self[..].abi_encode()
+    }
+}
+
+impl SolValue for Bytes {
+    type SolType = sol_data::Bytes;
+
+    #[inline]
+    fn abi_encode(&self) -> Vec<u8> {
+        self[..].abi_encode()
+    }
+}
+
+impl SolValue for Vec<u8> {
+    type SolType = sol_data::Bytes;
+
+    #[inline]
+    fn abi_encode(&self) -> Vec<u8> {
+        self[..].abi_encode()
+    }
+}
 
 #[cfg(test)]
 #[allow(clippy::type_complexity)]
@@ -395,5 +443,27 @@ mod tests {
         let _: Result<(u64, String, U256)> = <(u64, String, U256)>::abi_decode(b"", false);
         let _: Result<(i64, Vec<(u32, String, Vec<FixedBytes<4>>)>, U256)> =
             <(i64, Vec<(u32, String, Vec<FixedBytes<4>>)>, U256)>::abi_decode(b"", false);
+    }
+
+    #[test]
+    fn empty_spec() {
+        assert_eq!("".abi_encode(), crate::abi::EMPTY_BYTES);
+        assert_eq!(b"".abi_encode(), crate::abi::EMPTY_BYTES);
+        assert_eq!(
+            ("", "a").abi_encode(),
+            <(sol_data::String, sol_data::String)>::abi_encode(&("", "a"))
+        );
+        assert_eq!(
+            ("a", "").abi_encode(),
+            <(sol_data::String, sol_data::String)>::abi_encode(&("a", ""))
+        );
+        assert_eq!(
+            (&b""[..], &b"a"[..]).abi_encode(),
+            <(sol_data::Bytes, sol_data::Bytes)>::abi_encode(&(b"", b"a"))
+        );
+        assert_eq!(
+            (&b"a"[..], &b""[..]).abi_encode(),
+            <(sol_data::Bytes, sol_data::Bytes)>::abi_encode(&(b"a", b""))
+        );
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Avoids going through the entire encoding when doing `"".abi_encode()`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
