### PR TITLE
feat: derive Allocative on FixedBytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,4 @@ ruint = { version = "1.11.1", default-features = false, features = ["alloc"] }
 ruint-macro = { version = "1", default-features = false }
 winnow = { version = "0.5.39", default-features = false, features = ["alloc"] }
 postgres-types = "0.2.6"
+allocative = { version = "0.3.2", default-features = false }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -54,6 +54,9 @@ derive_arbitrary = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
+# allocative
+allocative = { workspace = true, optional = true }
+
 # postgres
 postgres-types = { workspace = true, optional = true }
 
@@ -97,6 +100,7 @@ arbitrary = [
     "ethereum_ssz?/arbitrary",
 ]
 k256 = ["dep:k256"]
+allocative = ["dep:allocative"]
 
 # `const-hex` compatibility feature for `hex`.
 # Should not be needed most of the time.

--- a/crates/primitives/src/bits/fixed.rs
+++ b/crates/primitives/src/bits/fixed.rs
@@ -27,6 +27,7 @@ use derive_more::{Deref, DerefMut, From, Index, IndexMut, IntoIterator};
     IntoIterator,
 )]
 #[cfg_attr(feature = "arbitrary", derive(derive_arbitrary::Arbitrary, proptest_derive::Arbitrary))]
+#[cfg_attr(feature = "allocative", derive(allocative::Allocative))]
 #[repr(transparent)]
 pub struct FixedBytes<const N: usize>(#[into_iterator(owned, ref, ref_mut)] pub [u8; N]);
 


### PR DESCRIPTION
## Motivation

Recently I was introduced to https://github.com/facebookexperimental/allocative, which seems promising as an easy way to collect granular information about certain data structures' memory usage in reth.

## Solution

Introduce the `allocative` feature into `primitives`, and to start, derive the `Allocative` trait on FixedBytes.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
