### PR TITLE
chore: include path in error

### DIFF
--- a/crates/sol-macro/src/input.rs
+++ b/crates/sol-macro/src/input.rs
@@ -90,9 +90,9 @@ impl SolInput {
                 p = dir.join(p);
             }
             p = dunce::canonicalize(&p)
-                .map_err(|e| Error::new(span, format!("failed to canonicalize path: {e}")))?;
+                .map_err(|e| Error::new(span, format!("failed to canonicalize path {p:?}: {e}")))?;
             value = std::fs::read_to_string(&p)
-                .map_err(|e| Error::new(span, format!("failed to read file: {e}")))?;
+                .map_err(|e| Error::new(span, format!("failed to read file {p:?}: {e}")))?;
             path = Some(p);
         }
 

--- a/crates/sol-types/tests/ui/features/json/abigen.stderr
+++ b/crates/sol-types/tests/ui/features/json/abigen.stderr
@@ -4,19 +4,19 @@ error: empty input is not allowed
 3 | sol!(EmptyStr, "");
   |                ^^
 
-error: failed to canonicalize path: No such file or directory (os error 2)
+error: failed to canonicalize path "$WORKSPACE/target/tests/trybuild/alloy-sol-types/???": No such file or directory (os error 2)
  --> tests/ui/features/json/abigen.rs:5:24
   |
 5 | sol!(PathDoesNotExist, "???");
   |                        ^^^^^
 
-error: failed to canonicalize path: No such file or directory (os error 2)
+error: failed to canonicalize path "$WORKSPACE/target/tests/trybuild/alloy-sol-types/pragma solidity ^0.8.0": No such file or directory (os error 2)
  --> tests/ui/features/json/abigen.rs:6:6
   |
 6 | sol!("pragma solidity ^0.8.0");
   |      ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: failed to canonicalize path: No such file or directory (os error 2)
+error: failed to canonicalize path "$WORKSPACE/target/tests/trybuild/alloy-sol-types/pragma solidity ^0.8.0;": No such file or directory (os error 2)
  --> tests/ui/features/json/abigen.rs:7:6
   |
 7 | sol!("pragma solidity ^0.8.0;");

--- a/crates/sol-types/tests/ui/features/not(json)/abigen.stderr
+++ b/crates/sol-types/tests/ui/features/not(json)/abigen.stderr
@@ -4,19 +4,19 @@ error: empty input is not allowed
 3 | sol!(EmptyStr, "");
   |                ^^
 
-error: failed to canonicalize path: No such file or directory (os error 2)
+error: failed to canonicalize path "$WORKSPACE/target/tests/trybuild/alloy-sol-types/???": No such file or directory (os error 2)
  --> tests/ui/features/not(json)/abigen.rs:5:24
   |
 5 | sol!(PathDoesNotExist, "???");
   |                        ^^^^^
 
-error: failed to canonicalize path: No such file or directory (os error 2)
+error: failed to canonicalize path "$WORKSPACE/target/tests/trybuild/alloy-sol-types/pragma solidity ^0.8.0": No such file or directory (os error 2)
  --> tests/ui/features/not(json)/abigen.rs:6:6
   |
 6 | sol!("pragma solidity ^0.8.0");
   |      ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: failed to canonicalize path: No such file or directory (os error 2)
+error: failed to canonicalize path "$WORKSPACE/target/tests/trybuild/alloy-sol-types/pragma solidity ^0.8.0;": No such file or directory (os error 2)
  --> tests/ui/features/not(json)/abigen.rs:7:6
   |
 7 | sol!("pragma solidity ^0.8.0;");


### PR DESCRIPTION
the io::Error does not contain the file path.

this includes the file path in errors