### PR TITLE
fix: force clippy to stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - run: cargo clippy --workspace --all-targets --all-features
+      - run: cargo +stable clippy --workspace --all-targets --all-features
         env:
           RUSTFLAGS: -Dwarnings
 

--- a/crates/dyn-abi/benches/abi.rs
+++ b/crates/dyn-abi/benches/abi.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::incompatible_msrv)]
+#![allow(unknown_lints, clippy::incompatible_msrv)]
 
 use alloy_dyn_abi::{DynSolType, DynSolValue};
 use alloy_primitives::{hex, U256};

--- a/crates/dyn-abi/benches/types.rs
+++ b/crates/dyn-abi/benches/types.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::incompatible_msrv)]
+#![allow(unknown_lints, clippy::incompatible_msrv)]
 
 use alloy_dyn_abi::{DynSolType, Specifier};
 use alloy_sol_type_parser::TypeSpecifier;

--- a/crates/json-abi/benches/json_abi.rs
+++ b/crates/json-abi/benches/json_abi.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::incompatible_msrv)]
+#![allow(unknown_lints, clippy::incompatible_msrv)]
 
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,

--- a/crates/primitives/benches/primitives.rs
+++ b/crates/primitives/benches/primitives.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::incompatible_msrv)]
+#![allow(unknown_lints, clippy::incompatible_msrv)]
 
 use alloy_primitives::{keccak256, Address, B256};
 use criterion::{criterion_group, criterion_main, Criterion};


### PR DESCRIPTION
## Motivation

Prevent future random CI breakage

closes #566 

## Solution

Set clippy to stable in CI

there may be a better way to achieve this, but this way is straightforward

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
