### PR TITLE
chore(docs): add doc aliases for `Tx` prefixed names

### DIFF
--- a/crates/primitives/src/aliases.rs
+++ b/crates/primitives/src/aliases.rs
@@ -66,12 +66,15 @@ pub type BlockHash = B256;
 pub type BlockNumber = u64;
 
 /// A transaction hash is a keccak hash of an RLP encoded signed transaction.
+#[doc(alias = "TransactionHash")]
 pub type TxHash = B256;
 
 /// The sequence number of all existing transactions.
+#[doc(alias = "TransactionNumber")]
 pub type TxNumber = u64;
 
 /// The index of transaction in a block.
+#[doc(alias = "TransactionIndex")]
 pub type TxIndex = u64;
 
 /// Chain identifier type (introduced in EIP-155).

--- a/crates/primitives/src/common.rs
+++ b/crates/primitives/src/common.rs
@@ -7,6 +7,7 @@ use alloy_rlp::{Buf, BufMut, Decodable, Encodable, EMPTY_STRING_CODE};
 /// contract creation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "arbitrary", derive(derive_arbitrary::Arbitrary, proptest_derive::Arbitrary))]
+#[doc(alias = "TransactionKind")]
 pub enum TxKind {
     /// A transaction that creates a contract.
     #[default]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

See: https://github.com/alloy-rs/alloy/issues/833

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Adds non-intrusive doc aliases so users can find types more easily.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
