### PR TITLE
docs: do not accept grammar prs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,11 @@ commit signing. This option allows us to make small changes to your PR to bring
 it in line with these standards. It helps us get your PR in faster, and with
 less work from you.
 
+### Contributions Related to Spelling and Grammar
+
+At this time, we will not be accepting contributions that only fix spelling or grammatical errors in documentation, code or
+elsewhere.
+
 ### Cargo Commands
 
 This section lists some commonly needed commands.

--- a/crates/primitives/src/postgres.rs
+++ b/crates/primitives/src/postgres.rs
@@ -115,7 +115,7 @@ impl<const BITS: usize, const LIMBS: usize> ToSql for Signed<BITS, LIMBS> {
             // Binary strings
             Type::BYTEA => out.put_slice(&self.0.to_be_bytes_vec()),
             Type::BIT | Type::VARBIT => {
-                // Bit in little-endian so the the first bit is the least significant.
+                // Bit in little-endian so the first bit is the least significant.
                 // Length must be at least one bit.
                 if BITS == 0 {
                     if *ty == Type::BIT {

--- a/crates/syn-solidity/tests/contracts/PrbMath.sol
+++ b/crates/syn-solidity/tests/contracts/PrbMath.sol
@@ -35,7 +35,7 @@ uint256 constant UNIT = 1e18;
 /// @dev The unit number inverted mod 2^256.
 uint256 constant UNIT_INVERSE = 78156646155174841979727994598816262306175212592076161876661_508869554232690281;
 
-/// @dev The the largest power of two that divides the decimal value of `UNIT`. The logarithm of this value is the least significant
+/// @dev The largest power of two that divides the decimal value of `UNIT`. The logarithm of this value is the least significant
 /// bit in the binary representation of `UNIT`.
 uint256 constant UNIT_LPOTD = 262144;
 


### PR DESCRIPTION
## Motivation

A common RPGF farming strategy is to open PRs to fix grammar/typos with a bot

## Solution

Don't allow it

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
