### PR TITLE
Fix Log serde for non self describing protocols

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ alloy-rlp = { version = "0.3", default-features = false }
 alloy-rlp-derive = { version = "0.3", default-features = false }
 arbitrary = "1.3"
 arrayvec = { version = "0.7", default-features = false }
+bcs = "0.1.6"
 bincode = "1.3"
 bytes = { version = "1", default-features = false }
 criterion = "0.5"

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -61,6 +61,7 @@ allocative = { workspace = true, optional = true }
 postgres-types = { workspace = true, optional = true }
 
 [dev-dependencies]
+bcs.workspace = true
 bincode.workspace = true
 criterion.workspace = true
 serde_json.workspace = true

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -51,6 +51,8 @@ pub use common::TxKind;
 
 mod log;
 pub use log::{Log, LogData};
+#[cfg(feature = "serde")]
+mod log_serde;
 
 mod sealed;
 pub use sealed::{Sealable, Sealed};

--- a/crates/primitives/src/log.rs
+++ b/crates/primitives/src/log.rs
@@ -83,7 +83,6 @@ impl LogData {
 
 /// A log consists of an address, and some log data.
 #[derive(Clone, Default, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(derive_arbitrary::Arbitrary, proptest_derive::Arbitrary))]
 pub struct Log<T = LogData> {
     /// The address which emitted this log.
@@ -195,53 +194,17 @@ impl alloy_rlp::Decodable for Log {
     }
 }
 
+#[cfg(feature = "rlp")]
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_rlp::{Decodable, Encodable};
 
-    #[cfg(feature = "rlp")]
     #[test]
     fn test_roundtrip_rlp_log_data() {
-        use alloy_rlp::{Decodable, Encodable};
         let log = Log::<LogData>::default();
         let mut buf = Vec::<u8>::new();
         log.encode(&mut buf);
         assert_eq!(Log::decode(&mut &buf[..]).unwrap(), log);
-    }
-
-    #[test]
-    fn test_bincode_encode_decode() {
-        #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-        struct MyStruct {
-            logs: Vec<Log>,
-        }
-
-        let my_struct = MyStruct {
-            logs: vec![Log {
-                address: address!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266"),
-                data: LogData::new(vec![], Default::default()).unwrap(),
-            }],
-        };
-
-        let bytes = bincode::serialize(&my_struct).unwrap();
-        let _: MyStruct = bincode::deserialize(&bytes).unwrap();
-    }
-
-    #[test]
-    fn test_bcs_encode_decode() {
-        #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-        struct MyStruct {
-            logs: Vec<Log>,
-        }
-
-        let my_struct = MyStruct {
-            logs: vec![Log {
-                address: address!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266"),
-                data: LogData::new(vec![], Default::default()).unwrap(),
-            }],
-        };
-
-        let bytes = bcs::to_bytes(&my_struct).unwrap();
-        let _: MyStruct = bcs::from_bytes(&bytes).unwrap();
     }
 }

--- a/crates/primitives/src/log.rs
+++ b/crates/primitives/src/log.rs
@@ -210,6 +210,24 @@ mod tests {
     }
 
     #[test]
+    fn test_bincode_encode_decode() {
+        #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        struct MyStruct {
+            logs: Vec<Log>,
+        }
+
+        let my_struct = MyStruct {
+            logs: vec![Log {
+                address: address!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266"),
+                data: LogData::new(vec![], Default::default()).unwrap(),
+            }],
+        };
+
+        let bytes = bincode::serialize(&my_struct).unwrap();
+        let _: MyStruct = bincode::deserialize(&bytes).unwrap();
+    }
+
+    #[test]
     fn test_bcs_encode_decode() {
         #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
         struct MyStruct {

--- a/crates/primitives/src/log_serde.rs
+++ b/crates/primitives/src/log_serde.rs
@@ -1,7 +1,7 @@
 //! This is an implementation of serde for Log for
 //! both human-readable and binary forms.
 //!
-//! Etherium JSON RPC requires logs in a flattened form.
+//! Ethereum JSON RPC requires logs in a flattened form.
 //! However `serde(flatten)` breaks binary implementations.
 //!
 //! This module uses a trick to select a proxy for serde:
@@ -77,8 +77,10 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for Log<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::log::{Log, LogData};
-    use crate::Bytes;
+    use crate::{
+        log::{Log, LogData},
+        Bytes,
+    };
 
     #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
     struct TestStruct {
@@ -120,7 +122,7 @@ mod tests {
     fn test_log_json_roundtrip() {
         let expected = "{\"logs\":[{\"address\":\"0x3100000000000000000000000000000000000001\",\"topics\":[\"0x32eff959e2e8d1609edc4b39ccf75900aa6c1da5719f8432752963fdf008234f\"],\"data\":\"0x303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030323165396462633161313166386530343661373264313239366363326438626230643135343464353666643062396262383839306130663839623838303336353431653964626331613131663865303436613732643132393663633264386262306431353434643536666430623962623838393061306638396238383033363534\"}]}";
 
-        let parsed: TestStruct = serde_json::from_str(&expected).unwrap();
+        let parsed: TestStruct = serde_json::from_str(expected).unwrap();
         let dumped = serde_json::to_string(&parsed).unwrap();
 
         assert_eq!(expected, dumped);

--- a/crates/primitives/src/log_serde.rs
+++ b/crates/primitives/src/log_serde.rs
@@ -1,0 +1,128 @@
+//! This is an implementation of serde for Log for
+//! both human-readable and binary forms.
+//!
+//! Etherium JSON RPC requires logs in a flattened form.
+//! However `serde(flatten)` breaks binary implementations.
+//!
+//! This module uses a trick to select a proxy for serde:
+//! 1. LogFlattenSerializer for a human-readable (JSON) serializer,
+//! 2. LogFlattenDeserializer for a human-readable (JSON) deserializer,
+//! 3. LogUnflattenSerializer for a binary serializer,
+//! 4. LogUnflattenDeserializer for a binary deserializer.
+
+use crate::{Address, Log};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Serialize)]
+#[serde(rename = "Log")]
+struct LogFlattenSerializer<'a, T> {
+    address: &'a Address,
+    #[serde(flatten)]
+    data: &'a T,
+}
+
+#[derive(Deserialize)]
+#[serde(rename = "Log")]
+struct LogFlattenDeserializer<T> {
+    address: Address,
+    #[serde(flatten)]
+    data: T,
+}
+
+#[derive(Serialize)]
+#[serde(rename = "Log")]
+struct LogUnflattenSerializer<'a, T> {
+    address: &'a Address,
+    data: &'a T,
+}
+
+#[derive(Deserialize)]
+#[serde(rename = "Log")]
+struct LogUnflattenDeserializer<T> {
+    address: Address,
+    data: T,
+}
+
+impl<T: Serialize> Serialize for Log<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let Log { address, data } = self;
+        if serializer.is_human_readable() {
+            let replace = LogFlattenSerializer { address, data };
+            replace.serialize(serializer)
+        } else {
+            let replace = LogUnflattenSerializer { address, data };
+            replace.serialize(serializer)
+        }
+    }
+}
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for Log<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            let LogFlattenDeserializer { address, data } = <_>::deserialize(deserializer)?;
+            Ok(Self { address, data })
+        } else {
+            let LogUnflattenDeserializer { address, data } = <_>::deserialize(deserializer)?;
+            Ok(Self { address, data })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::log::{Log, LogData};
+    use crate::Bytes;
+
+    #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+    struct TestStruct {
+        logs: Vec<Log>,
+    }
+
+    fn gen_test_struct() -> TestStruct {
+        // assume it's random:
+        TestStruct {
+            logs: vec![Log {
+                address: address!("3100000000000000000000000000000000000001"),
+                data: LogData::new(
+                    vec![b256!("32eff959e2e8d1609edc4b39ccf75900aa6c1da5719f8432752963fdf008234f")],
+                    Bytes::from_static(b"00000000000000000000000000000000000000000000000000000000000000021e9dbc1a11f8e046a72d1296cc2d8bb0d1544d56fd0b9bb8890a0f89b88036541e9dbc1a11f8e046a72d1296cc2d8bb0d1544d56fd0b9bb8890a0f89b8803654"),
+                ).unwrap(),
+            }],
+        }
+    }
+
+    #[test]
+    fn test_log_bincode_roundtrip() {
+        let generated = gen_test_struct();
+
+        let bytes = bincode::serialize(&generated).unwrap();
+        let parsed: TestStruct = bincode::deserialize(&bytes).unwrap();
+        assert_eq!(generated, parsed);
+    }
+
+    #[test]
+    fn test_log_bcs_roundtrip() {
+        let generated = gen_test_struct();
+
+        let bytes = bcs::to_bytes(&generated).unwrap();
+        let parsed: TestStruct = bcs::from_bytes(&bytes).unwrap();
+        assert_eq!(generated, parsed);
+    }
+
+    #[test]
+    fn test_log_json_roundtrip() {
+        let expected = "{\"logs\":[{\"address\":\"0x3100000000000000000000000000000000000001\",\"topics\":[\"0x32eff959e2e8d1609edc4b39ccf75900aa6c1da5719f8432752963fdf008234f\"],\"data\":\"0x303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030323165396462633161313166386530343661373264313239366363326438626230643135343464353666643062396262383839306130663839623838303336353431653964626331613131663865303436613732643132393663633264386262306431353434643536666430623962623838393061306638396238383033363534\"}]}";
+
+        let parsed: TestStruct = serde_json::from_str(&expected).unwrap();
+        let dumped = serde_json::to_string(&parsed).unwrap();
+
+        assert_eq!(expected, dumped);
+    }
+}


### PR DESCRIPTION
Log flattens data for serde, which is an issue for a non self describing protocols as bcs and bincode. Without this fix test will fail with:

1. bcs:

```
---- log::tests::test_bcs_encode_decode stdout ----
thread 'log::tests::test_bcs_encode_decode' panicked at crates/primitives/src/log.rs:248:51:
called `Result::unwrap()` on an `Err` value: NotSupported("deserialize_any")
```

2. bincode:

```
---- log::tests::test_bincode_encode_decode stdout ----
thread 'log::tests::test_bincode_encode_decode' panicked at crates/primitives/src/log.rs:227:52:
called `Result::unwrap()` on an `Err` value: SequenceMustHaveLength
```

Code affected: reth_primitives::Receipt.