### PR TITLE
fix: ingest domain when instantiating TypedData

### DIFF
--- a/crates/dyn-abi/src/eip712/resolver.rs
+++ b/crates/dyn-abi/src/eip712/resolver.rs
@@ -487,6 +487,15 @@ impl Resolver {
         };
         Ok(keccak256(to_hash))
     }
+
+    /// Check if the resolver graph contains a type by its name.
+    ///
+    /// ## Warning
+    ///
+    /// This checks by NAME only. It does NOT check for type
+    pub fn contains_type_name(&self, name: &str) -> bool {
+        self.nodes.contains_key(name)
+    }
 }
 
 #[cfg(test)]

--- a/crates/dyn-abi/src/eip712/typed_data.rs
+++ b/crates/dyn-abi/src/eip712/typed_data.rs
@@ -132,9 +132,12 @@ impl TypedData {
     /// Instantiate [`TypedData`] from a [`SolStruct`] that implements
     /// [`serde::Serialize`].
     pub fn from_struct<S: SolStruct + Serialize>(s: &S, domain: Option<Eip712Domain>) -> Self {
+        let mut resolver = Resolver::from_struct::<S>();
+        let domain = domain.unwrap_or_default();
+        resolver.ingest_string(domain.encode_type());
         Self {
             domain: domain.unwrap_or_default(),
-            resolver: Resolver::from_struct::<S>(),
+            resolver,
             primary_type: S::NAME.into(),
             message: serde_json::to_value(s).unwrap(),
         }

--- a/crates/dyn-abi/src/eip712/typed_data.rs
+++ b/crates/dyn-abi/src/eip712/typed_data.rs
@@ -134,9 +134,9 @@ impl TypedData {
     pub fn from_struct<S: SolStruct + Serialize>(s: &S, domain: Option<Eip712Domain>) -> Self {
         let mut resolver = Resolver::from_struct::<S>();
         let domain = domain.unwrap_or_default();
-        resolver.ingest_string(domain.encode_type());
+        resolver.ingest_string(domain.encode_type()).expect("domain string always valid");
         Self {
-            domain: domain.unwrap_or_default(),
+            domain,
             resolver,
             primary_type: S::NAME.into(),
             message: serde_json::to_value(s).unwrap(),
@@ -677,6 +677,8 @@ mod tests {
 
         let typed_data = TypedData::from_struct(&s, None);
         assert_eq!(typed_data.encode_type().unwrap(), "MyStruct(string name,string otherThing)",);
+
+        assert!(typed_data.resolver.contains_type_name("EIP712Domain"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #452 

## Solution

Properly ingest the domain into the type resolver when instantiating a typed data from a struct

Fix parser to allow empty types


## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
