### PR TITLE
fix: handle 0 for inverting eip155 parity.

### DIFF
--- a/crates/primitives/src/signature/parity.rs
+++ b/crates/primitives/src/signature/parity.rs
@@ -106,7 +106,8 @@ impl Parity {
         match *self {
             Self::Parity(b) => Self::Parity(!b),
             Self::NonEip155(b) => Self::NonEip155(!b),
-            Self::Eip155(v @ 0..=34) => Self::Eip155(if v % 2 == 0 { v - 1 } else { v + 1 }),
+            Self::Eip155(0) => Self::Eip155(1),
+            Self::Eip155(v @ 1..=34) => Self::Eip155(if v % 2 == 0 { v - 1 } else { v + 1 }),
             Self::Eip155(v @ 35..) => Self::Eip155(v ^ 1),
         }
     }
@@ -238,5 +239,23 @@ mod test {
         assert_eq!(p.to_parity_bool(), Parity::Parity(false));
 
         assert_eq!(p.with_chain_id(1), Parity::Eip155(37));
+    }
+
+    #[test]
+    fn invert_parity() {
+        let p = Parity::Eip155(0);
+        assert_eq!(p.inverted(), Parity::Eip155(1));
+
+        let p = Parity::Eip155(22);
+        assert_eq!(p.inverted(), Parity::Eip155(21));
+
+        let p = Parity::Eip155(58);
+        assert_eq!(p.inverted(), Parity::Eip155(59));
+
+        let p = Parity::NonEip155(false);
+        assert_eq!(p.inverted(), Parity::NonEip155(true));
+
+        let p = Parity::Parity(true);
+        assert_eq!(p.inverted(), Parity::Parity(false));
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

As mentioned in #630 , there is a corner case for inverting parity with value of Eip155(0). Program will try to return Eip155(-1) which is panic issue. 

## Solution

One should handle the 0 case separately and return Eip155(1) as the inverted output.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
