### PR TITLE
fix(sol-macro): overridden event signatures

### DIFF
--- a/crates/sol-macro-expander/Cargo.toml
+++ b/crates/sol-macro-expander/Cargo.toml
@@ -25,7 +25,7 @@ proc-macro2.workspace = true
 quote.workspace = true
 syn = { workspace = true, features = ["extra-traits"] }
 
-heck = "0.4"
+heck = "0.5"
 hex.workspace = true
 indexmap = "2"
 proc-macro-error.workspace = true

--- a/crates/sol-macro-expander/src/expand/event.rs
+++ b/crates/sol-macro-expander/src/expand/event.rs
@@ -30,7 +30,7 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, event: &ItemEvent) -> Result<TokenStream>
     event.assert_valid()?;
 
     let name = cx.overloaded_name(event.into());
-    let signature = cx.signature(name.as_string(), &params);
+    let signature = cx.event_signature(event);
     let selector = crate::utils::event_selector(&signature);
     let anonymous = event.is_anonymous();
 

--- a/crates/sol-macro-expander/src/expand/mod.rs
+++ b/crates/sol-macro-expander/src/expand/mod.rs
@@ -1,6 +1,5 @@
 //! Functions which generate Rust code from the Solidity AST.
 
-#![allow(rustdoc::private_intra_doc_links)]
 use crate::{
     expand::ty::expand_rust_type,
     utils::{self, ExprArray},
@@ -20,6 +19,7 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 use syn::{ext::IdentExt, parse_quote, Attribute, Error, Result};
+
 #[macro_use]
 mod macros;
 
@@ -574,7 +574,7 @@ pub fn generate_name(i: usize) -> Ident {
 }
 
 /// Returns the name of a parameter, or a generated name if it is `None`.
-fn anon_name<T: Into<Ident> + Clone>((i, name): (usize, Option<&T>)) -> Ident {
+pub fn anon_name<T: Into<Ident> + Clone>((i, name): (usize, Option<&T>)) -> Ident {
     match name {
         Some(name) => name.clone().into(),
         None => generate_name(i),

--- a/crates/sol-types/tests/macros/sol/mod.rs
+++ b/crates/sol-types/tests/macros/sol/mod.rs
@@ -808,3 +808,49 @@ fn bytecode_attributes() {
     assert_eq!(Dummy::BYTECODE[..], hex::decode("1234").unwrap());
     assert_eq!(Dummy::DEPLOYED_BYTECODE[..], hex::decode("5678").unwrap());
 }
+
+#[test]
+fn function_overrides() {
+    mod one {
+        alloy_sol_types::sol! {
+            function TestEvent(bytes32 one);
+        }
+    }
+
+    mod two {
+        alloy_sol_types::sol! {
+            function TestEvent(bytes32 one);
+            function TestEvent(bytes32 one, bytes32 two);
+        }
+    }
+
+    assert_eq!(one::TestEventCall::SIGNATURE, "TestEvent(bytes32)");
+    assert_eq!(one::TestEventCall::SIGNATURE, two::TestEvent_0Call::SIGNATURE);
+
+    assert_eq!(two::TestEvent_1Call::SIGNATURE, "TestEvent(bytes32,bytes32)");
+}
+
+// https://github.com/alloy-rs/core/issues/640
+#[test]
+fn event_overrides() {
+    mod one {
+        alloy_sol_types::sol! {
+            event TestEvent(bytes32 indexed one);
+        }
+    }
+
+    mod two {
+        alloy_sol_types::sol! {
+            event TestEvent(bytes32 indexed one);
+            event TestEvent(bytes32 indexed one, bytes32 indexed two);
+        }
+    }
+
+    assert_eq!(one::TestEvent::SIGNATURE, "TestEvent(bytes32)");
+    assert_eq!(one::TestEvent::SIGNATURE, two::TestEvent_0::SIGNATURE);
+    assert_eq!(one::TestEvent::SIGNATURE_HASH, keccak256("TestEvent(bytes32)"));
+    assert_eq!(one::TestEvent::SIGNATURE_HASH, two::TestEvent_0::SIGNATURE_HASH);
+
+    assert_eq!(two::TestEvent_1::SIGNATURE, "TestEvent(bytes32,bytes32)");
+    assert_eq!(two::TestEvent_1::SIGNATURE_HASH, keccak256("TestEvent(bytes32,bytes32)"));
+}


### PR DESCRIPTION
The overridden name was used for calculating the signature, which is wrong.

Fixes https://github.com/alloy-rs/core/issues/640