### PR TITLE
feat(sol-macro): allow missing docs for event fields

### DIFF
--- a/crates/sol-macro/src/expand/event.rs
+++ b/crates/sol-macro/src/expand/event.rs
@@ -139,7 +139,10 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, event: &ItemEvent) -> Result<TokenStream>
         #[allow(non_camel_case_types, non_snake_case, clippy::style)]
         #[derive(Clone)]
         pub struct #name {
-            #(pub #fields,)*
+            #(
+                #[allow(missing_docs)]
+                pub #fields,
+            )*
         }
 
         #[allow(non_camel_case_types, non_snake_case, clippy::style)]


### PR DESCRIPTION
See https://github.com/alloy-rs/core/issues/588#issuecomment-2094823588

## Motivation

We want this `sol!` invocation to not generate a `missing_docs` warning:

```rust
sol! {
    /// Emitted when `value` tokens are moved from one account (`from`) to
    /// another (`to`).
    ///
    /// Note that `value` may be zero.
    event Transfer(address indexed from, address indexed to, uint256 value);
    /// Emitted when the allowance of a `spender` for an `owner` is set by a
    /// call to `approve`. `value` is the new allowance.
    event Approval(address indexed owner, address indexed spender, uint256 value);
}
```

## Solution

We add an `#[allow(missing_docs)]` annotation to the generated event struct fields. The alternative would be supporting:

```rust
sol! {
    /// ...
    event Approval(
        /// ...
        address indexed owner,
        /// ...
        address indexed spender,
        /// ...
        uint256 value
    );
}
```

Which is less readable and redundant.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

I don't think the above apply, but lmk if that is not the case.