### PR TITLE
feature: sealed

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -44,6 +44,9 @@ pub use self::bytes_::Bytes;
 mod log;
 pub use log::Log;
 
+mod sealed;
+pub use sealed::{Sealable, Sealed};
+
 mod signed;
 pub use signed::{BigIntConversionError, ParseSignedError, Sign, Signed};
 

--- a/crates/primitives/src/sealed.rs
+++ b/crates/primitives/src/sealed.rs
@@ -42,12 +42,6 @@ impl<T> Sealed<T> {
     pub const fn seal(&self) -> B256 {
         self.seal
     }
-
-    /// Geth the hash (alias for [`Self::seal`]).
-    #[inline(always)]
-    pub const fn hash(&self) -> B256 {
-        self.seal()
-    }
 }
 
 /// Sealeable objects.

--- a/crates/primitives/src/sealed.rs
+++ b/crates/primitives/src/sealed.rs
@@ -53,11 +53,11 @@ impl<T> Sealed<T> {
 /// Sealeable objects.
 pub trait Sealable: Sized {
     /// Calculate the seal hash, this may be slow.
-    fn hash(&self) -> B256;
+    fn hash_slow(&self) -> B256;
 
     /// Seal the object by calculating the hash. This may be slow.
     fn seal_slow(self) -> Sealed<Self> {
-        let seal = self.hash();
+        let seal = self.hash_slow();
         Sealed::new_unchecked(self, seal)
     }
 

--- a/crates/primitives/src/sealed.rs
+++ b/crates/primitives/src/sealed.rs
@@ -1,0 +1,68 @@
+use crate::B256;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+/// A consensus hashable item, with its memoized hash.
+///
+/// We do not implement
+pub struct Sealed<T> {
+    /// The inner item
+    inner: T,
+    /// Its hash.
+    seal: B256,
+}
+
+impl<T> core::ops::Deref for Sealed<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner()
+    }
+}
+
+impl<T> Sealed<T> {
+    /// Instantiate without performing the hash. This should be used carefully.
+    pub const fn new_unchecked(inner: T, seal: B256) -> Self {
+        Self { inner, seal }
+    }
+
+    /// Decompose into parts.
+    #[allow(clippy::missing_const_for_fn)] // false positive
+    pub fn into_parts(self) -> (T, B256) {
+        (self.inner, self.seal)
+    }
+
+    /// Get the inner item.
+    #[inline(always)]
+    pub const fn inner(&self) -> &T {
+        &self.inner
+    }
+
+    /// Get the hash.
+    #[inline(always)]
+    pub const fn seal(&self) -> B256 {
+        self.seal
+    }
+
+    /// Geth the hash (alias for [`Self::seal`]).
+    #[inline(always)]
+    pub const fn hash(&self) -> B256 {
+        self.seal()
+    }
+}
+
+/// Sealeable objects.
+pub trait Sealable: Sized {
+    /// Calculate the seal hash, this may be slow.
+    fn hash(&self) -> B256;
+
+    /// Seal the object by calculating the hash. This may be slow.
+    fn seal_slow(self) -> Sealed<Self> {
+        let seal = self.hash();
+        Sealed::new_unchecked(self, seal)
+    }
+
+    /// Instantiate an unchecked seal. This should be used with caution.
+    fn seal_unchecked(self, seal: B256) -> Sealed<Self> {
+        Sealed::new_unchecked(self, seal)
+    }
+}

--- a/crates/primitives/src/sealed.rs
+++ b/crates/primitives/src/sealed.rs
@@ -24,11 +24,16 @@ impl<T> Sealed<T> {
     pub const fn new_unchecked(inner: T, seal: B256) -> Self {
         Self { inner, seal }
     }
-
     /// Decompose into parts.
     #[allow(clippy::missing_const_for_fn)] // false positive
     pub fn into_parts(self) -> (T, B256) {
         (self.inner, self.seal)
+    }
+
+    /// Decompose into parts. Alias for [`Self::into_parts`].
+    #[allow(clippy::missing_const_for_fn)] // false positive
+    pub fn split(self) -> (T, B256) {
+        self.into_parts()
     }
 
     /// Get the inner item.
@@ -41,6 +46,21 @@ impl<T> Sealed<T> {
     #[inline(always)]
     pub const fn seal(&self) -> B256 {
         self.seal
+    }
+
+    /// Unseal the inner item, discarding the hash.
+    #[inline(always)]
+    #[allow(clippy::missing_const_for_fn)] // false positive
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+
+    /// Unseal the inner item, discarding the hash. Alias for
+    /// [`Self::into_inner`].
+    #[inline(always)]
+    #[allow(clippy::missing_const_for_fn)] // false positive
+    pub fn unseal(self) -> T {
+        self.into_inner()
     }
 }
 


### PR DESCRIPTION
Moves `Sealed` and `Sealable` into alloy-primitives

## Motivation

Commonly used across many potential networks and crates.

## Solution

Make `Sealed` and `Sealable` primitives

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
