### PR TITLE
feat(core): re-export `uint!`

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -20,7 +20,7 @@
 #[doc(inline)]
 pub use alloy_primitives as primitives;
 #[doc(no_inline)]
-pub use primitives::hex;
+pub use primitives::{hex, uint};
 
 #[cfg(feature = "dyn-abi")]
 #[doc(inline)]

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -72,13 +72,8 @@ pub use {
     ::bytes,
     ::hex,
     hex_literal::{self, hex},
-    ruint::{self, Uint},
+    ruint::{self, uint, Uint},
 };
-
-/// Re-export of [`ruint::uint!`] for convenience. Note that users of this macro
-/// must also add [`ruint`] to their `Cargo.toml` as a dependency.
-#[doc(inline)]
-pub use ruint::uint;
 
 #[cfg(feature = "serde")]
 #[doc(no_inline)]


### PR DESCRIPTION
And removes the doc override added in https://github.com/alloy-rs/core/pull/265 thanks to https://github.com/recmo/uint/pull/351 (blocked on a new release first).