### PR TITLE
docs: fix relative paths in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ This repository contains the following crates:
 - [`alloy-sol-type-parser`] - A simple parser for Solidity type strings
 - [`syn-solidity`] - [`syn`]-powered Solidity parser
 
-[`alloy-core`]: ./crates/core
-[`alloy-primitives`]: ./crates/primitives
-[`alloy-sol-types`]: ./crates/sol-types
-[`alloy-sol-macro`]: ./crates/sol-macro
-[`alloy-dyn-abi`]: ./crates/dyn-abi
-[`alloy-json-abi`]: ./crates/json-abi
-[`alloy-sol-type-parser`]: ./crates/sol-type-parser
-[`syn-solidity`]: ./crates/syn-solidity
+[`alloy-core`]: /crates/core
+[`alloy-primitives`]: /crates/primitives
+[`alloy-sol-types`]: /crates/sol-types
+[`alloy-sol-macro`]: /crates/sol-macro
+[`alloy-dyn-abi`]: /crates/dyn-abi
+[`alloy-json-abi`]: /crates/json-abi
+[`alloy-sol-type-parser`]: /crates/sol-type-parser
+[`syn-solidity`]: /crates/syn-solidity
 [JSON-ABI]: https://docs.soliditylang.org/en/latest/abi-spec.html#json
 [ABI]: https://docs.soliditylang.org/en/latest/abi-spec.html
 [EIP-712]: https://eips.ethereum.org/EIPS/eip-712


### PR DESCRIPTION
## Motivation

Since the main README.md file from the root of the repository is used in the `crates/core` dir as well, the relative paths were not working. You can try to access any of the relative paths in the `overview` section of the README.md file in `crates/core` of the main repository here: https://github.com/alloy-rs/core/tree/main/crates/core
As you notice, none of them work.

## Solution

I merely changed the relative paths so that they all start at the root.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
