### PR TITLE
feat: add `abi_packed_encoded_size`

### DIFF
--- a/crates/dyn-abi/src/dynamic/event.rs
+++ b/crates/dyn-abi/src/dynamic/event.rs
@@ -16,7 +16,7 @@ pub struct DynSolEvent {
 impl DynSolEvent {
     /// Creates a new event, without length-checking the indexed, or ensuring
     /// the body is a tuple. This allows creation of invalid events.
-    pub fn new_unchecked(
+    pub const fn new_unchecked(
         topic_0: Option<B256>,
         indexed: Vec<DynSolType>,
         body: DynSolType,

--- a/crates/dyn-abi/src/eip712/resolver.rs
+++ b/crates/dyn-abi/src/eip712/resolver.rs
@@ -122,7 +122,7 @@ impl TypeDef {
     /// Instantiate a new type definition, without checking that the type name
     /// is a valid root type. This may result in bad behavior in a resolver.
     #[inline]
-    pub fn new_unchecked(type_name: String, props: Vec<PropertyDef>) -> Self {
+    pub const fn new_unchecked(type_name: String, props: Vec<PropertyDef>) -> Self {
         Self { type_name, props }
     }
 

--- a/crates/primitives/src/log.rs
+++ b/crates/primitives/src/log.rs
@@ -17,7 +17,7 @@ impl LogData {
     /// invalid logs. May be safely used when the length of the topic list is
     /// known to be 4 or less.
     #[inline]
-    pub fn new_unchecked(topics: Vec<B256>, data: Bytes) -> Self {
+    pub const fn new_unchecked(topics: Vec<B256>, data: Bytes) -> Self {
         Self { topics, data }
     }
 
@@ -109,7 +109,7 @@ impl Log {
 
     /// Creates a new log.
     #[inline]
-    pub fn new_unchecked(address: Address, topics: Vec<B256>, data: Bytes) -> Self {
+    pub const fn new_unchecked(address: Address, topics: Vec<B256>, data: Bytes) -> Self {
         Self { address, data: LogData::new_unchecked(topics, data) }
     }
 

--- a/crates/sol-macro-expander/src/expand/enum.rs
+++ b/crates/sol-macro-expander/src/expand/enum.rs
@@ -143,6 +143,7 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, enumm: &ItemEnum) -> Result<TokenStream> 
 
                 const SOL_NAME: &'static str = #uint8_st::SOL_NAME;
                 const ENCODED_SIZE: ::core::option::Option<usize> = #uint8_st::ENCODED_SIZE;
+                const PACKED_ENCODED_SIZE: ::core::option::Option<usize> = #uint8_st::PACKED_ENCODED_SIZE;
 
                 #[inline]
                 fn valid_token(token: &Self::Token<'_>) -> bool {

--- a/crates/sol-macro-expander/src/expand/struct.rs
+++ b/crates/sol-macro-expander/src/expand/struct.rs
@@ -90,6 +90,10 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, s: &ItemStruct) -> Result<TokenStream> {
 
                 #[inline]
                 fn stv_abi_encoded_size(&self) -> usize {
+                    if let Some(size) = <Self as alloy_sol_types::SolType>::ENCODED_SIZE {
+                        return size;
+                    }
+
                     // TODO: Avoid cloning
                     let tuple = <UnderlyingRustTuple<'_> as ::core::convert::From<Self>>::from(self.clone());
                     <UnderlyingSolTuple<'_> as alloy_sol_types::SolType>::abi_encoded_size(&tuple)
@@ -106,6 +110,17 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, s: &ItemStruct) -> Result<TokenStream> {
                     let tuple = <UnderlyingRustTuple<'_> as ::core::convert::From<Self>>::from(self.clone());
                     <UnderlyingSolTuple<'_> as alloy_sol_types::SolType>::abi_encode_packed_to(&tuple, out)
                 }
+
+                #[inline]
+                fn stv_abi_packed_encoded_size(&self) -> usize {
+                    if let Some(size) = <Self as alloy_sol_types::SolType>::PACKED_ENCODED_SIZE {
+                        return size;
+                    }
+
+                    // TODO: Avoid cloning
+                    let tuple = <UnderlyingRustTuple<'_> as ::core::convert::From<Self>>::from(self.clone());
+                    <UnderlyingSolTuple<'_> as alloy_sol_types::SolType>::abi_packed_encoded_size(&tuple)
+                }
             }
 
             #[automatically_derived]
@@ -116,6 +131,8 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, s: &ItemStruct) -> Result<TokenStream> {
                 const SOL_NAME: &'static str = <Self as alloy_sol_types::SolStruct>::NAME;
                 const ENCODED_SIZE: Option<usize> =
                     <UnderlyingSolTuple<'_> as alloy_sol_types::SolType>::ENCODED_SIZE;
+                const PACKED_ENCODED_SIZE: Option<usize> =
+                    <UnderlyingSolTuple<'_> as alloy_sol_types::SolType>::PACKED_ENCODED_SIZE;
 
                 #[inline]
                 fn valid_token(token: &Self::Token<'_>) -> bool {

--- a/crates/sol-macro-expander/src/expand/udt.rs
+++ b/crates/sol-macro-expander/src/expand/udt.rs
@@ -56,6 +56,11 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, udt: &ItemUdt) -> Result<TokenStream> {
                 fn stv_abi_encode_packed_to(&self, out: &mut alloy_sol_types::private::Vec<u8>) {
                     <#underlying_sol as alloy_sol_types::SolType>::abi_encode_packed_to(self, out)
                 }
+
+                #[inline]
+                fn stv_abi_packed_encoded_size(&self) -> usize {
+                    <#underlying_sol as alloy_sol_types::SolType>::abi_encoded_size(self)
+                }
             }
 
             #[automatically_derived]
@@ -97,6 +102,7 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, udt: &ItemUdt) -> Result<TokenStream> {
 
                 const SOL_NAME: &'static str = Self::NAME;
                 const ENCODED_SIZE: Option<usize> = <#underlying_sol as alloy_sol_types::SolType>::ENCODED_SIZE;
+                const PACKED_ENCODED_SIZE: Option<usize> = <#underlying_sol as alloy_sol_types::SolType>::PACKED_ENCODED_SIZE;
 
                 #[inline]
                 fn valid_token(token: &Self::Token<'_>) -> bool {

--- a/crates/sol-types/src/lib.rs
+++ b/crates/sol-types/src/lib.rs
@@ -248,12 +248,19 @@ pub mod private {
     pub trait SolTypeValue<T: super::SolType> {
         // Note: methods are prefixed with `stv_` to avoid name collisions with
         // the `SolValue` trait.
-        fn stv_to_tokens(&self) -> T::Token<'_>;
+
         #[inline(always)]
         fn stv_abi_encoded_size(&self) -> usize {
             T::ENCODED_SIZE.unwrap()
         }
+        fn stv_to_tokens(&self) -> T::Token<'_>;
+
+        #[inline(always)]
+        fn stv_abi_packed_encoded_size(&self) -> usize {
+            T::PACKED_ENCODED_SIZE.unwrap()
+        }
         fn stv_abi_encode_packed_to(&self, out: &mut Vec<u8>);
+
         fn stv_eip712_data_word(&self) -> super::Word;
     }
 

--- a/crates/sol-types/src/types/data_type.rs
+++ b/crates/sol-types/src/types/data_type.rs
@@ -45,6 +45,7 @@ impl SolType for Bool {
 
     const SOL_NAME: &'static str = "bool";
     const ENCODED_SIZE: Option<usize> = Some(32);
+    const PACKED_ENCODED_SIZE: Option<usize> = Some(1);
 
     #[inline]
     fn valid_token(token: &Self::Token<'_>) -> bool {
@@ -90,6 +91,7 @@ where
 
     const SOL_NAME: &'static str = IntBitCount::<BITS>::INT_NAME;
     const ENCODED_SIZE: Option<usize> = Some(32);
+    const PACKED_ENCODED_SIZE: Option<usize> = Some(BITS / 8);
 
     #[inline]
     fn valid_token(token: &Self::Token<'_>) -> bool {
@@ -143,6 +145,7 @@ where
 
     const SOL_NAME: &'static str = IntBitCount::<BITS>::UINT_NAME;
     const ENCODED_SIZE: Option<usize> = Some(32);
+    const PACKED_ENCODED_SIZE: Option<usize> = Some(BITS / 8);
 
     #[inline]
     fn valid_token(token: &Self::Token<'_>) -> bool {
@@ -190,6 +193,7 @@ where
 
     const SOL_NAME: &'static str = <ByteCount<N>>::NAME;
     const ENCODED_SIZE: Option<usize> = Some(32);
+    const PACKED_ENCODED_SIZE: Option<usize> = Some(N);
 
     #[inline]
     fn valid_token(token: &Self::Token<'_>) -> bool {
@@ -228,6 +232,7 @@ impl SolType for Address {
 
     const SOL_NAME: &'static str = "address";
     const ENCODED_SIZE: Option<usize> = Some(32);
+    const PACKED_ENCODED_SIZE: Option<usize> = Some(20);
 
     #[inline]
     fn detokenize(token: Self::Token<'_>) -> Self::RustType {
@@ -266,6 +271,7 @@ impl SolType for Function {
 
     const SOL_NAME: &'static str = "function";
     const ENCODED_SIZE: Option<usize> = Some(32);
+    const PACKED_ENCODED_SIZE: Option<usize> = Some(24);
 
     #[inline]
     fn detokenize(token: Self::Token<'_>) -> Self::RustType {
@@ -306,6 +312,11 @@ impl<T: ?Sized + AsRef<[u8]>> SolTypeValue<Bytes> for T {
     fn stv_abi_encode_packed_to(&self, out: &mut Vec<u8>) {
         out.extend_from_slice(self.as_ref());
     }
+
+    #[inline]
+    fn stv_abi_packed_encoded_size(&self) -> usize {
+        self.as_ref().len()
+    }
 }
 
 impl SolType for Bytes {
@@ -314,6 +325,7 @@ impl SolType for Bytes {
 
     const SOL_NAME: &'static str = "bytes";
     const ENCODED_SIZE: Option<usize> = None;
+    const PACKED_ENCODED_SIZE: Option<usize> = None;
 
     #[inline]
     fn valid_token(_token: &Self::Token<'_>) -> bool {
@@ -354,6 +366,11 @@ impl<T: ?Sized + AsRef<str>> SolTypeValue<String> for T {
     fn stv_abi_encode_packed_to(&self, out: &mut Vec<u8>) {
         out.extend_from_slice(self.as_ref().as_ref());
     }
+
+    #[inline]
+    fn stv_abi_packed_encoded_size(&self) -> usize {
+        self.as_ref().len()
+    }
 }
 
 impl SolType for String {
@@ -362,6 +379,7 @@ impl SolType for String {
 
     const SOL_NAME: &'static str = "string";
     const ENCODED_SIZE: Option<usize> = None;
+    const PACKED_ENCODED_SIZE: Option<usize> = None;
 
     #[inline]
     fn valid_token(token: &Self::Token<'_>) -> bool {
@@ -412,8 +430,17 @@ where
     #[inline]
     fn stv_abi_encode_packed_to(&self, out: &mut Vec<u8>) {
         for item in self {
+            // Array elements are left-padded to 32 bytes.
+            if let Some(padding_needed) = 32usize.checked_sub(item.stv_abi_packed_encoded_size()) {
+                out.extend(core::iter::repeat(0).take(padding_needed));
+            }
             T::stv_abi_encode_packed_to(item, out);
         }
+    }
+
+    #[inline]
+    fn stv_abi_packed_encoded_size(&self) -> usize {
+        self.iter().map(|item| item.stv_abi_packed_encoded_size().max(32)).sum()
     }
 }
 
@@ -441,6 +468,11 @@ where
     fn stv_abi_encode_packed_to(&self, out: &mut Vec<u8>) {
         (**self).stv_abi_encode_packed_to(out)
     }
+
+    #[inline]
+    fn stv_abi_packed_encoded_size(&self) -> usize {
+        (**self).stv_abi_packed_encoded_size()
+    }
 }
 
 impl<T, U> SolTypeValue<Array<U>> for &mut [T]
@@ -466,6 +498,11 @@ where
     #[inline]
     fn stv_abi_encode_packed_to(&self, out: &mut Vec<u8>) {
         (**self).stv_abi_encode_packed_to(out)
+    }
+
+    #[inline]
+    fn stv_abi_packed_encoded_size(&self) -> usize {
+        (**self).stv_abi_packed_encoded_size()
     }
 }
 
@@ -493,6 +530,11 @@ where
     fn stv_abi_encode_packed_to(&self, out: &mut Vec<u8>) {
         (**self).stv_abi_encode_packed_to(out)
     }
+
+    #[inline]
+    fn stv_abi_packed_encoded_size(&self) -> usize {
+        (**self).stv_abi_packed_encoded_size()
+    }
 }
 
 impl<T: SolType> SolType for Array<T> {
@@ -502,6 +544,7 @@ impl<T: SolType> SolType for Array<T> {
     const SOL_NAME: &'static str =
         NameBuffer::new().write_str(T::SOL_NAME).write_str("[]").as_str();
     const ENCODED_SIZE: Option<usize> = None;
+    const PACKED_ENCODED_SIZE: Option<usize> = None;
 
     #[inline]
     fn valid_token(token: &Self::Token<'_>) -> bool {
@@ -556,8 +599,17 @@ where
     #[inline]
     fn stv_abi_encode_packed_to(&self, out: &mut Vec<u8>) {
         for item in self {
+            // Array elements are left-padded to 32 bytes.
+            if let Some(padding_needed) = 32usize.checked_sub(item.stv_abi_packed_encoded_size()) {
+                out.extend(core::iter::repeat(0).take(padding_needed));
+            }
             T::stv_abi_encode_packed_to(item, out);
         }
+    }
+
+    #[inline]
+    fn stv_abi_packed_encoded_size(&self) -> usize {
+        self.iter().map(|item| item.stv_abi_packed_encoded_size().max(32)).sum()
     }
 }
 
@@ -585,6 +637,11 @@ where
     fn stv_abi_encode_packed_to(&self, out: &mut Vec<u8>) {
         SolTypeValue::<FixedArray<U, N>>::stv_abi_encode_packed_to(&**self, out)
     }
+
+    #[inline]
+    fn stv_abi_packed_encoded_size(&self) -> usize {
+        SolTypeValue::<FixedArray<U, N>>::stv_abi_packed_encoded_size(&**self)
+    }
 }
 
 impl<T, U, const N: usize> SolTypeValue<FixedArray<U, N>> for &mut [T; N]
@@ -611,6 +668,11 @@ where
     fn stv_abi_encode_packed_to(&self, out: &mut Vec<u8>) {
         SolTypeValue::<FixedArray<U, N>>::stv_abi_encode_packed_to(&**self, out)
     }
+
+    #[inline]
+    fn stv_abi_packed_encoded_size(&self) -> usize {
+        SolTypeValue::<FixedArray<U, N>>::stv_abi_packed_encoded_size(&**self)
+    }
 }
 
 impl<T: SolType, const N: usize> SolType for FixedArray<T, N> {
@@ -623,12 +685,11 @@ impl<T: SolType, const N: usize> SolType for FixedArray<T, N> {
         .write_usize(N)
         .write_byte(b']')
         .as_str();
-    const ENCODED_SIZE: Option<usize> = {
-        match T::ENCODED_SIZE {
-            Some(size) => Some(size * N),
-            None => None,
-        }
+    const ENCODED_SIZE: Option<usize> = match T::ENCODED_SIZE {
+        Some(size) => Some(size * N),
+        None => None,
     };
+    const PACKED_ENCODED_SIZE: Option<usize> = None;
 
     #[inline]
     fn valid_token(token: &Self::Token<'_>) -> bool {
@@ -667,7 +728,6 @@ macro_rules! tuple_encodable_impls {
 
             fn stv_abi_encode_packed_to(&self, out: &mut Vec<u8>) {
                 let ($($ty,)+) = self;
-                // TODO: Reserve
                 $(
                     $ty.stv_abi_encode_packed_to(out);
                 )+
@@ -681,6 +741,11 @@ macro_rules! tuple_encodable_impls {
                 // SAFETY: Flattening [[u8; 32]; $count] to [u8; $count * 32] is valid
                 let encoding: &[u8] = unsafe { core::slice::from_raw_parts(encoding.as_ptr().cast(), $count * 32) };
                 keccak256(encoding).into()
+            }
+
+            fn stv_abi_packed_encoded_size(&self) -> usize {
+                let ($($ty,)+) = self;
+                0 $(+ $ty.stv_abi_packed_encoded_size())+
             }
         }
     };
@@ -706,6 +771,16 @@ macro_rules! tuple_impls {
                 let mut acc = 0;
                 $(
                     match <$ty as SolType>::ENCODED_SIZE {
+                        Some(size) => acc += size,
+                        None => break 'l None,
+                    }
+                )+
+                Some(acc)
+            };
+            const PACKED_ENCODED_SIZE: Option<usize> = 'l: {
+                let mut acc = 0;
+                $(
+                    match <$ty as SolType>::PACKED_ENCODED_SIZE {
                         Some(size) => acc += size,
                         None => break 'l None,
                     }
@@ -749,6 +824,7 @@ impl SolType for () {
 
     const SOL_NAME: &'static str = "()";
     const ENCODED_SIZE: Option<usize> = Some(0);
+    const PACKED_ENCODED_SIZE: Option<usize> = Some(0);
 
     #[inline]
     fn valid_token((): &()) -> bool {

--- a/crates/sol-types/src/types/event/topic.rs
+++ b/crates/sol-types/src/types/event/topic.rs
@@ -208,8 +208,6 @@ all_the_tuples!(tuple_impls);
 fn encode_topic_bytes(sl: &[u8], out: &mut Vec<u8>) {
     let padding = 32 - sl.len() % 32;
     out.reserve(sl.len() + padding);
-
-    static PAD: [u8; 32] = [0; 32];
     out.extend_from_slice(sl);
-    out.extend_from_slice(&PAD[..padding]);
+    out.extend(core::iter::repeat(0).take(padding));
 }

--- a/crates/sol-types/src/types/ty.rs
+++ b/crates/sol-types/src/types/ty.rs
@@ -112,6 +112,12 @@ pub trait SolType: Sized {
     /// encoded size is dynamic.
     const ENCODED_SIZE: Option<usize>;
 
+    /// The statically-known Non-standard Packed Mode ABI-encoded size of the type.
+    ///
+    /// If this is not known at compile time, this should be `None`, which indicates that the
+    /// encoded size is dynamic.
+    const PACKED_ENCODED_SIZE: Option<usize>;
+
     /// Whether the ABI-encoded size is dynamic.
     ///
     /// There should be no need to override the default implementation.
@@ -171,6 +177,14 @@ pub trait SolType: Sized {
         rust.stv_eip712_data_word()
     }
 
+    /// Returns the length of this value when ABI-encoded in Non-standard Packed Mode.
+    ///
+    /// See [`abi_encode_packed`][SolType::abi_encode_packed] for more details.
+    #[inline]
+    fn abi_packed_encoded_size<E: ?Sized + SolTypeValue<Self>>(rust: &E) -> usize {
+        rust.stv_abi_packed_encoded_size()
+    }
+
     /// Non-standard Packed Mode ABI encoding.
     ///
     /// See [`abi_encode_packed`][SolType::abi_encode_packed] for more details.
@@ -189,7 +203,7 @@ pub trait SolType: Sized {
     /// More information can be found in the [Solidity docs](https://docs.soliditylang.org/en/latest/abi-spec.html#non-standard-packed-mode).
     #[inline]
     fn abi_encode_packed<E: ?Sized + SolTypeValue<Self>>(rust: &E) -> Vec<u8> {
-        let mut out = Vec::new();
+        let mut out = Vec::with_capacity(Self::abi_packed_encoded_size(rust));
         Self::abi_encode_packed_to(rust, &mut out);
         out
     }


### PR DESCRIPTION
For reserving before encoding in packed mode, and for calculating the padding needed at runtime for arrays