### PR TITLE
refactor: change identical resolve traits to Specifier<T>

### DIFF
--- a/crates/dyn-abi/benches/types.rs
+++ b/crates/dyn-abi/benches/types.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::incompatible_msrv)]
 
-use alloy_dyn_abi::{DynSolType, ResolveSolType};
+use alloy_dyn_abi::{DynSolType, Specifier};
 use alloy_sol_type_parser::TypeSpecifier;
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,

--- a/crates/dyn-abi/src/eip712/resolver.rs
+++ b/crates/dyn-abi/src/eip712/resolver.rs
@@ -1,6 +1,6 @@
 use crate::{
-    eip712::typed_data::Eip712Types, eip712_parser::EncodeType, resolve::ResolveSolType,
-    DynSolType, DynSolValue, Error, Result,
+    eip712::typed_data::Eip712Types, eip712_parser::EncodeType, DynSolType, DynSolValue, Error,
+    Result, Specifier,
 };
 use alloc::{
     borrow::ToOwned,

--- a/crates/dyn-abi/src/ext/abi.rs
+++ b/crates/dyn-abi/src/ext/abi.rs
@@ -1,4 +1,4 @@
-use crate::{DynSolValue, Error as CrateError, ResolveSolType, Result};
+use crate::{DynSolValue, Error as CrateError, Result, Specifier};
 use alloc::vec::Vec;
 use alloy_json_abi::{Constructor, Error, Function, Param};
 use alloy_primitives::Selector;

--- a/crates/dyn-abi/src/ext/event.rs
+++ b/crates/dyn-abi/src/ext/event.rs
@@ -1,6 +1,4 @@
-use crate::{
-    resolve::ResolveSolEvent, DecodedEvent, DynSolEvent, DynSolType, Error, ResolveSolType, Result,
-};
+use crate::{DecodedEvent, DynSolEvent, DynSolType, Error, Result, Specifier};
 use alloc::vec::Vec;
 use alloy_json_abi::Event;
 use alloy_primitives::{LogData, B256};
@@ -11,7 +9,7 @@ mod sealed {
 }
 use sealed::Sealed;
 
-impl ResolveSolEvent for Event {
+impl Specifier<DynSolEvent> for Event {
     fn resolve(&self) -> Result<DynSolEvent> {
         let mut indexed = Vec::with_capacity(self.inputs.len());
         let mut body = Vec::with_capacity(self.inputs.len());
@@ -72,7 +70,7 @@ impl EventExt for Event {
     where
         I: IntoIterator<Item = B256>,
     {
-        ResolveSolEvent::resolve(self)?.decode_log_parts(topics, data, validate)
+        Specifier::resolve(self)?.decode_log_parts(topics, data, validate)
     }
 }
 

--- a/crates/dyn-abi/src/lib.rs
+++ b/crates/dyn-abi/src/lib.rs
@@ -55,7 +55,7 @@ mod token;
 pub use token::DynToken;
 
 mod resolve;
-pub use resolve::{ResolveSolEvent, ResolveSolType};
+pub use resolve::Specifier;
 
 #[cfg(feature = "eip712")]
 pub mod eip712;

--- a/crates/dyn-abi/src/ty.rs
+++ b/crates/dyn-abi/src/ty.rs
@@ -1,4 +1,4 @@
-use crate::{resolve::ResolveSolType, DynSolValue, DynToken, Error, Result, SolType, Word};
+use crate::{DynSolValue, DynToken, Error, Result, SolType, Specifier, Word};
 use alloc::{borrow::Cow, boxed::Box, string::String, vec::Vec};
 use alloy_primitives::{
     try_vec,


### PR DESCRIPTION

## Motivation

Prep for more `DynSol____` by unifying resolution under the concept of a `Specifier<T>`. A specifier is any data that specifies a Solidity interface item. E.g. the string `"bytes memory"`,  the solidity code `function a()` or a JSON ABI object.

This PR preps for adding `DynSolFunc` and `DynSolError` and removal or modification of `JsonAbiExt` and related traits in favor of shortcut encoding traits blanket implemented on `Specifier<T>` 

## Solution

Unify `ResolveSolType` and `ResolveSolEvent` into `Specifier<T>`

## PR Checklist

- [ ] Added Tests
- [X] Added Documentation
- [X] Breaking changes
