### PR TITLE
feat(`primitives`): Add `y_parity_byte_non_eip155` to `Parity`

### DIFF
--- a/crates/primitives/src/signature/parity.rs
+++ b/crates/primitives/src/signature/parity.rs
@@ -83,6 +83,15 @@ impl Parity {
         self.y_parity() as u8
     }
 
+    /// Return the y-parity byte as 27 or 28,
+    /// In the case of a non-EIP155 signature.
+    pub const fn y_parity_byte_legacy(&self) -> Option<u8> {
+        match self {
+            Self::NonEip155(v) => Some(*v as u8 + 27),
+            _ => None,
+        }
+    }
+
     /// Inverts the parity.
     pub const fn inverted(&self) -> Self {
         match *self {

--- a/crates/primitives/src/signature/parity.rs
+++ b/crates/primitives/src/signature/parity.rs
@@ -87,7 +87,7 @@ impl Parity {
     /// in the case of a non-EIP155 signature.
     pub const fn y_parity_byte_non_eip155(&self) -> Option<u8> {
         match self {
-            Self::NonEip155(v) => Some(*v as u8 + 27),
+            Self::NonEip155(v) | Self::Parity(v) => Some(*v as u8 + 27),
             _ => None,
         }
     }

--- a/crates/primitives/src/signature/parity.rs
+++ b/crates/primitives/src/signature/parity.rs
@@ -85,7 +85,7 @@ impl Parity {
 
     /// Return the y-parity byte as 27 or 28,
     /// In the case of a non-EIP155 signature.
-    pub const fn y_parity_byte_legacy(&self) -> Option<u8> {
+    pub const fn y_parity_byte_non_eip155(&self) -> Option<u8> {
         match self {
             Self::NonEip155(v) => Some(*v as u8 + 27),
             _ => None,

--- a/crates/primitives/src/signature/parity.rs
+++ b/crates/primitives/src/signature/parity.rs
@@ -84,7 +84,7 @@ impl Parity {
     }
 
     /// Return the y-parity byte as 27 or 28,
-    /// In the case of a non-EIP155 signature.
+    /// in the case of a non-EIP155 signature.
     pub const fn y_parity_byte_non_eip155(&self) -> Option<u8> {
         match self {
             Self::NonEip155(v) => Some(*v as u8 + 27),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

In the case of a signature without EIP155 applied, the `y_parity` byte should be returned as 27 or 28. `y_parity_byte` only returns it as `{0,1}`.

## Solution

 This adds a fn `y_parity_byte_non_eip155` which, when not having an EIP155 parity, we get 27 or 28, or `None` otherwise.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
