### PR TITLE
refactor: Log implementation

### DIFF
--- a/crates/dyn-abi/src/event.rs
+++ b/crates/dyn-abi/src/event.rs
@@ -1,6 +1,6 @@
 use crate::{DynSolType, DynSolValue, Error, Result};
 use alloc::vec::Vec;
-use alloy_primitives::{Log, B256};
+use alloy_primitives::{LogData, B256};
 
 /// A dynamic ABI event.
 ///
@@ -106,7 +106,7 @@ impl DynSolEvent {
     }
 
     /// Decode the event from the given log info.
-    pub fn decode_log(&self, log: &Log, validate: bool) -> Result<DecodedEvent> {
+    pub fn decode_log(&self, log: &LogData, validate: bool) -> Result<DecodedEvent> {
         self.decode_log_parts(log.topics().iter().copied(), &log.data, validate)
     }
 
@@ -143,7 +143,7 @@ mod test {
 
     #[test]
     fn it_decodes_a_simple_log() {
-        let log = Log::new_unchecked(vec![], U256::ZERO.to_be_bytes_vec().into());
+        let log = LogData::new_unchecked(vec![], U256::ZERO.to_be_bytes_vec().into());
         let event = DynSolEvent {
             topic_0: None,
             indexed: vec![],
@@ -155,7 +155,7 @@ mod test {
     #[test]
     fn it_decodes_logs_with_indexed_params() {
         let t0 = b256!("cf74b4e62f836eeedcd6f92120ffb5afea90e6fa490d36f8b81075e2a7de0cf7");
-        let log = Log::new_unchecked(
+        let log = LogData::new_unchecked(
             vec![t0, b256!("0000000000000000000000000000000000000000000000000000000000012321")],
             bytes!(
                 "

--- a/crates/dyn-abi/src/ext/event.rs
+++ b/crates/dyn-abi/src/ext/event.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 use alloc::vec::Vec;
 use alloy_json_abi::Event;
-use alloy_primitives::{Log, B256};
+use alloy_primitives::{LogData, B256};
 
 mod sealed {
     pub trait Sealed {}
@@ -62,7 +62,7 @@ pub trait EventExt: Sealed {
     ///
     /// See [`decode_log`](EventExt::decode_log).
     #[inline]
-    fn decode_log(&self, log: &Log, validate: bool) -> Result<DecodedEvent> {
+    fn decode_log(&self, log: &LogData, validate: bool) -> Result<DecodedEvent> {
         self.decode_log_parts(log.topics().iter().copied(), &log.data, validate)
     }
 }
@@ -189,7 +189,7 @@ mod tests {
         wrong_event.inputs[0].indexed = true;
         wrong_event.inputs[1].indexed = false;
 
-        let log = Log::new_unchecked(
+        let log = LogData::new_unchecked(
             vec![
                 b256!("cf74b4e62f836eeedcd6f92120ffb5afea90e6fa490d36f8b81075e2a7de0cf7"),
                 b256!("0000000000000000000000000000000000000000000000000000000000012321"),

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -42,7 +42,7 @@ mod bytes_;
 pub use self::bytes_::Bytes;
 
 mod log;
-pub use log::Log;
+pub use log::{Log, LogData};
 
 mod signed;
 pub use signed::{BigIntConversionError, ParseSignedError, Sign, Signed};

--- a/crates/sol-macro/src/expand/contract.rs
+++ b/crates/sol-macro/src/expand/contract.rs
@@ -450,7 +450,7 @@ impl<'a> CallLikeExpander<'a> {
         let err = quote! {
             ::alloy_sol_types::private::Err(::alloy_sol_types::Error::InvalidLog {
                 name: <Self as ::alloy_sol_types::SolEventInterface>::NAME,
-                log: ::alloy_sol_types::private::Box::new(::alloy_sol_types::private::Log::new_unchecked(
+                log: ::alloy_sol_types::private::Box::new(::alloy_sol_types::private::LogData::new_unchecked(
                     topics.to_vec(),
                     data.to_vec().into(),
                 )),
@@ -464,7 +464,7 @@ impl<'a> CallLikeExpander<'a> {
                 match topics.first().copied() {
                     #(
                         Some(<#variants as ::alloy_sol_types::#trait_>::SIGNATURE_HASH) =>
-                            #ret <#variants as ::alloy_sol_types::#trait_>::decode_log(topics, data, validate)
+                            #ret <#variants as ::alloy_sol_types::#trait_>::decode_raw_log(topics, data, validate)
                                 .map(Self::#variants),
                     )*
                     _ => { #ret_err }
@@ -475,7 +475,7 @@ impl<'a> CallLikeExpander<'a> {
             let variants = events.iter().filter(|e| e.is_anonymous()).map(e_name);
             quote! {
                 #(
-                    if let Ok(res) = <#variants as ::alloy_sol_types::#trait_>::decode_log(topics, data, validate) {
+                    if let Ok(res) = <#variants as ::alloy_sol_types::#trait_>::decode_raw_log(topics, data, validate) {
                         return Ok(Self::#variants(res));
                     }
                 )*
@@ -490,7 +490,7 @@ impl<'a> CallLikeExpander<'a> {
                 const NAME: &'static str = #name_s;
                 const COUNT: usize = #count;
 
-                fn decode_log(topics: &[::alloy_sol_types::Word], data: &[u8], validate: bool) -> ::alloy_sol_types::Result<Self> {
+                fn decode_raw_log(topics: &[::alloy_sol_types::Word], data: &[u8], validate: bool) -> ::alloy_sol_types::Result<Self> {
                     #non_anon_impl
                     #anon_impl
                 }

--- a/crates/sol-types/src/errors.rs
+++ b/crates/sol-types/src/errors.rs
@@ -9,7 +9,7 @@
 
 use crate::abi;
 use alloc::{borrow::Cow, boxed::Box, string::String};
-use alloy_primitives::Log;
+use alloy_primitives::LogData;
 use core::fmt;
 
 /// ABI result type.
@@ -50,7 +50,7 @@ pub enum Error {
         /// The name of the enum or event.
         name: &'static str,
         /// The invalid log.
-        log: Box<Log>,
+        log: Box<LogData>,
     },
 
     /// Unknown selector.

--- a/crates/sol-types/src/lib.rs
+++ b/crates/sol-types/src/lib.rs
@@ -212,7 +212,8 @@ pub mod private {
         vec::Vec,
     };
     pub use alloy_primitives::{
-        bytes, keccak256, Address, Bytes, FixedBytes, Function, Log, Signed, Uint, B256, I256, U256,
+        bytes, keccak256, Address, Bytes, FixedBytes, Function, LogData, Signed, Uint, B256, I256,
+        U256,
     };
     pub use core::{
         borrow::{Borrow, BorrowMut},

--- a/crates/sol-types/src/types/event/mod.rs
+++ b/crates/sol-types/src/types/event/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     Result, SolType, Word,
 };
 use alloc::vec::Vec;
-use alloy_primitives::{FixedBytes, Log, B256};
+use alloy_primitives::{FixedBytes, Log, LogData, B256};
 
 mod topic;
 pub use topic::EventTopic;
@@ -142,7 +142,7 @@ pub trait SolEvent: Sized {
     }
 
     /// Decode the event from the given log info.
-    fn decode_log<I, D>(topics: I, data: &[u8], validate: bool) -> Result<Self>
+    fn decode_raw_log<I, D>(topics: I, data: &[u8], validate: bool) -> Result<Self>
     where
         I: IntoIterator<Item = D>,
         D: Into<WordToken>,
@@ -153,7 +153,12 @@ pub trait SolEvent: Sized {
     }
 
     /// Decode the event from the given log object.
-    fn decode_log_object(log: &Log, validate: bool) -> Result<Self> {
-        Self::decode_log(log.topics(), &log.data, validate)
+    fn decode_log_data(log: &LogData, validate: bool) -> Result<Self> {
+        Self::decode_raw_log(log.topics(), &log.data, validate)
+    }
+
+    /// Decode the event from the given log object.
+    fn decode_log(log: &Log, validate: bool) -> Result<Log<Self>> {
+        Self::decode_log_data(&log.data, validate).map(|data| Log { address: log.address, data })
     }
 }

--- a/crates/sol-types/src/types/interface/event.rs
+++ b/crates/sol-types/src/types/interface/event.rs
@@ -18,10 +18,11 @@ pub trait SolEventInterface: Sized {
     const COUNT: usize;
 
     /// Decode the events from the given log info.
-    fn decode_log(topics: &[Word], data: &[u8], validate: bool) -> Result<Self>;
+    fn decode_raw_log(topics: &[Word], data: &[u8], validate: bool) -> Result<Self>;
 
     /// Decode the events from the given log object.
-    fn decode_log_object(log: &Log, validate: bool) -> Result<Self> {
-        Self::decode_log(log.topics(), &log.data, validate)
+    fn decode_log(log: &Log, validate: bool) -> Result<Log<Self>> {
+        Self::decode_raw_log(log.topics(), &log.data.data, validate)
+            .map(|data| Log { address: log.address, data })
     }
 }


### PR DESCRIPTION
CC @Evalir  @DaniPopes 

## Motivation

Refactors log to support address and raw/decoded data 

## Solution

- rename `Log` to `LogData`
- make `Log<T = LogData>`
- modify `SolEvent` and `SolEventInterface` to decode into `Log<Self>`
- rename functions for added clarity
- implement RLP on `Log` (needs testing)
- expand `Bloom` with `FromIterator` and `Extend`, and specialized `contains` methods for logs

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Breaking changes
