### PR TITLE
fix(primitives): Signed formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,9 @@ bytes = { version = "1", default-features = false }
 criterion = "0.5"
 derive_arbitrary = "1.3"
 getrandom = "0.2"
-hex = { package = "const-hex", version = "1.10", default-features = false, features = ["alloc"] }
+hex = { package = "const-hex", version = "1.10", default-features = false, features = [
+    "alloc",
+] }
 itoa = "1"
 once_cell = "1"
 postgres-types = "0.2.6"
@@ -73,6 +75,6 @@ pretty_assertions = "1.4"
 proptest = "1"
 proptest-derive = "0.4"
 rand = { version = "0.8", default-features = false }
-ruint = { version = "1.11.1", default-features = false, features = ["alloc"] }
+ruint = { version = "1.12.3", default-features = false, features = ["alloc"] }
 ruint-macro = { version = "1", default-features = false }
 winnow = { version = "0.6", default-features = false, features = ["alloc"] }

--- a/crates/primitives/src/signed/int.rs
+++ b/crates/primitives/src/signed/int.rs
@@ -66,7 +66,11 @@ impl<const BITS: usize, const LIMBS: usize> fmt::Display for Signed<BITS, LIMBS>
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let (sign, abs) = self.into_sign_and_abs();
         sign.fmt(f)?;
-        abs.fmt(f)
+        if f.sign_plus() {
+            write!(f, "{abs}")
+        } else {
+            abs.fmt(f)
+        }
     }
 }
 
@@ -750,19 +754,13 @@ mod tests {
 
                 assert_eq!(format!("{positive:x}"), format!("{unsigned:x}"));
                 assert_eq!(format!("{negative:x}"), format!("{unsigned_negative:x}"));
-                assert_eq!(format!("{positive:+x}"), format!("{unsigned:x}"));
-                assert_eq!(format!("{negative:+x}"), format!("{unsigned_negative:x}"));
+                assert_eq!(format!("{positive:+x}"), format!("+{unsigned:x}"));
+                assert_eq!(format!("{negative:+x}"), format!("+{unsigned_negative:x}"));
 
-                assert_eq!(format!("{positive:X}"), format!("{unsigned:x}").to_uppercase());
-                assert_eq!(
-                    format!("{negative:X}"),
-                    format!("{unsigned_negative:x}").to_uppercase()
-                );
-                assert_eq!(format!("{positive:+X}"), format!("{unsigned:x}").to_uppercase());
-                assert_eq!(
-                    format!("{negative:+X}"),
-                    format!("{unsigned_negative:x}").to_uppercase()
-                );
+                assert_eq!(format!("{positive:X}"), format!("{unsigned:X}"));
+                assert_eq!(format!("{negative:X}"), format!("{unsigned_negative:X}"));
+                assert_eq!(format!("{positive:+X}"), format!("+{unsigned:X}"));
+                assert_eq!(format!("{negative:+X}"), format!("+{unsigned_negative:X}"));
             };
         }
 


### PR DESCRIPTION
`sign_plus` flag (`{:+}`) would get printed twice as now `Uint` also formats it. Only this flag is affected which is pretty rare.