### PR TITLE
fix(`signature`): construct Signature bytes using v+27 when we do not have an EIP155 `v`

### DIFF
--- a/crates/primitives/src/signature/parity.rs
+++ b/crates/primitives/src/signature/parity.rs
@@ -83,6 +83,15 @@ impl Parity {
         self.y_parity() as u8
     }
 
+    /// Return the y-parity byte as 27 or 28,
+    /// In the case of a non-EIP155 signature.
+    pub const fn y_parity_byte_legacy(&self) -> Option<u8> {
+        match self {
+            Self::NonEip155(v) => Some(*v as u8 + 27),
+            _ => None,
+        }
+    }
+
     /// Inverts the parity.
     pub const fn inverted(&self) -> Self {
         match *self {

--- a/crates/primitives/src/signature/parity.rs
+++ b/crates/primitives/src/signature/parity.rs
@@ -87,7 +87,7 @@ impl Parity {
     /// in the case of a non-EIP155 signature.
     pub const fn y_parity_byte_non_eip155(&self) -> Option<u8> {
         match self {
-            Self::NonEip155(v) => Some(*v as u8 + 27),
+            Self::NonEip155(v) | Self::Parity(v) => Some(*v as u8 + 27),
             _ => None,
         }
     }

--- a/crates/primitives/src/signature/parity.rs
+++ b/crates/primitives/src/signature/parity.rs
@@ -85,7 +85,7 @@ impl Parity {
 
     /// Return the y-parity byte as 27 or 28,
     /// In the case of a non-EIP155 signature.
-    pub const fn y_parity_byte_legacy(&self) -> Option<u8> {
+    pub const fn y_parity_byte_non_eip155(&self) -> Option<u8> {
         match self {
             Self::NonEip155(v) => Some(*v as u8 + 27),
             _ => None,

--- a/crates/primitives/src/signature/parity.rs
+++ b/crates/primitives/src/signature/parity.rs
@@ -84,7 +84,7 @@ impl Parity {
     }
 
     /// Return the y-parity byte as 27 or 28,
-    /// In the case of a non-EIP155 signature.
+    /// in the case of a non-EIP155 signature.
     pub const fn y_parity_byte_non_eip155(&self) -> Option<u8> {
         match self {
             Self::NonEip155(v) => Some(*v as u8 + 27),

--- a/crates/primitives/src/signature/sig.rs
+++ b/crates/primitives/src/signature/sig.rs
@@ -328,7 +328,7 @@ impl<S> Signature<S> {
         let mut sig = [0u8; 65];
         sig[..32].copy_from_slice(&self.r.to_be_bytes::<32>());
         sig[32..64].copy_from_slice(&self.s.to_be_bytes::<32>());
-        sig[64] = self.v.y_parity_byte();
+        sig[64] = self.v.y_parity_byte_non_eip155().unwrap_or(self.v.y_parity_byte());
         sig
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Followup for #499.

## Solution

In the cases when we do not have an EIP155 v, construct the signature using `y_parity_byte_non_eip155`, to add `27` to v if necessary.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
