### PR TITLE
perf(sol-macro): use a lookup table when generating `SolInterface::abi_decode_raw`

### DIFF
--- a/crates/sol-macro/src/utils.rs
+++ b/crates/sol-macro/src/utils.rs
@@ -32,6 +32,7 @@ pub fn combine_errors(v: impl IntoIterator<Item = syn::Error>) -> syn::Result<()
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct ExprArray<T> {
     pub array: Vec<T>,
     pub span: Span,


### PR DESCRIPTION
Faster and maybe less binary size