### PR TITLE
feat(primitives): manually implement arbitrary for signature

### DIFF
--- a/crates/json-abi/src/item.rs
+++ b/crates/json-abi/src/item.rs
@@ -438,7 +438,7 @@ impl Function {
     ///
     /// Note:
     /// - [`state_mutability`](Self::state_mutability) is currently not parsed from the input and is
-    /// always set to [`StateMutability::NonPayable`]
+    ///   always set to [`StateMutability::NonPayable`]
     /// - visibility is rejected
     ///
     /// If you want to parse a generic [Human-Readable ABI] string, use [`AbiItem::parse`].

--- a/crates/primitives/src/signature/parity.rs
+++ b/crates/primitives/src/signature/parity.rs
@@ -6,7 +6,7 @@ use crate::{
 /// The parity of the signature, stored as either a V value (which may include
 /// a chain id), or the y-parity.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[cfg_attr(any(test, feature = "arbitrary"), derive(derive_arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(derive_arbitrary::Arbitrary, proptest_derive::Arbitrary))]
 pub enum Parity {
     /// Explicit V value. May be EIP-155 modified.
     Eip155(u64),

--- a/crates/primitives/src/signed/int.rs
+++ b/crates/primitives/src/signed/int.rs
@@ -504,8 +504,7 @@ impl<const BITS: usize, const LIMBS: usize> Signed<BITS, LIMBS> {
     ///
     /// * [`BaseConvertError::InvalidBase`] if the base is less than 2.
     /// * [`BaseConvertError::InvalidDigit`] if a digit is out of range.
-    /// * [`BaseConvertError::Overflow`] if the number is too large to
-    /// fit.
+    /// * [`BaseConvertError::Overflow`] if the number is too large to fit.
     pub fn from_base_be<I: IntoIterator<Item = u64>>(
         base: u64,
         digits: I,


### PR DESCRIPTION
The underlying type doesn't need to implement the trait for `Signature` to do so