### PR TITLE
fix: don't decode ZSTs

### DIFF
--- a/crates/dyn-abi/src/lib.rs
+++ b/crates/dyn-abi/src/lib.rs
@@ -66,3 +66,13 @@ pub use alloy_sol_types::{
     abi::{self, Decoder, Encoder},
     Eip712Domain, SolType, Word,
 };
+
+#[cfg(test)]
+mod test {
+    use crate::{DynSolType, DynSolValue};
+    #[test]
+    fn zst_dos() {
+        let my_type: DynSolType = "()[]".parse().unwrap();
+        let decoded = my_type.abi_decode(&hex::decode("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000FFFFFFFF").unwrap()).unwrap();
+    }
+}

--- a/crates/dyn-abi/src/lib.rs
+++ b/crates/dyn-abi/src/lib.rs
@@ -74,5 +74,7 @@ mod test {
     fn zst_dos() {
         let my_type: DynSolType = "()[]".parse().unwrap();
         let decoded = my_type.abi_decode(&hex::decode("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000FFFFFFFF").unwrap()).unwrap();
+
+        dbg!(decoded);
     }
 }

--- a/crates/dyn-abi/src/lib.rs
+++ b/crates/dyn-abi/src/lib.rs
@@ -69,12 +69,10 @@ pub use alloy_sol_types::{
 
 #[cfg(test)]
 mod test {
-    use crate::{DynSolType, DynSolValue};
+    use crate::DynSolType;
     #[test]
     fn zst_dos() {
         let my_type: DynSolType = "()[]".parse().unwrap();
-        let decoded = my_type.abi_decode(&hex::decode("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000FFFFFFFF").unwrap()).unwrap();
-
-        dbg!(decoded);
+        let _ = my_type.abi_decode(&hex::decode("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000FFFFFFFF").unwrap()).unwrap();
     }
 }

--- a/crates/dyn-abi/src/ty.rs
+++ b/crates/dyn-abi/src/ty.rs
@@ -545,6 +545,10 @@ impl DynSolType {
     where
         F: FnOnce(&mut DynToken<'d>, &mut Decoder<'d>) -> Result<()>,
     {
+        if self.is_zst() {
+            return Ok(self.zero_sized_value().expect("checked"));
+        }
+
         let mut token = self.empty_dyn_token();
         f(&mut token, decoder)?;
         let value = self.detokenize(token).expect("invalid empty_dyn_token");
@@ -571,6 +575,27 @@ impl DynSolType {
         iter: impl IntoIterator<Item = Option<NonZeroUsize>>,
     ) -> Self {
         iter.into_iter().fold(self, Self::array_wrap)
+    }
+
+    /// Return true if the type is zero-sized, e.g. `()` or `T[0]`
+    #[inline]
+    pub fn is_zst(&self) -> bool {
+        match self {
+            DynSolType::Array(inner) => inner.is_zst(),
+            DynSolType::FixedArray(inner, size) => *size == 0 || inner.is_zst(),
+            DynSolType::Tuple(inner) => inner.is_empty() || inner.iter().all(|t| t.is_zst()),
+            _ => false,
+        }
+    }
+
+    #[inline]
+    fn zero_sized_value(&self) -> Option<DynSolValue> {
+        match self {
+            DynSolType::Array(inner) => Some(DynSolValue::Array(vec![])),
+            DynSolType::FixedArray(inner, size) => Some(DynSolValue::FixedArray(vec![])),
+            DynSolType::Tuple(inner) => Some(DynSolValue::Tuple(vec![])),
+            _ => None,
+        }
     }
 }
 

--- a/crates/dyn-abi/src/ty.rs
+++ b/crates/dyn-abi/src/ty.rs
@@ -589,11 +589,11 @@ impl DynSolType {
     }
 
     #[inline]
-    fn zero_sized_value(&self) -> Option<DynSolValue> {
+    const fn zero_sized_value(&self) -> Option<DynSolValue> {
         match self {
-            DynSolType::Array(inner) => Some(DynSolValue::Array(vec![])),
-            DynSolType::FixedArray(inner, size) => Some(DynSolValue::FixedArray(vec![])),
-            DynSolType::Tuple(inner) => Some(DynSolValue::Tuple(vec![])),
+            DynSolType::Array(_) => Some(DynSolValue::Array(vec![])),
+            DynSolType::FixedArray(_, _) => Some(DynSolValue::FixedArray(vec![])),
+            DynSolType::Tuple(_) => Some(DynSolValue::Tuple(vec![])),
             _ => None,
         }
     }


### PR DESCRIPTION

## Motivation

Closes #392 

Fix here prevents zero-sized types from adding significant overhead to decoding, this is an alternative to the proposed fix of disabling instantiation of ZSTs. `DynSolType` has many instantiation vectors, and we may not be able to effectively prevent incorrect use of all of them. 

Followup: research whether we can do this effectively

## Solution

Add an `is_zst` check to decoding, which short-circuits decoding of zero-sized values.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
