### PR TITLE
feat: add `RevertReason` enum

### DIFF
--- a/crates/sol-types/src/lib.rs
+++ b/crates/sol-types/src/lib.rs
@@ -183,8 +183,8 @@ mod impl_core;
 mod types;
 pub use types::{
     data_type as sol_data, decode_revert_reason, ContractError, EventTopic, GenericContractError,
-    Panic, PanicKind, Revert, Selectors, SolCall, SolEnum, SolError, SolEvent, SolEventInterface,
-    SolInterface, SolStruct, SolType, SolValue, TopicList,
+    GenericRevertReason, Panic, PanicKind, Revert, Selectors, SolCall, SolEnum, SolError, SolEvent,
+    SolEventInterface, SolInterface, SolStruct, SolType, SolValue, TopicList,
 };
 
 pub mod utils;

--- a/crates/sol-types/src/types/interface/mod.rs
+++ b/crates/sol-types/src/types/interface/mod.rs
@@ -370,7 +370,7 @@ impl<T> ContractError<T> {
 }
 
 /// Represents the reason for a revert in a generic contract error.
-pub(crate) type GenericRevertReason = RevertReason<Infallible>;
+pub type GenericRevertReason = RevertReason<Infallible>;
 
 /// Represents the reason for a revert in a smart contract.
 ///

--- a/crates/sol-types/src/types/interface/mod.rs
+++ b/crates/sol-types/src/types/interface/mod.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Panic, Result, Revert, SolError};
+use crate::{alloc::string::ToString, Error, Panic, Result, Revert, SolError};
 use alloc::{string::String, vec::Vec};
 use core::{convert::Infallible, fmt, iter::FusedIterator, marker::PhantomData};
 
@@ -433,7 +433,7 @@ where
     /// If both attempts fail, it returns `None`.
     pub fn decode(out: &[u8]) -> Option<Self> {
         // Try to decode as a generic contract error.
-        if let Ok(error) = GenericContractError::abi_decode(out, true) {
+        if let Ok(error) = ContractError::<T>::abi_decode(out, true) {
             return Some(error.into());
         }
 

--- a/crates/sol-types/src/types/interface/mod.rs
+++ b/crates/sol-types/src/types/interface/mod.rs
@@ -369,6 +369,47 @@ impl<T> ContractError<T> {
     }
 }
 
+/// Represents the reason for a revert in a generic contract error.
+pub(crate) type GenericRevertReason = RevertReason<Infallible>;
+
+/// Represents the reason for a revert in a smart contract.
+///
+/// This enum captures two possible scenarios for a revert:
+///
+/// - [`ContractError`](RevertReason::ContractError): Contains detailed error information, such as a
+///   specific [`Revert`] or [`Panic`] error.
+///
+/// - [`RawString`](RevertReason::RawString): Represents a raw string message as the reason for the
+///   revert.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RevertReason<T> {
+    /// A detailed contract error, including a specific revert or panic error.
+    ContractError(ContractError<T>),
+    /// Represents a raw string message as the reason for the revert.
+    RawString(String),
+}
+
+/// Converts a `ContractError<T>` into a `RevertReason<T>`.
+impl<T> From<ContractError<T>> for RevertReason<T> {
+    fn from(error: ContractError<T>) -> Self {
+        RevertReason::ContractError(error)
+    }
+}
+
+/// Converts a `Revert` into a `RevertReason<T>`.
+impl<T> From<Revert> for RevertReason<T> {
+    fn from(revert: Revert) -> Self {
+        RevertReason::ContractError(ContractError::Revert(revert))
+    }
+}
+
+/// Converts a `String` into a `RevertReason<T>`.
+impl<T> From<String> for RevertReason<T> {
+    fn from(raw_string: String) -> Self {
+        RevertReason::RawString(raw_string)
+    }
+}
+
 /// Iterator over the function or error selectors of a [`SolInterface`] type.
 ///
 /// This `struct` is created by the [`selectors`] method on [`SolInterface`].

--- a/crates/sol-types/src/types/interface/mod.rs
+++ b/crates/sol-types/src/types/interface/mod.rs
@@ -1,5 +1,5 @@
 use crate::{Error, Panic, Result, Revert, SolError};
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 use core::{convert::Infallible, fmt, iter::FusedIterator, marker::PhantomData};
 
 #[cfg(feature = "std")]

--- a/crates/sol-types/src/types/interface/mod.rs
+++ b/crates/sol-types/src/types/interface/mod.rs
@@ -389,6 +389,15 @@ pub enum RevertReason<T> {
     RawString(String),
 }
 
+impl<T: fmt::Display> fmt::Display for RevertReason<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RevertReason::ContractError(error) => error.fmt(f),
+            RevertReason::RawString(raw_string) => write!(f, "{}", raw_string),
+        }
+    }
+}
+
 /// Converts a `ContractError<T>` into a `RevertReason<T>`.
 impl<T> From<ContractError<T>> for RevertReason<T> {
     fn from(error: ContractError<T>) -> Self {

--- a/crates/sol-types/src/types/mod.rs
+++ b/crates/sol-types/src/types/mod.rs
@@ -14,7 +14,8 @@ pub use function::SolCall;
 
 mod interface;
 pub use interface::{
-    ContractError, GenericContractError, Selectors, SolEventInterface, SolInterface,
+    ContractError, GenericContractError, GenericRevertReason, Selectors, SolEventInterface,
+    SolInterface,
 };
 
 mod r#struct;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Adding the `RevertReason` enum addresses the need to encapsulate and distinguish reasons for reverts.

Should close #449.

## Solution

Introducing the `RevertReason` enum offers a structured way to represent both detailed contract errors and raw string messages as reasons for reverts, enhancing clarity and flexibility in error handling within the codebase.

## PR Checklist

- [X] Added Tests
- [X] Added Documentation
