### PR TITLE
feat: IntoLogData

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -50,7 +50,7 @@ mod common;
 pub use common::TxKind;
 
 mod log;
-pub use log::{Log, LogData};
+pub use log::{IntoLogData, Log, LogData};
 #[cfg(feature = "serde")]
 mod log_serde;
 

--- a/crates/primitives/src/log.rs
+++ b/crates/primitives/src/log.rs
@@ -81,6 +81,26 @@ impl LogData {
     }
 }
 
+/// Trait for an object that can be converted into a log data object.
+pub trait IntoLogData {
+    /// Convert into a [`LogData`] object.
+    fn to_log_data(&self) -> LogData;
+    /// Consume and convert into a [`LogData`] object.
+    fn into_log_data(self) -> LogData;
+}
+
+impl IntoLogData for LogData {
+    #[inline]
+    fn to_log_data(&self) -> LogData {
+        self.clone()
+    }
+
+    #[inline]
+    fn into_log_data(self) -> LogData {
+        self
+    }
+}
+
 /// A log consists of an address, and some log data.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(derive_arbitrary::Arbitrary, proptest_derive::Arbitrary))]

--- a/crates/sol-macro-expander/src/expand/contract.rs
+++ b/crates/sol-macro-expander/src/expand/contract.rs
@@ -811,6 +811,28 @@ impl<'a> CallLikeExpander<'a> {
             }
         });
 
+        let into_impl = {
+            let variants: Vec<_> = events.iter().map(e_name).collect();
+            let v2 = variants.clone();
+            quote! {
+                #[automatically_derived]
+                impl alloy_sol_types::private::IntoLogData for #name {
+                    fn to_log_data(&self) -> alloy_sol_types::private::LogData {
+                        match self {#(
+                            Self::#variants(ref inner) =>
+                            alloy_sol_types::private::IntoLogData::to_log_data(inner),
+                        )*}
+                    }
+                    fn into_log_data(self) -> alloy_sol_types::private::LogData {
+                        match self {#(
+                            Self::#v2(inner) =>
+                            alloy_sol_types::private::IntoLogData::into_log_data(inner),
+                        )*}
+                    }
+                }
+            }
+        };
+
         quote! {
             #def
 
@@ -824,6 +846,8 @@ impl<'a> CallLikeExpander<'a> {
                     #anon_impl
                 }
             }
+
+            #into_impl
         }
     }
 

--- a/crates/sol-macro-expander/src/expand/contract.rs
+++ b/crates/sol-macro-expander/src/expand/contract.rs
@@ -812,17 +812,18 @@ impl<'a> CallLikeExpander<'a> {
         });
 
         let into_impl = {
-            let variants: Vec<_> = events.iter().map(e_name).collect();
+            let variants = events.iter().map(e_name);
             let v2 = variants.clone();
             quote! {
                 #[automatically_derived]
                 impl alloy_sol_types::private::IntoLogData for #name {
                     fn to_log_data(&self) -> alloy_sol_types::private::LogData {
                         match self {#(
-                            Self::#variants(ref inner) =>
+                            Self::#variants(inner) =>
                             alloy_sol_types::private::IntoLogData::to_log_data(inner),
                         )*}
                     }
+
                     fn into_log_data(self) -> alloy_sol_types::private::LogData {
                         match self {#(
                             Self::#v2(inner) =>

--- a/crates/sol-macro-expander/src/expand/event.rs
+++ b/crates/sol-macro-expander/src/expand/event.rs
@@ -197,25 +197,22 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, event: &ItemEvent) -> Result<TokenStream>
             }
 
             #[automatically_derived]
-            impl alloy_sol_types::private::IntoLogData for #name
-                {
-                    fn to_log_data(&self) -> alloy_sol_types::private::LogData {
-                        From::from(self)
-                    }
-
-                    fn into_log_data(self) -> alloy_sol_types::private::LogData {
-                        From::from(&self)
-                    }
+            impl alloy_sol_types::private::IntoLogData for #name {
+                fn to_log_data(&self) -> alloy_sol_types::private::LogData {
+                    From::from(self)
                 }
+
+                fn into_log_data(self) -> alloy_sol_types::private::LogData {
+                    From::from(&self)
+                }
+            }
 
 
             #[automatically_derived]
             impl From<&#name> for alloy_sol_types::private::LogData {
                 #[inline]
                 fn from(this: &#name) -> alloy_sol_types::private::LogData {
-                    let topics = alloy_sol_types::SolEvent::encode_topics(this).into_iter().map(|t| t.into()).collect();
-                    let data = alloy_sol_types::SolEvent::encode_data(this).into();
-                    alloy_sol_types::private::LogData::new_unchecked(topics, data)
+                    alloy_sol_types::SolEvent::encode_log_data(this)
                 }
             }
 

--- a/crates/sol-macro-expander/src/expand/event.rs
+++ b/crates/sol-macro-expander/src/expand/event.rs
@@ -196,6 +196,20 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, event: &ItemEvent) -> Result<TokenStream>
                 }
             }
 
+            #[automatically_derived]
+            impl alloy_sol_types::private::IntoLogData for #name
+                {
+                    fn to_log_data(&self) -> alloy_sol_types::private::LogData {
+                        From::from(self)
+                    }
+
+                    fn into_log_data(self) -> alloy_sol_types::private::LogData {
+                        From::from(&self)
+                    }
+                }
+
+
+            #[automatically_derived]
             impl From<&#name> for alloy_sol_types::private::LogData {
                 #[inline]
                 fn from(this: &#name) -> alloy_sol_types::private::LogData {

--- a/crates/sol-types/src/lib.rs
+++ b/crates/sol-types/src/lib.rs
@@ -218,8 +218,8 @@ pub mod private {
         vec::Vec,
     };
     pub use alloy_primitives::{
-        bytes, keccak256, Address, Bytes, FixedBytes, Function, LogData, Signed, Uint, B256, I256,
-        U256,
+        bytes, keccak256, Address, Bytes, FixedBytes, Function, IntoLogData, LogData, Signed, Uint,
+        B256, I256, U256,
     };
     pub use core::{
         borrow::{Borrow, BorrowMut},

--- a/crates/sol-types/src/types/event/mod.rs
+++ b/crates/sol-types/src/types/event/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     Result, SolType, Word,
 };
 use alloc::vec::Vec;
-use alloy_primitives::{FixedBytes, Log, LogData, B256};
+use alloy_primitives::{FixedBytes, IntoLogData, Log, LogData, B256};
 
 mod topic;
 pub use topic::EventTopic;

--- a/crates/sol-types/src/types/event/mod.rs
+++ b/crates/sol-types/src/types/event/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     Result, SolType, Word,
 };
 use alloc::vec::Vec;
-use alloy_primitives::{FixedBytes, IntoLogData, Log, LogData, B256};
+use alloy_primitives::{FixedBytes, Log, LogData, B256};
 
 mod topic;
 pub use topic::EventTopic;
@@ -120,6 +120,20 @@ pub trait SolEvent: Sized {
         let mut out = [WordToken(B256::ZERO); LEN];
         self.encode_topics_raw(&mut out).unwrap();
         out
+    }
+
+    /// Encode this event to a [`LogData`].
+    fn encode_log_data(&self) -> LogData {
+        LogData::new_unchecked(
+            self.encode_topics().into_iter().map(Into::into).collect(),
+            self.encode_data().into(),
+        )
+    }
+
+    /// Transform ca [`Log`] containing this event into a [`Log`] containing
+    /// [`LogData`].
+    fn encode_log(log: &Log<Self>) -> Log<LogData> {
+        Log { address: log.address, data: log.data.encode_log_data() }
     }
 
     /// Decode the topics of this event from the given data.


### PR DESCRIPTION

## Motivation

Groundwork for https://github.com/alloy-rs/alloy/issues/623
Adding this conversion trait allows us to bound receipt log vectors in more meaningful ways


## Solution

Introduce trait for types which can be infallibly converted into LogData


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
