### PR TITLE
feat: rlp encoding for logs with generic event data

### DIFF
--- a/crates/primitives/src/log.rs
+++ b/crates/primitives/src/log.rs
@@ -122,21 +122,49 @@ impl Log {
     }
 }
 
+impl<T> Log<T>
+where
+    for<'a> &'a T: Into<LogData>,
+{
+    /// Creates a new log.
+    #[inline]
+    pub const fn new_from_event_unchecked(address: Address, data: T) -> Self {
+        Self { address, data }
+    }
+
+    /// Creates a new log from an deserialized event.
+    pub fn new_from_event(address: Address, data: T) -> Option<Self> {
+        let this = Self::new_from_event_unchecked(address, data);
+        (&this.data).into().is_valid().then_some(this)
+    }
+
+    /// Reserialize the data.
+    #[inline]
+    pub fn reserialze(&self) -> Log<LogData> {
+        Log { address: self.address, data: (&self.data).into() }
+    }
+}
+
 #[cfg(feature = "rlp")]
-impl alloy_rlp::Encodable for Log {
+impl<T> alloy_rlp::Encodable for Log<T>
+where
+    for<'a> &'a T: Into<LogData>,
+{
     fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
+        let this = self.reserialze();
         let payload_length =
-            self.address.length() + self.data.data.length() + self.data.topics.length();
+            this.address.length() + this.data.data.length() + this.data.topics.length();
 
         alloy_rlp::Header { list: true, payload_length }.encode(out);
-        self.address.encode(out);
-        self.data.topics.encode(out);
-        self.data.data.encode(out);
+        this.address.encode(out);
+        this.data.topics.encode(out);
+        this.data.data.encode(out);
     }
 
     fn length(&self) -> usize {
+        let this = self.reserialze();
         let payload_length =
-            self.address.length() + self.data.data.length() + self.data.topics.length();
+            this.address.length() + this.data.data.length() + this.data.topics.length();
         payload_length + alloy_rlp::length_of_length(payload_length)
     }
 }

--- a/crates/primitives/src/log.rs
+++ b/crates/primitives/src/log.rs
@@ -140,7 +140,7 @@ where
 
     /// Reserialize the data.
     #[inline]
-    pub fn reserialze(&self) -> Log<LogData> {
+    pub fn reserialize(&self) -> Log<LogData> {
         Log { address: self.address, data: (&self.data).into() }
     }
 }
@@ -151,7 +151,7 @@ where
     for<'a> &'a T: Into<LogData>,
 {
     fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
-        let this = self.reserialze();
+        let this = self.reserialize();
         let payload_length =
             this.address.length() + this.data.data.length() + this.data.topics.length();
 
@@ -162,7 +162,7 @@ where
     }
 
     fn length(&self) -> usize {
-        let this = self.reserialze();
+        let this = self.reserialize();
         let payload_length =
             this.address.length() + this.data.data.length() + this.data.topics.length();
         payload_length + alloy_rlp::length_of_length(payload_length)

--- a/crates/sol-macro/src/expand/event.rs
+++ b/crates/sol-macro/src/expand/event.rs
@@ -193,6 +193,15 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, event: &ItemEvent) -> Result<TokenStream>
                 }
             }
 
+            impl From<&#name> for alloy_sol_types::private::LogData {
+                #[inline]
+                fn from(this: &#name) -> alloy_sol_types::private::LogData {
+                    let topics = alloy_sol_types::SolEvent::encode_topics(this).into_iter().map(|t| t.into()).collect();
+                    let data = alloy_sol_types::SolEvent::encode_data(this).into();
+                    alloy_sol_types::private::LogData::new_unchecked(topics, data)
+                }
+            }
+
             #abi
         };
     };

--- a/crates/sol-types/Cargo.toml
+++ b/crates/sol-types/Cargo.toml
@@ -30,7 +30,8 @@ alloy-json-abi = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
 
 [dev-dependencies]
-alloy-primitives = { workspace = true, features = ["arbitrary", "serde"] }
+alloy-primitives = { workspace = true, features = ["arbitrary", "serde", "rlp"] }
+alloy-rlp.workspace = true
 derive_more.workspace = true
 paste.workspace = true
 pretty_assertions.workspace = true

--- a/crates/sol-types/src/abi/token.rs
+++ b/crates/sol-types/src/abi/token.rs
@@ -125,6 +125,13 @@ impl From<Word> for WordToken {
     }
 }
 
+impl From<WordToken> for Word {
+    #[inline]
+    fn from(value: WordToken) -> Word {
+        value.0
+    }
+}
+
 impl From<bool> for WordToken {
     #[inline]
     fn from(value: bool) -> Self {

--- a/crates/sol-types/tests/doctests/events.rs
+++ b/crates/sol-types/tests/doctests/events.rs
@@ -75,6 +75,7 @@ fn event_rlp_roundtrip() {
 
     let mut rlp_encoded = vec![];
     rlpable_log.encode(&mut rlp_encoded);
+    assert_eq!(rlpable_log.length(), rlp_encoded.len());
 
     let rlp_decoded = Log::decode(&mut rlp_encoded.as_slice()).unwrap();
     assert_eq!(rlp_decoded, rlpable_log.reserialze());

--- a/crates/sol-types/tests/doctests/events.rs
+++ b/crates/sol-types/tests/doctests/events.rs
@@ -78,7 +78,7 @@ fn event_rlp_roundtrip() {
     assert_eq!(rlpable_log.length(), rlp_encoded.len());
 
     let rlp_decoded = Log::decode(&mut rlp_encoded.as_slice()).unwrap();
-    assert_eq!(rlp_decoded, rlpable_log.reserialze());
+    assert_eq!(rlp_decoded, rlpable_log.reserialize());
 
     let decoded_log = MyEvent::decode_log(&rlp_decoded, true).unwrap();
 

--- a/crates/sol-types/tests/doctests/events.rs
+++ b/crates/sol-types/tests/doctests/events.rs
@@ -1,10 +1,11 @@
 #![allow(clippy::assertions_on_constants)]
 
-use alloy_primitives::{hex, keccak256, B256, U256};
+use alloy_primitives::{hex, keccak256, Log, B256, U256};
+use alloy_rlp::{Decodable, Encodable};
 use alloy_sol_types::{abi::token::WordToken, sol, SolEvent};
 
 sol! {
-    #[derive(Default)]
+    #[derive(Default, PartialEq, Debug)]
     event MyEvent(bytes32 indexed a, uint256 b, string indexed c, bytes d);
 
     event LogNote(
@@ -59,6 +60,28 @@ fn event() {
 
     assert_event_signature::<MyEvent2>("MyEvent2((bytes))");
     assert!(!MyEvent2::ANONYMOUS);
+}
+
+#[test]
+fn event_rlp_roundtrip() {
+    let event = MyEvent {
+        a: [0x11; 32].into(),
+        b: U256::from(1u64),
+        c: keccak256("Hello World"),
+        d: Vec::new(),
+    };
+
+    let rlpable_log = Log::<MyEvent>::new_from_event_unchecked(Default::default(), event);
+
+    let mut rlp_encoded = vec![];
+    rlpable_log.encode(&mut rlp_encoded);
+
+    let rlp_decoded = Log::decode(&mut rlp_encoded.as_slice()).unwrap();
+    assert_eq!(rlp_decoded, rlpable_log.reserialze());
+
+    let decoded_log = MyEvent::decode_log(&rlp_decoded, true).unwrap();
+
+    assert_eq!(decoded_log, rlpable_log)
 }
 
 fn assert_event_signature<T: SolEvent>(expected: &str) {


### PR DESCRIPTION
closes #544

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Allow rlp encoding of logs after their data has been ABI decoded.

## Solution

Add a set of methods and a blanket Encode implementation for 
`Log<T> where for<'a> &'a T: Into<LogData>,`

Note that this change does not allow decoding, as that would require embedding the ABI error into the RLP error decode impl

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
