### PR TITLE
feat(json-abi): add full_signature

### DIFF
--- a/crates/json-abi/src/item.rs
+++ b/crates/json-abi/src/item.rs
@@ -503,7 +503,7 @@ impl Function {
     }
 
     /// Returns this function's full signature including names of params:
-    /// `event $name($($inputs names),*) state_mutability returns ($(outputs names),*)`.
+    /// `function $name($($inputs $names),*) state_mutability returns ($($outputs $names),*)`.
     ///
     /// This is a full human-readable string, including all parameter names, any optional modifiers
     /// (e.g. indexed, public, etc) and white-space to aid in human readability. This is useful for

--- a/crates/json-abi/src/item.rs
+++ b/crates/json-abi/src/item.rs
@@ -498,7 +498,7 @@ impl Function {
     /// This is the same as [`signature`](Self::signature), but also includes
     /// the output types.
     #[inline]
-    pub fn signature_full(&self) -> String {
+    pub fn signature_with_outputs(&self) -> String {
         signature(&self.name, &self.inputs, Some(&self.outputs))
     }
 
@@ -506,7 +506,7 @@ impl Function {
     /// `function $name($($inputs $names),*) state_mutability returns ($($outputs $names),*)`.
     ///
     /// This is a full human-readable string, including all parameter names, any optional modifiers
-    /// (e.g. indexed, public, etc) and white-space to aid in human readability. This is useful for
+    /// (e.g. view, payable, pure) and white-space to aid in human readability. This is useful for
     /// storing a string which can still fully reconstruct the original Fragment
     #[inline]
     pub fn full_signature(&self) -> String {
@@ -574,7 +574,12 @@ impl Event {
         event_signature(&self.name, &self.inputs)
     }
 
-    /// Returns this event's full signature: `event $name($($inputs indexed names),*)`.
+    /// Returns this event's full signature
+    /// `event $name($($inputs indexed $names),*)`.
+    ///
+    /// This is a full human-readable string, including all parameter names, any optional modifiers
+    /// (e.g. indexed) and white-space to aid in human readability. This is useful for
+    /// storing a string which can still fully reconstruct the original Fragment
     #[inline]
     pub fn full_signature(&self) -> String {
         event_full_signature(&self.name, &self.inputs)

--- a/crates/json-abi/src/item.rs
+++ b/crates/json-abi/src/item.rs
@@ -502,6 +502,17 @@ impl Function {
         signature(&self.name, &self.inputs, Some(&self.outputs))
     }
 
+    /// Returns this function's full signature including names of params:
+    /// `event $name($($inputs names),*) state_mutability returns ($(outputs names),*)`.
+    ///
+    /// This is a full human-readable string, including all parameter names, any optional modifiers
+    /// (e.g. indexed, public, etc) and white-space to aid in human readability. This is useful for
+    /// storing a string which can still fully reconstruct the original Fragment
+    #[inline]
+    pub fn full_signature(&self) -> String {
+        full_signature(&self.name, &self.inputs, Some(&self.outputs), self.state_mutability)
+    }
+
     /// Computes this error's selector: `keccak256(self.signature())[..4]`
     #[inline]
     pub fn selector(&self) -> Selector {
@@ -561,6 +572,12 @@ impl Event {
     #[inline]
     pub fn signature(&self) -> String {
         event_signature(&self.name, &self.inputs)
+    }
+
+    /// Returns this event's full signature: `event $name($($inputs indexed names),*)`.
+    #[inline]
+    pub fn full_signature(&self) -> String {
+        event_full_signature(&self.name, &self.inputs)
     }
 
     /// Computes this event's selector: `keccak256(self.signature())`

--- a/crates/json-abi/src/param.rs
+++ b/crates/json-abi/src/param.rs
@@ -218,6 +218,24 @@ impl Param {
         }
     }
 
+    /// Formats the canonical type of this parameter into the given string including then names of
+    /// the params.
+    ///
+    /// This is used to encode the preimage of a function selector.
+    #[inline]
+    pub fn full_selector_type_raw(&self, s: &mut String) {
+        if self.components.is_empty() {
+            s.push_str(&self.ty);
+        } else {
+            s.push_str("tuple");
+            crate::utils::full_signature_raw(&self.components, s);
+            // checked during deserialization, but might be invalid from a user
+            if let Some(suffix) = self.ty.strip_prefix("tuple") {
+                s.push_str(suffix);
+            }
+        }
+    }
+
     /// Returns the canonical type of this parameter.
     ///
     /// This is used to encode the preimage of a function or error selector.
@@ -449,6 +467,24 @@ impl EventParam {
             s.push_str(&self.ty);
         } else {
             crate::utils::signature_raw(&self.components, s);
+            // checked during deserialization, but might be invalid from a user
+            if let Some(suffix) = self.ty.strip_prefix("tuple") {
+                s.push_str(suffix);
+            }
+        }
+    }
+
+    /// Formats the canonical type of this parameter into the given string including then names of
+    /// the params.
+    ///
+    /// This is used to encode the preimage of the event selector.
+    #[inline]
+    pub fn full_selector_type_raw(&self, s: &mut String) {
+        if self.components.is_empty() {
+            s.push_str(&self.ty);
+        } else {
+            s.push_str("tuple");
+            crate::utils::full_signature_raw(&self.components, s);
             // checked during deserialization, but might be invalid from a user
             if let Some(suffix) = self.ty.strip_prefix("tuple") {
                 s.push_str(suffix);

--- a/crates/json-abi/src/param.rs
+++ b/crates/json-abi/src/param.rs
@@ -220,8 +220,6 @@ impl Param {
 
     /// Formats the canonical type of this parameter into the given string including then names of
     /// the params.
-    ///
-    /// This is used to encode the preimage of a function selector.
     #[inline]
     pub fn full_selector_type_raw(&self, s: &mut String) {
         if self.components.is_empty() {
@@ -476,8 +474,6 @@ impl EventParam {
 
     /// Formats the canonical type of this parameter into the given string including then names of
     /// the params.
-    ///
-    /// This is used to encode the preimage of the event selector.
     #[inline]
     pub fn full_selector_type_raw(&self, s: &mut String) {
         if self.components.is_empty() {

--- a/crates/json-abi/src/utils.rs
+++ b/crates/json-abi/src/utils.rs
@@ -1,5 +1,8 @@
-use crate::{EventParam, Param};
-use alloc::{string::String, vec::Vec};
+use crate::{EventParam, Param, StateMutability};
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use alloy_primitives::Selector;
 use core::{fmt::Write, num::NonZeroUsize};
 use parser::{ParameterSpecifier, TypeSpecifier, TypeStem};
@@ -33,6 +36,45 @@ macro_rules! signature {
     };
 }
 
+macro_rules! event_full_signature {
+    ($inputs:expr, $preimage:expr) => {
+        $preimage.push('(');
+        for (i, input) in $inputs.iter().enumerate() {
+            if i > 0 {
+                $preimage.push(',');
+                $preimage.push(' ');
+            }
+            input.full_selector_type_raw($preimage);
+            if input.indexed {
+                $preimage.push_str(" indexed");
+            }
+            if !input.name.is_empty() {
+                $preimage.push(' ');
+                $preimage.push_str(&input.name);
+            }
+        }
+        $preimage.push(')');
+    };
+}
+
+macro_rules! full_signature {
+    ($inputs:expr, $preimage:expr) => {
+        $preimage.push('(');
+        for (i, input) in $inputs.iter().enumerate() {
+            if i > 0 {
+                $preimage.push(',');
+                $preimage.push(' ');
+            }
+            input.full_selector_type_raw($preimage);
+            if !input.name.is_empty() {
+                $preimage.push(' ');
+                $preimage.push_str(&input.name);
+            }
+        }
+        $preimage.push(')');
+    };
+}
+
 /// `$name($($inputs),*)($($outputs),*)`
 pub(crate) fn signature(name: &str, inputs: &[Param], outputs: Option<&[Param]>) -> String {
     let parens = 2 + outputs.is_some() as usize * 2;
@@ -47,9 +89,45 @@ pub(crate) fn signature(name: &str, inputs: &[Param], outputs: Option<&[Param]>)
     preimage
 }
 
+pub(crate) fn full_signature(
+    name: &str,
+    inputs: &[Param],
+    outputs: Option<&[Param]>,
+    state_mutability: StateMutability,
+) -> String {
+    let parens = 2 + outputs.is_some() as usize * 2;
+    let n_outputs = outputs.map(<[_]>::len).unwrap_or(0);
+    let mut state_mutability_str = format!(" {}", state_mutability.as_str().unwrap_or_default());
+    if state_mutability_str.trim().is_empty() {
+        state_mutability_str = "".to_string();
+    }
+    let cap = "function ".len()
+        + name.len()
+        + parens
+        + (inputs.len() + n_outputs) * PARAM
+        + state_mutability_str.len();
+    let mut preimage = String::with_capacity(cap);
+
+    preimage.push_str("function ");
+    preimage.push_str(name);
+    full_signature_raw(inputs, &mut preimage);
+    preimage.push_str(&state_mutability_str);
+    if let Some(outputs) = outputs {
+        if !outputs.is_empty() {
+            preimage.push_str(" returns ");
+            full_signature_raw(outputs, &mut preimage);
+        }
+    }
+    preimage
+}
+
 /// `($($params),*)`
 pub(crate) fn signature_raw(params: &[Param], preimage: &mut String) {
     signature!(params, preimage);
+}
+
+pub(crate) fn full_signature_raw(params: &[Param], preimage: &mut String) {
+    full_signature!(params, preimage);
 }
 
 /// `$name($($inputs),*)`
@@ -57,6 +135,16 @@ pub(crate) fn event_signature(name: &str, inputs: &[EventParam]) -> String {
     let mut preimage = String::with_capacity(name.len() + 2 + inputs.len() * PARAM);
     preimage.push_str(name);
     signature!(inputs, &mut preimage);
+    preimage
+}
+
+/// `$name($($inputs indexed names),*)`
+pub(crate) fn event_full_signature(name: &str, inputs: &[EventParam]) -> String {
+    let mut preimage =
+        String::with_capacity("event ".len() + name.len() + 2 + inputs.len() * PARAM);
+    preimage.push_str("event ");
+    preimage.push_str(name);
+    event_full_signature!(inputs, &mut preimage);
     preimage
 }
 
@@ -152,18 +240,48 @@ mod tests {
     }
 
     fn eparam(kind: &str) -> EventParam {
+        eparam_with_indexed(kind, "param", false)
+    }
+
+    fn eparam2(kind: &str, name: &str, indexed: bool) -> EventParam {
+        eparam_with_indexed(kind, name, indexed)
+    }
+
+    fn eparam_with_indexed(kind: &str, name: &str, indexed: bool) -> EventParam {
         EventParam {
-            name: "param".into(),
+            name: name.into(),
             ty: kind.into(),
             internal_type: None,
             components: vec![],
-            indexed: false,
+            indexed,
         }
     }
 
     fn params(components: impl IntoIterator<Item = &'static str>) -> Param {
         let components = components.into_iter().map(param).collect();
         crate::Param { name: "param".into(), ty: "tuple".into(), internal_type: None, components }
+    }
+
+    fn full_signature_raw(
+        name: &str,
+        inputs: &[Param],
+        outputs: Option<&[Param]>,
+        state_mutability: StateMutability,
+    ) -> String {
+        full_signature(name, inputs, outputs, state_mutability)
+    }
+
+    fn full_signature_np(name: &str, inputs: &[Param], outputs: Option<&[Param]>) -> String {
+        full_signature_raw(name, inputs, outputs, StateMutability::NonPayable)
+    }
+
+    fn full_signature_with_sm(
+        name: &str,
+        inputs: &[Param],
+        outputs: Option<&[Param]>,
+        state_mutability: StateMutability,
+    ) -> String {
+        full_signature_raw(name, inputs, outputs, state_mutability)
     }
 
     #[test]
@@ -188,10 +306,119 @@ mod tests {
     }
 
     #[test]
+    fn test_full_signature() {
+        assert_eq!(full_signature_np("foo", &[], None), "function foo()");
+        assert_eq!(full_signature_np("foo", &[], Some(&[])), "function foo()");
+        assert_eq!(full_signature_np("bar", &[param2("bool", "")], None), "function bar(bool)");
+        assert_eq!(
+            full_signature_np("bar", &[param2("bool", "")], Some(&[param2("bool", "")])),
+            "function bar(bool) returns (bool)"
+        );
+        assert_eq!(
+            full_signature_np(
+                "foo",
+                &[param2("address", "asset"), param2("uint256", "amount")],
+                None
+            ),
+            "function foo(address asset, uint256 amount)"
+        );
+        assert_eq!(
+            full_signature_np(
+                "foo",
+                &[param2("address", "asset")],
+                Some(&[param2("uint256", "amount")])
+            ),
+            "function foo(address asset) returns (uint256 amount)"
+        );
+
+        let mut components = vec![];
+        components.push(param2("address", "pool"));
+        components.push(param2("uint256", "tokenInParam"));
+        components.push(param2("uint256", "tokenOutParam"));
+        components.push(param2("uint256", "maxPrice"));
+        let swaps =
+            Param { name: "swaps".into(), ty: "tuple[]".into(), internal_type: None, components };
+
+        assert_eq!(
+            full_signature_with_sm(
+                "batchSwapExactIn",
+                &[
+                    swaps,
+                    param2("address", "tokenIn"),
+                    param2("address", "tokenOut"),
+                    param2("uint256", "totalAmountIn"),
+                    param2("uint256", "minTotalAmountOut"),
+                ],
+                Some(&[param2("uint256", "totalAmountOut")]),
+                StateMutability::Payable,
+            ),
+            "function batchSwapExactIn(tuple(address pool, uint256 tokenInParam, uint256 tokenOutParam, uint256 maxPrice)[] swaps, address tokenIn, address tokenOut, uint256 totalAmountIn, uint256 minTotalAmountOut) payable returns (uint256 totalAmountOut)"
+        );
+
+        assert_eq!(
+            full_signature_with_sm(
+                "name",
+                &[],
+                Some(&[param2("string", "")]),
+                StateMutability::View
+            ),
+            "function name() view returns (string)"
+        );
+
+        assert_eq!(
+            full_signature_with_sm(
+                "calculateHash",
+                &[param2("address[]", "_addresses")],
+                Some(&[param2("bytes32", "")]),
+                StateMutability::Pure,
+            ),
+            "function calculateHash(address[] _addresses) pure returns (bytes32)"
+        );
+    }
+
+    #[test]
     fn test_event_signature() {
         assert_eq!(event_signature("foo", &[]), "foo()");
         assert_eq!(event_signature("foo", &[eparam("bool")]), "foo(bool)");
         assert_eq!(event_signature("foo", &[eparam("bool"), eparam("string")]), "foo(bool,string)");
+    }
+
+    #[test]
+    fn test_event_full_signature() {
+        assert_eq!(event_full_signature("foo", &[]), "event foo()");
+        assert_eq!(
+            event_full_signature("foo", &[eparam2("bool", "confirmed", true)]),
+            "event foo(bool indexed confirmed)"
+        );
+        assert_eq!(
+            event_full_signature(
+                "foo",
+                &[eparam2("bool", "confirmed", true), eparam2("string", "message", false)]
+            ),
+            "event foo(bool indexed confirmed, string message)"
+        );
+
+        let mut components = vec![];
+        components.push(param2("uint256", "amount"));
+        components.push(param2("uint256", "startTime"));
+        components.push(param2("uint256", "interval"));
+        let info = EventParam {
+            name: "info".into(),
+            ty: "tuple".into(),
+            internal_type: None,
+            components,
+            indexed: false,
+        };
+        assert_eq!(
+            event_full_signature(
+                "SetupDirectDebit",
+                &[
+                    eparam2("address", "debtor", true),
+                    eparam2("address", "receiver", true),
+                    info,
+                ]            ),
+            "event SetupDirectDebit(address indexed debtor, address indexed receiver, tuple(uint256 amount, uint256 startTime, uint256 interval) info)"
+        );
     }
 
     #[test]

--- a/crates/json-abi/src/utils.rs
+++ b/crates/json-abi/src/utils.rs
@@ -331,11 +331,12 @@ mod tests {
             "function foo(address asset) returns (uint256 amount)"
         );
 
-        let mut components = vec![];
-        components.push(param2("address", "pool"));
-        components.push(param2("uint256", "tokenInParam"));
-        components.push(param2("uint256", "tokenOutParam"));
-        components.push(param2("uint256", "maxPrice"));
+        let components = vec![
+            param2("address", "pool"),
+            param2("uint256", "tokenInParam"),
+            param2("uint256", "tokenOutParam"),
+            param2("uint256", "maxPrice"),
+        ];
         let swaps =
             Param { name: "swaps".into(), ty: "tuple[]".into(), internal_type: None, components };
 
@@ -398,10 +399,11 @@ mod tests {
             "event foo(bool indexed confirmed, string message)"
         );
 
-        let mut components = vec![];
-        components.push(param2("uint256", "amount"));
-        components.push(param2("uint256", "startTime"));
-        components.push(param2("uint256", "interval"));
+        let components = vec![
+            param2("uint256", "amount"),
+            param2("uint256", "startTime"),
+            param2("uint256", "interval"),
+        ];
         let info = EventParam {
             name: "info".into(),
             ty: "tuple".into(),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

I’m working on a ABI fragments database so we can fill in function and event data for contracts that haven’t been verified, but we having a matching ABI fragment for from another contract.

We’re going to have each row be unique based on the `full_signature`, which includes the name of each param, for events, whether the param is indexed or not, and for functions, the state mutability

In `ethers.js`, there is a fragment `FormatTypes.full` that can generate the full signature for you.

https://docs.ethers.org/v5/api/utils/abi/fragments/#fragments--output-formats

some maximally illustrative examples:
`function batchSwapExactIn(tuple(address pool, uint256 tokenInParam, uint256 tokenOutParam, uint256 maxPrice)[] swaps, address tokenIn, address tokenOut, uint256 totalAmountIn, uint256 minTotalAmountOut) payable returns (uint256 totalAmountOut)`

`event SetupDirectDebit(address indexed debtor, address indexed receiver, tuple(uint256 amount, uint256 startTime, uint256 interval) info)`

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I've added a `.full_signature()` function to the `Function` and `Event` structs

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] No Breaking changes

## Notes

Functions already have `signature_full` that includes the output types. This is pretty close to `full_signature` as a name. Are we fine with that or do we need to think of a different name for `full_signature`?

I thought about trying to overload some of the functions instead of making additional functions prepended with `full_`, but I don’t think it’d make it any cleaner.
