### PR TITLE
fix(primitives): include in aliases export to prevent having to import from `aliases::{..}`

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -30,9 +30,9 @@ pub mod postgres;
 pub mod aliases;
 #[doc(no_inline)]
 pub use aliases::{
-    BlockHash, BlockNumber, ChainId, Selector, StorageKey, StorageValue, TxHash, TxIndex, TxNumber,
-    B128, B256, B512, B64, I128, I16, I160, I256, I32, I64, I8, U128, U16, U160, U256, U32, U512,
-    U64, U8,
+    BlockHash, BlockNumber, BlockTimestamp, ChainId, Selector, StorageKey, StorageValue, TxHash,
+    TxIndex, TxNonce, TxNumber, B128, B256, B512, B64, I128, I16, I160, I256, I32, I64, I8, U128,
+    U16, U160, U256, U32, U512, U64, U8,
 };
 
 #[macro_use]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

My apologies for the oversight. Low priority, can simply be part of a next release.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Export the new aliases: `TxNonce` and `BlockTimestamp` so they do not have to be imported as `aliases::{TxNonce, BlockTimestamp}`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
