### PR TITLE
feat(primitives): serialize yParity and v simultaneously

### DIFF
--- a/crates/primitives/src/signature/sig.rs
+++ b/crates/primitives/src/signature/sig.rs
@@ -782,9 +782,9 @@ mod tests {
             "v":"0x1"
         }"#;
 
-        let deserialized: crate::Signature = serde_json::from_str(&v_y_should_appear).unwrap();
+        let deserialized: crate::Signature = serde_json::from_str(v_y_should_appear).unwrap();
 
-        let serialized = serde_json::to_value(&deserialized).unwrap();
+        let serialized = serde_json::to_value(deserialized).unwrap();
 
         // Check if v and yParity key exists together
         assert_eq!(serialized.get("v").unwrap(), "0x1");
@@ -796,9 +796,9 @@ mod tests {
             "v":"0x23"
         }"#;
 
-        let deserialized: crate::Signature = serde_json::from_str(&only_v_should_appear).unwrap();
+        let deserialized: crate::Signature = serde_json::from_str(only_v_should_appear).unwrap();
 
-        let serialized = serde_json::to_value(&deserialized).unwrap();
+        let serialized = serde_json::to_value(deserialized).unwrap();
 
         assert_eq!(serialized.get("v").unwrap(), "0x23");
         assert!(serialized.get("yParity").is_none());

--- a/crates/primitives/src/signature/sig.rs
+++ b/crates/primitives/src/signature/sig.rs
@@ -418,13 +418,10 @@ impl serde::Serialize for crate::Signature {
             match self.v {
                 Parity::Eip155(v) => map.serialize_entry("v", &crate::U64::from(v))?,
                 Parity::NonEip155(b) => map.serialize_entry("v", &(b as u8 + 27))?,
-                Parity::Parity(true) => {
-                    map.serialize_entry("v", "0x1")?;
-                    map.serialize_entry("yParity", "0x1")?;
-                }
-                Parity::Parity(false) => {
-                    map.serialize_entry("v", "0x0")?;
-                    map.serialize_entry("yParity", "0x0")?;
+                Parity::Parity(parity) => {
+                    let (v, y_parity) = if parity { ("0x1", "0x1") } else { ("0x0", "0x0") };
+                    map.serialize_entry("v", v)?;
+                    map.serialize_entry("yParity", y_parity)?;
                 }
             }
             map.end()

--- a/crates/primitives/src/signature/sig.rs
+++ b/crates/primitives/src/signature/sig.rs
@@ -689,7 +689,7 @@ mod tests {
         let serialized = serde_json::to_string(&signature).unwrap();
         assert_eq!(
             serialized,
-            r#"{"r":"0xc569c92f176a3be1a6352dd5005bfc751dcb32f57623dd2a23693e64bf4447b0","s":"0x1a891b566d369e79b7a66eecab1e008831e22daa15f91a0a0cf4f9f28f47ee05","yParity":"0x1"}"#
+            r#"{"r":"0xc569c92f176a3be1a6352dd5005bfc751dcb32f57623dd2a23693e64bf4447b0","s":"0x1a891b566d369e79b7a66eecab1e008831e22daa15f91a0a0cf4f9f28f47ee05","v":"0x1","yParity":"0x1"}"#
         );
     }
 
@@ -706,7 +706,7 @@ mod tests {
         )
         .unwrap();
 
-        let expected = r#"{"r":"0xc569c92f176a3be1a6352dd5005bfc751dcb32f57623dd2a23693e64bf4447b0","s":"0x1a891b566d369e79b7a66eecab1e008831e22daa15f91a0a0cf4f9f28f47ee05","yParity":"0x1"}"#;
+        let expected = r#"{"r":"0xc569c92f176a3be1a6352dd5005bfc751dcb32f57623dd2a23693e64bf4447b0","s":"0x1a891b566d369e79b7a66eecab1e008831e22daa15f91a0a0cf4f9f28f47ee05","v":"0x1","yParity":"0x1"}"#;
 
         let serialized = serde_json::to_string(&signature).unwrap();
         assert_eq!(serialized, expected);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Previously, when `v` was set to `0x0 || 0x1` i.e `Parity::Parity(false || true)`, only `yParity` would appear in the serialized form of the sig.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Serialize `v` along with `yParity` in that case. 
Ref: https://github.com/ethereum/go-ethereum/blob/473ee8fc07a3f89cf3978e164a6fad218de9a6b5/internal/ethapi/api.go#L1342-L1345 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
