### PR TITLE
feat(primitives): derive `Arbitrary` for Signature

### DIFF
--- a/crates/primitives/src/signature/parity.rs
+++ b/crates/primitives/src/signature/parity.rs
@@ -6,6 +6,7 @@ use crate::{
 /// The parity of the signature, stored as either a V value (which may include
 /// a chain id), or the y-parity.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(derive_arbitrary::Arbitrary))]
 pub enum Parity {
     /// Explicit V value. May be EIP-155 modified.
     Eip155(u64),

--- a/crates/primitives/src/signature/sig.rs
+++ b/crates/primitives/src/signature/sig.rs
@@ -7,6 +7,7 @@ use alloc::vec::Vec;
 use core::str::FromStr;
 
 /// An Ethereum ECDSA signature.
+#[cfg_attr(any(test, feature = "arbitrary"), derive(derive_arbitrary::Arbitrary))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Signature<T> {
     /// Memoized ecdsa signature (if any)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Needed for https://github.com/alloy-rs/alloy/issues/109. 

primitive `Signature` and `Parity` types do not derive `Arbitrary`. But the `Transaction` type in alloy requires it. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Derive `Arbitrary` for the test and arbitrary feature. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
