### PR TITLE
feat(dyn-abi): derive `Eq` for `TypedData`

### DIFF
--- a/crates/dyn-abi/src/eip712/resolver.rs
+++ b/crates/dyn-abi/src/eip712/resolver.rs
@@ -204,7 +204,7 @@ struct DfsContext<'a> {
 /// A dependency graph built from the `Eip712Types` object. This is used to
 /// safely resolve JSON into a [`crate::DynSolType`] by detecting cycles in the
 /// type graph and traversing the dep graph.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Resolver {
     /// Nodes in the graph
     // NOTE: Non-duplication of names must be enforced. See note on impl of Ord

--- a/crates/dyn-abi/src/eip712/typed_data.rs
+++ b/crates/dyn-abi/src/eip712/typed_data.rs
@@ -63,7 +63,7 @@ impl<'de> Deserialize<'de> for Eip712Types {
 ///     "required": ["types", "primaryType", "domain", "message"]
 /// }
 /// ```
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct TypedData {
     /// Signing domain metadata. The signing domain is the intended context for
     /// the signature (e.g. the dapp, protocol, etc. that it's intended for).


### PR DESCRIPTION
## Motivation

`TypeData` in `ethers_core` [derives](https://github.com/gakonst/ethers-rs/blob/51fe937f6515689b17a3a83b74a05984ad3a7f11/ethers-core/src/types/transaction/eip712.rs#L270) `PartialEq` and `Eq`, but it isn't derived in `alloy-dyn-abi`.

## Solution

Derive `PartialEq` and `Eq` for `TypeData` in `alloy-dyn-abi`.


## PR Checklist

- [ ] Added Tests (n/a)
- [X] Added Documentation (docs are autogenerated for this)
- [ ] Breaking changes (not a breaking change)
