### PR TITLE
chore: fix tests

### DIFF
--- a/crates/dyn-abi/Cargo.toml
+++ b/crates/dyn-abi/Cargo.toml
@@ -38,10 +38,11 @@ derive_arbitrary = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 
 [dev-dependencies]
+alloy-dyn-abi = { workspace = true, features = ["std"] }
 criterion.workspace = true
 ethabi = "18"
 rand = "0.8"
-serde_json = { workspace = true }
+serde_json.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/sol-types/tests/compiletest.rs
+++ b/crates/sol-types/tests/compiletest.rs
@@ -1,3 +1,4 @@
+#[rustversion::attr(nightly, ignore = "type.rs depends way too much on compiler internals")]
 #[rustversion::attr(not(nightly), ignore)]
 #[cfg_attr(any(target_os = "windows", miri), ignore)]
 #[test]


### PR DESCRIPTION
`winnow/std` is now enabled by `toml`, which was added in the latest `trybuild` version. This breaks an internal hack in `winnow` regarding `std::error::Error`, so we have to enable `std` on ourselves too.