### PR TITLE
feat: Create new method on Param and EventParam

### DIFF
--- a/crates/json-abi/src/param.rs
+++ b/crates/json-abi/src/param.rs
@@ -99,7 +99,12 @@ impl Param {
     /// # use alloy_json_abi::Param;
     /// assert_eq!(
     ///     Param::parse("uint256[] foo"),
-    ///     Ok(Param {name: "foo".into(), ty: "uint256[]".into(), components:vec![], internal_type:None})
+    ///     Ok(Param {
+    ///         name: "foo".into(),
+    ///         ty: "uint256[]".into(),
+    ///         components: vec![],
+    ///         internal_type: None,
+    ///     })
     /// );
     /// ```
     pub fn parse(input: &str) -> parser::Result<Self> {
@@ -108,13 +113,13 @@ impl Param {
 
     /// Validate and create new instance of Param.
     pub fn new(
-        name: String,
-        ty: String,
+        name: &str,
+        ty: &str,
         components: Vec<Self>,
         internal_type: Option<InternalType>,
     ) -> parser::Result<Self> {
-        Self::validate_fields(&name, &ty, !components.is_empty())?;
-        Ok(Self { ty, name, components, internal_type })
+        Self::validate_fields(name, ty, !components.is_empty())?;
+        Ok(Self { ty: ty.into(), name: name.into(), components, internal_type })
     }
 
     /// The internal type of the parameter.
@@ -384,7 +389,13 @@ impl EventParam {
     /// use alloy_json_abi::EventParam;
     /// assert_eq!(
     ///     EventParam::parse("uint256[] indexed foo"),
-    ///     Ok(EventParam {name:"foo".into(), ty:"uint256[]".into(), indexed:true, components: vec![], internal_type: None})
+    ///     Ok(EventParam {
+    ///         name: "foo".into(),
+    ///         ty: "uint256[]".into(),
+    ///         indexed: true,
+    ///         components: vec![],
+    ///         internal_type: None,
+    ///     })
     /// );
     /// ```
     #[inline]
@@ -394,14 +405,14 @@ impl EventParam {
 
     /// Validate and create new instance of EventParam
     pub fn new(
-        name: String,
-        ty: String,
+        name: &str,
+        ty: &str,
         indexed: bool,
         components: Vec<Param>,
         internal_type: Option<InternalType>,
     ) -> parser::Result<Self> {
-        Param::validate_fields(&name, &ty, !components.is_empty())?;
-        Ok(Self { name, ty, indexed, components, internal_type })
+        Param::validate_fields(name, ty, !components.is_empty())?;
+        Ok(Self { name: name.into(), ty: ty.into(), indexed, components, internal_type })
     }
 
     /// The internal type of the parameter.
@@ -612,7 +623,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn param() {
+    fn param_from_str() {
         let param = r#"{
             "internalType": "string",
             "name": "reason",
@@ -628,5 +639,25 @@ mod tests {
                 components: vec![],
             }
         );
+    }
+
+    #[test]
+    fn param_from_new() {
+        let param = Param::new("something", "string", vec![], None);
+        assert_eq!(
+            param,
+            Ok(Param {
+                name: "something".into(),
+                ty: "string".into(),
+                components: vec![],
+                internal_type: None,
+            })
+        );
+
+        let err_not_a_type = Param::new("something", "not a type", vec![], None);
+        assert!(err_not_a_type.is_err());
+
+        let err_not_tuple = Param::new("something", "string", vec![param.unwrap()], None);
+        assert!(err_not_tuple.is_err())
     }
 }

--- a/crates/sol-type-parser/src/error.rs
+++ b/crates/sol-type-parser/src/error.rs
@@ -40,6 +40,13 @@ impl Error {
         Self::_new("invalid type string: ", &ty)
     }
 
+    /// Instantiate an invalid identifier string error. Invalid identifier string errors are for
+    /// identifier strings that do not follow the format described in
+    /// <https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityLexer.Identifier>.
+    pub fn invalid_identifier_string(identifier: impl fmt::Display) -> Self {
+        Self::_new("invalid identifier string: ", &identifier)
+    }
+
     /// Instantiate an invalid size error. Invalid size errors are for valid
     /// primitive types with invalid sizes. E.g. `"uint7"` or `"bytes1337"` or
     /// `"string[aaaaaa]"`.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Resolve https://github.com/alloy-rs/core/issues/240


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

* Create a `new` method for `Param` and `EventParam` 
* Annotate the `ty` and `name` fields on `Param` and `EventParam` with `#[doc(hidden)]` to discourage users from creating their own isntances of those types wihtout using the `new` method. The reason for not making those fields private is that they are used by macros in different crates.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
