### PR TITLE
feat: add constructorCall to `sol!`

### DIFF
--- a/crates/json-abi/src/to_sol.rs
+++ b/crates/json-abi/src/to_sol.rs
@@ -67,9 +67,9 @@ impl ToSol for JsonAbi {
         let mut its = InternalTypes::new();
         its.visit_abi(self);
         fmt!(its.0);
-        fmt!(self.constructor());
         fmt!(self.errors());
         fmt!(self.events());
+        fmt!(self.constructor());
         fmt!(self.fallback);
         fmt!(self.receive);
         fmt!(self.functions());

--- a/crates/json-abi/tests/abi/AggregationRouterV5.sol
+++ b/crates/json-abi/tests/abi/AggregationRouterV5.sol
@@ -30,8 +30,6 @@ interface AggregationRouterV5 {
         uint256 flags;
     }
 
-    constructor(address weth);
-
     error AccessDenied();
     error AdvanceNonceFailed();
     error AlreadyFilled();
@@ -85,6 +83,8 @@ interface AggregationRouterV5 {
     event OrderFilled(address indexed maker, bytes32 orderHash, uint256 remaining);
     event OrderFilledRFQ(bytes32 orderHash, uint256 makingAmount);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    constructor(address weth);
 
     receive() external payable;
 

--- a/crates/json-abi/tests/abi/AggregationRouterV5.sol
+++ b/crates/json-abi/tests/abi/AggregationRouterV5.sol
@@ -30,6 +30,8 @@ interface AggregationRouterV5 {
         uint256 flags;
     }
 
+    constructor(address weth);
+
     error AccessDenied();
     error AdvanceNonceFailed();
     error AlreadyFilled();

--- a/crates/json-abi/tests/abi/BlurExchange.sol
+++ b/crates/json-abi/tests/abi/BlurExchange.sol
@@ -34,8 +34,6 @@ interface BlurExchange {
         bytes extraParams;
     }
 
-    constructor();
-
     event AdminChanged(address previousAdmin, address newAdmin);
     event BeaconUpgraded(address indexed beacon);
     event Closed();
@@ -53,6 +51,8 @@ interface BlurExchange {
     event OrdersMatched(address indexed maker, address indexed taker, Order sell, bytes32 sellHash, Order buy, bytes32 buyHash);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
     event Upgraded(address indexed implementation);
+
+    constructor();
 
     function FEE_TYPEHASH() external view returns (bytes32);
     function INVERSE_BASIS_POINT() external view returns (uint256);

--- a/crates/json-abi/tests/abi/BlurExchange.sol
+++ b/crates/json-abi/tests/abi/BlurExchange.sol
@@ -34,6 +34,8 @@ interface BlurExchange {
         bytes extraParams;
     }
 
+    constructor();
+
     event AdminChanged(address previousAdmin, address newAdmin);
     event BeaconUpgraded(address indexed beacon);
     event Closed();

--- a/crates/json-abi/tests/abi/DoubleExponentInterestSetter.sol
+++ b/crates/json-abi/tests/abi/DoubleExponentInterestSetter.sol
@@ -1,4 +1,6 @@
 interface DoubleExponentInterestSetter {
+    constructor((uint128, uint128) params);
+
     function getCoefficients() external view returns (uint256[] memory);
     function getInterestRate(address, uint256 borrowWei, uint256 supplyWei) external view returns ((uint256,) memory);
     function getMaxAPR() external view returns (uint256);

--- a/crates/json-abi/tests/abi/GaugeController.sol
+++ b/crates/json-abi/tests/abi/GaugeController.sol
@@ -1,4 +1,6 @@
 interface GaugeController {
+    constructor(address _token, address _voting_escrow);
+
     event AddType(string name, int128 type_id);
     event ApplyOwnership(address admin);
     event CommitOwnership(address admin);

--- a/crates/json-abi/tests/abi/GaugeController.sol
+++ b/crates/json-abi/tests/abi/GaugeController.sol
@@ -1,6 +1,4 @@
 interface GaugeController {
-    constructor(address _token, address _voting_escrow);
-
     event AddType(string name, int128 type_id);
     event ApplyOwnership(address admin);
     event CommitOwnership(address admin);
@@ -8,6 +6,8 @@ interface GaugeController {
     event NewGaugeWeight(address gauge_address, uint256 time, uint256 weight, uint256 total_weight);
     event NewTypeWeight(int128 type_id, uint256 time, uint256 weight, uint256 total_weight);
     event VoteForGauge(uint256 time, address user, address gauge_addr, uint256 weight);
+
+    constructor(address _token, address _voting_escrow);
 
     function add_gauge(address addr, int128 gauge_type, uint256 weight) external;
     function add_type(string memory _name, uint256 weight) external;

--- a/crates/json-abi/tests/abi/GnosisSafe.sol
+++ b/crates/json-abi/tests/abi/GnosisSafe.sol
@@ -1,6 +1,8 @@
 interface GnosisSafe {
     type Operation is uint8;
 
+    constructor();
+
     event AddedOwner(address owner);
     event ApproveHash(bytes32 indexed approvedHash, address indexed owner);
     event ChangedMasterCopy(address masterCopy);

--- a/crates/json-abi/tests/abi/GnosisSafe.sol
+++ b/crates/json-abi/tests/abi/GnosisSafe.sol
@@ -1,8 +1,6 @@
 interface GnosisSafe {
     type Operation is uint8;
 
-    constructor();
-
     event AddedOwner(address owner);
     event ApproveHash(bytes32 indexed approvedHash, address indexed owner);
     event ChangedMasterCopy(address masterCopy);
@@ -15,6 +13,8 @@ interface GnosisSafe {
     event ExecutionSuccess(bytes32 txHash, uint256 payment);
     event RemovedOwner(address owner);
     event SignMsg(bytes32 indexed msgHash);
+
+    constructor();
 
     fallback() external payable;
 

--- a/crates/json-abi/tests/abi/Junkyard.sol
+++ b/crates/json-abi/tests/abi/Junkyard.sol
@@ -1,6 +1,4 @@
 interface Junkyard {
-    constructor(address[] jkdPayees, uint256[] jkdShares, address _gateway, address _gasReceiver);
-
     error InvalidAddress();
     error InvalidAddressString();
     error NotApprovedByGateway();
@@ -16,6 +14,8 @@ interface Junkyard {
     event PaymentReleased(address to, uint256 amount);
     event PricesChange(uint256, uint256);
     event Unpaused(address account);
+
+    constructor(address[] jkdPayees, uint256[] jkdShares, address _gateway, address _gasReceiver);
 
     receive() external payable;
 

--- a/crates/json-abi/tests/abi/Junkyard.sol
+++ b/crates/json-abi/tests/abi/Junkyard.sol
@@ -1,4 +1,6 @@
 interface Junkyard {
+    constructor(address[] jkdPayees, uint256[] jkdShares, address _gateway, address _gasReceiver);
+
     error InvalidAddress();
     error InvalidAddressString();
     error NotApprovedByGateway();

--- a/crates/json-abi/tests/abi/LiquidityGaugeV4.sol
+++ b/crates/json-abi/tests/abi/LiquidityGaugeV4.sol
@@ -1,6 +1,4 @@
 interface LiquidityGaugeV4 {
-    constructor();
-
     event ApplyOwnership(address admin);
     event Approval(address indexed _owner, address indexed _spender, uint256 _value);
     event CommitOwnership(address admin);
@@ -9,6 +7,8 @@ interface LiquidityGaugeV4 {
     event Transfer(address indexed _from, address indexed _to, uint256 _value);
     event UpdateLiquidityLimit(address user, uint256 original_balance, uint256 original_supply, uint256 working_balance, uint256 working_supply);
     event Withdraw(address indexed provider, uint256 value);
+
+    constructor();
 
     function SDT() external view returns (address);
     function accept_transfer_ownership() external;

--- a/crates/json-abi/tests/abi/LiquidityGaugeV4.sol
+++ b/crates/json-abi/tests/abi/LiquidityGaugeV4.sol
@@ -1,4 +1,6 @@
 interface LiquidityGaugeV4 {
+    constructor();
+
     event ApplyOwnership(address admin);
     event Approval(address indexed _owner, address indexed _spender, uint256 _value);
     event CommitOwnership(address admin);

--- a/crates/json-abi/tests/abi/Seaport.sol
+++ b/crates/json-abi/tests/abi/Seaport.sol
@@ -113,8 +113,6 @@ interface Seaport {
         uint256 amount;
     }
 
-    constructor(address conduitController);
-
     error BadContractSignature();
     error BadFraction();
     error BadReturnValueFromERC20OnTransfer(address token, address from, address to, uint256 amount);
@@ -166,6 +164,8 @@ interface Seaport {
     event OrderFulfilled(bytes32 orderHash, address indexed offerer, address indexed zone, address recipient, SpentItem[] offer, ReceivedItem[] consideration);
     event OrderValidated(bytes32 orderHash, OrderParameters orderParameters);
     event OrdersMatched(bytes32[] orderHashes);
+
+    constructor(address conduitController);
 
     receive() external payable;
 

--- a/crates/json-abi/tests/abi/Seaport.sol
+++ b/crates/json-abi/tests/abi/Seaport.sol
@@ -113,6 +113,8 @@ interface Seaport {
         uint256 amount;
     }
 
+    constructor(address conduitController);
+
     error BadContractSignature();
     error BadFraction();
     error BadReturnValueFromERC20OnTransfer(address token, address from, address to, uint256 amount);

--- a/crates/json-abi/tests/abi/UniswapV2Factory.sol
+++ b/crates/json-abi/tests/abi/UniswapV2Factory.sol
@@ -1,4 +1,6 @@
 interface UniswapV2Factory {
+    constructor(address _feeToSetter);
+
     event PairCreated(address indexed token0, address indexed token1, address pair, uint256);
 
     function allPairs(uint256) external view returns (address);

--- a/crates/json-abi/tests/abi/UniswapV2Factory.sol
+++ b/crates/json-abi/tests/abi/UniswapV2Factory.sol
@@ -1,7 +1,7 @@
 interface UniswapV2Factory {
-    constructor(address _feeToSetter);
-
     event PairCreated(address indexed token0, address indexed token1, address pair, uint256);
+
+    constructor(address _feeToSetter);
 
     function allPairs(uint256) external view returns (address);
     function allPairsLength() external view returns (uint256);

--- a/crates/json-abi/tests/abi/UniswapV2FactoryWithMigrator.sol
+++ b/crates/json-abi/tests/abi/UniswapV2FactoryWithMigrator.sol
@@ -1,7 +1,7 @@
 interface UniswapV2FactoryWithMigrator {
-    constructor(address _feeToSetter);
-
     event PairCreated(address indexed token0, address indexed token1, address pair, uint256);
+
+    constructor(address _feeToSetter);
 
     function allPairs(uint256) external view returns (address);
     function allPairsLength() external view returns (uint256);

--- a/crates/json-abi/tests/abi/UniswapV2FactoryWithMigrator.sol
+++ b/crates/json-abi/tests/abi/UniswapV2FactoryWithMigrator.sol
@@ -1,4 +1,6 @@
 interface UniswapV2FactoryWithMigrator {
+    constructor(address _feeToSetter);
+
     event PairCreated(address indexed token0, address indexed token1, address pair, uint256);
 
     function allPairs(uint256) external view returns (address);

--- a/crates/json-abi/tests/abi/ZRXToken.sol
+++ b/crates/json-abi/tests/abi/ZRXToken.sol
@@ -2,6 +2,8 @@ interface ZRXToken {
     event Approval(address indexed _owner, address indexed _spender, uint256 _value);
     event Transfer(address indexed _from, address indexed _to, uint256 _value);
 
+    constructor();
+
     function allowance(address _owner, address _spender) external returns (uint256);
     function approve(address _spender, uint256 _value) external returns (bool);
     function balanceOf(address _owner) external returns (uint256);

--- a/crates/json-abi/tests/abi/ZeroXExchange.sol
+++ b/crates/json-abi/tests/abi/ZeroXExchange.sol
@@ -1,11 +1,11 @@
 interface ZeroXExchange {
-    constructor(bytes _zrxAssetData);
-
     event AssetProxyRegistered(bytes4 id, address assetProxy);
     event Cancel(address indexed makerAddress, address indexed feeRecipientAddress, address senderAddress, bytes32 indexed orderHash, bytes makerAssetData, bytes takerAssetData);
     event CancelUpTo(address indexed makerAddress, address indexed senderAddress, uint256 orderEpoch);
     event Fill(address indexed makerAddress, address indexed feeRecipientAddress, address takerAddress, address senderAddress, uint256 makerAssetFilledAmount, uint256 takerAssetFilledAmount, uint256 makerFeePaid, uint256 takerFeePaid, bytes32 indexed orderHash, bytes makerAssetData, bytes takerAssetData);
     event SignatureValidatorApproval(address indexed signerAddress, address indexed validatorAddress, bool approved);
+
+    constructor(bytes _zrxAssetData);
 
     function EIP712_DOMAIN_HASH() external view returns (bytes32);
     function VERSION() external view returns (string memory);

--- a/crates/json-abi/tests/abi/ZeroXExchange.sol
+++ b/crates/json-abi/tests/abi/ZeroXExchange.sol
@@ -1,4 +1,6 @@
 interface ZeroXExchange {
+    constructor(bytes _zrxAssetData);
+
     event AssetProxyRegistered(bytes4 id, address assetProxy);
     event Cancel(address indexed makerAddress, address indexed feeRecipientAddress, address senderAddress, bytes32 indexed orderHash, bytes makerAssetData, bytes takerAssetData);
     event CancelUpTo(address indexed makerAddress, address indexed senderAddress, uint256 orderEpoch);

--- a/crates/sol-macro/src/expand/function.rs
+++ b/crates/sol-macro/src/expand/function.rs
@@ -30,7 +30,7 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, function: &ItemFunction) -> Result<TokenS
         return expand_constructor(cx, function);
     }
 
-    let Option::Some(_) = name else {
+    if name.is_none() {
         // ignore functions without names (modifiers...)
         return Ok(quote!());
     };

--- a/crates/sol-macro/src/expand/function.rs
+++ b/crates/sol-macro/src/expand/function.rs
@@ -2,9 +2,9 @@
 
 use super::{expand_fields, expand_from_into_tuples, expand_tokenize, expand_tuple_types, ExpCtxt};
 use crate::attr;
-use ast::ItemFunction;
+use ast::{FunctionKind, ItemFunction};
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::Result;
 
 /// Expands an [`ItemFunction`]:
@@ -24,10 +24,17 @@ use syn::Result;
 /// }
 /// ```
 pub(super) fn expand(cx: &ExpCtxt<'_>, function: &ItemFunction) -> Result<TokenStream> {
-    let ItemFunction { attrs, parameters, returns, name: Some(_), .. } = function else {
-        // ignore functions without names (constructors, modifiers...)
+    let ItemFunction { attrs, parameters, returns, name, kind, .. } = function;
+
+    if matches!(kind, FunctionKind::Constructor(_)) {
+        return expand_constructor(cx, function);
+    }
+
+    let Option::Some(_) = name else {
+        // ignore functions without names (modifiers...)
         return Ok(quote!());
     };
+
     let returns = returns.as_ref().map(|r| &r.returns).unwrap_or_default();
 
     cx.assert_resolved(parameters)?;
@@ -139,6 +146,54 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, function: &ItemFunction) -> Result<TokenS
             }
 
             #abi
+        };
+    };
+    Ok(tokens)
+}
+
+fn expand_constructor(cx: &ExpCtxt<'_>, constructor: &ItemFunction) -> Result<TokenStream> {
+    let ItemFunction { attrs, parameters, .. } = constructor;
+
+    let (sol_attrs, call_attrs) = crate::attr::SolAttrs::parse(attrs)?;
+    let docs = sol_attrs.docs.or(cx.attrs.docs).unwrap_or(true);
+    let call_name = format_ident!("constructorCall");
+    let call_fields = expand_fields(parameters);
+    let call_tuple = expand_tuple_types(parameters.types()).0;
+    let converts = expand_from_into_tuples(&call_name, parameters);
+    let tokenize_impl = expand_tokenize(parameters);
+
+    let call_doc = docs.then(|| {
+        attr::mk_doc(format!(
+            "Constructor`.\n\
+            ```solidity\n{constructor}\n```"
+        ))
+    });
+
+    let tokens = quote! {
+        #(#call_attrs)*
+        #call_doc
+        #[allow(non_camel_case_types, non_snake_case)]
+        #[derive(Clone)]
+        pub struct #call_name {
+            #(#call_fields),*
+        }
+
+        const _: () = {
+            { #converts }
+
+            #[automatically_derived]
+            impl ::alloy_sol_types::SolConstructor for #call_name {
+                type Parameters<'a> = #call_tuple;
+                type Token<'a> = <Self::Parameters<'a> as ::alloy_sol_types::SolType>::Token<'a>;
+
+                fn new<'a>(tuple: <Self::Parameters<'a> as ::alloy_sol_types::SolType>::RustType) -> Self {
+                    tuple.into()
+                }
+
+                fn tokenize(&self) -> Self::Token<'_> {
+                    #tokenize_impl
+                }
+            }
         };
     };
     Ok(tokens)

--- a/crates/sol-types/src/lib.rs
+++ b/crates/sol-types/src/lib.rs
@@ -183,8 +183,8 @@ mod impl_core;
 mod types;
 pub use types::{
     data_type as sol_data, decode_revert_reason, ContractError, EventTopic, GenericContractError,
-    GenericRevertReason, Panic, PanicKind, Revert, Selectors, SolCall, SolEnum, SolError, SolEvent,
-    SolEventInterface, SolInterface, SolStruct, SolType, SolValue, TopicList,
+    GenericRevertReason, Panic, PanicKind, Revert, Selectors, SolCall, SolConstructor, SolEnum,
+    SolError, SolEvent, SolEventInterface, SolInterface, SolStruct, SolType, SolValue, TopicList,
 };
 
 pub mod utils;

--- a/crates/sol-types/src/types/function.rs
+++ b/crates/sol-types/src/types/function.rs
@@ -101,3 +101,41 @@ pub trait SolCall: Sized {
         crate::abi::encode_sequence(&e.stv_to_tokens())
     }
 }
+
+/// A Solidity constructor.
+pub trait SolConstructor: Sized {
+    /// The underlying tuple type which represents this type's arguments.
+    ///
+    /// If this type has no arguments, this will be the unit type `()`.
+    type Parameters<'a>: SolType<Token<'a> = Self::Token<'a>>;
+
+    /// The arguments' corresponding [TokenSeq] type.
+    type Token<'a>: TokenSeq<'a>;
+
+    /// Convert from the tuple type used for ABI encoding and decoding.
+    fn new(tuple: <Self::Parameters<'_> as SolType>::RustType) -> Self;
+
+    /// Tokenize the call's arguments.
+    fn tokenize(&self) -> Self::Token<'_>;
+
+    /// The size of the encoded data in bytes.
+    #[inline]
+    fn abi_encoded_size(&self) -> usize {
+        if let Some(size) = <Self::Parameters<'_> as SolType>::ENCODED_SIZE {
+            return size;
+        }
+
+        // `total_words` includes the first dynamic offset which we ignore.
+        let offset = <<Self::Parameters<'_> as SolType>::Token<'_> as Token>::DYNAMIC as usize * 32;
+        (self.tokenize().total_words() * Word::len_bytes()).saturating_sub(offset)
+    }
+
+    /// ABI encode the call to the given buffer.
+    #[inline]
+    fn abi_encode(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(self.abi_encoded_size());
+        out.reserve(self.abi_encoded_size());
+        out.extend(crate::abi::encode_sequence(&self.tokenize()));
+        out
+    }
+}

--- a/crates/sol-types/src/types/function.rs
+++ b/crates/sol-types/src/types/function.rs
@@ -133,9 +133,6 @@ pub trait SolConstructor: Sized {
     /// ABI encode the call to the given buffer.
     #[inline]
     fn abi_encode(&self) -> Vec<u8> {
-        let mut out = Vec::with_capacity(self.abi_encoded_size());
-        out.reserve(self.abi_encoded_size());
-        out.extend(crate::abi::encode_sequence(&self.tokenize()));
-        out
+        crate::abi::encode_sequence(&self.tokenize())
     }
 }

--- a/crates/sol-types/src/types/mod.rs
+++ b/crates/sol-types/src/types/mod.rs
@@ -10,7 +10,7 @@ mod event;
 pub use event::{EventTopic, SolEvent, TopicList};
 
 mod function;
-pub use function::SolCall;
+pub use function::{SolCall, SolConstructor};
 
 mod interface;
 pub use interface::{

--- a/crates/sol-types/tests/doctests/contracts.rs
+++ b/crates/sol-types/tests/doctests/contracts.rs
@@ -1,12 +1,14 @@
 use alloy_primitives::{address, hex, U256};
-use alloy_sol_types::{sol, SolCall, SolInterface};
+use alloy_sol_types::{sol, SolCall, SolConstructor, SolInterface};
 
 sol! {
     /// Interface of the ERC20 standard as defined in [the EIP].
     ///
     /// [the EIP]: https://eips.ethereum.org/EIPS/eip-20
     #[derive(Debug, PartialEq, Eq)]
-    interface IERC20 {
+    contract ERC20 {
+        constructor(string name, string symbol);
+
         event Transfer(address indexed from, address indexed to, uint256 value);
         event Approval(address indexed owner, address indexed spender, uint256 value);
 
@@ -20,7 +22,17 @@ sol! {
 }
 
 #[test]
-fn contracts() {
+fn constructor() {
+    let constructor_args =
+        ERC20::constructorCall::new((String::from("Wrapped Ether"), String::from("WETH")))
+            .abi_encode();
+    let constructor_args_expected = hex!("00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000d577261707065642045746865720000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000045745544800000000000000000000000000000000000000000000000000000000");
+
+    assert_eq!(constructor_args.as_slice(), constructor_args_expected);
+}
+
+#[test]
+fn transfer() {
     // random mainnet ERC20 transfer
     // https://etherscan.io/tx/0x947332ff624b5092fb92e8f02cdbb8a50314e861a4b39c29a286b3b75432165e
     let data = hex!(
@@ -28,13 +40,13 @@ fn contracts() {
         "0000000000000000000000008bc47be1e3abbaba182069c89d08a61fa6c2b292"
         "0000000000000000000000000000000000000000000000000000000253c51700"
     );
-    let expected = IERC20::transferCall {
+    let expected = ERC20::transferCall {
         to: address!("8bc47be1e3abbaba182069c89d08a61fa6c2b292"),
         amount: U256::from(9995360000_u64),
     };
 
-    assert_eq!(data[..4], IERC20::transferCall::SELECTOR);
-    let decoded = IERC20::IERC20Calls::abi_decode(&data, true).unwrap();
-    assert_eq!(decoded, IERC20::IERC20Calls::transfer(expected));
+    assert_eq!(data[..4], ERC20::transferCall::SELECTOR);
+    let decoded = ERC20::ERC20Calls::abi_decode(&data, true).unwrap();
+    assert_eq!(decoded, ERC20::ERC20Calls::transfer(expected));
     assert_eq!(decoded.abi_encode(), data);
 }

--- a/crates/sol-types/tests/macros/sol/json.rs
+++ b/crates/sol-types/tests/macros/sol/json.rs
@@ -45,6 +45,9 @@ fn seaport() {
     sol!(Seaport, "../json-abi/tests/abi/Seaport.json");
     use Seaport::*;
 
+    // Constructor with a single argument
+    let _ = constructorCall { conduitController: Address::ZERO };
+
     // BasicOrderType is a uint8 UDVT
     let _ = BasicOrderType::from(0u8);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

I needed to encode constructor args to create a contract creation tx, and saw #482.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

### In `sol-types`

* Adding `SolConstructor` trait 
* Handle constructor in `function::expand()` (creating a constructorCall struct  that impl `SolConstructor`)

### In `json-abi`

* impl `ToSol` for `Constructor`
* Adding `AbiFunctionKw::Constructor` variant
* Update fixtures in "tests/abi"
 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
