### PR TITLE
feat: add LogData::split

### DIFF
--- a/crates/primitives/src/log.rs
+++ b/crates/primitives/src/log.rs
@@ -73,6 +73,12 @@ impl LogData {
         topics.truncate(4);
         self.set_topics_unchecked(topics);
     }
+
+    /// Consumes the log data, returning the topic list and the data.
+    #[inline]
+    pub fn split(self) -> (Vec<B256>, Bytes) {
+        (self.topics, self.data)
+    }
 }
 
 /// A log consists of an address, and some log data.


### PR DESCRIPTION
ref https://github.com/paradigmxyz/reth/pull/7048

allow to consume all internals, this is convenient for conversions