### PR TITLE
feat: implement namespaces on `sol!` side

### DIFF
--- a/crates/json-abi/src/to_sol.rs
+++ b/crates/json-abi/src/to_sol.rs
@@ -241,10 +241,14 @@ impl<'a> InternalTypes<'a> {
 
     fn extend_one(&mut self, contract: &'a Option<String>, it: It<'a>) {
         let contract = contract.as_ref();
-        if contract.is_none() || contract.unwrap() == self.name {
-            self.this_its.insert(it);
+        if let Some(contract) = contract {
+            if contract == self.name {
+                self.this_its.insert(it);
+            } else {
+                self.other.entry(contract).or_default().insert(it);
+            }
         } else {
-            self.other.entry(contract.unwrap()).or_default().insert(it);
+            self.this_its.insert(it);
         }
     }
 }

--- a/crates/sol-macro-expander/src/expand/contract.rs
+++ b/crates/sol-macro-expander/src/expand/contract.rs
@@ -28,7 +28,7 @@ use syn::{parse_quote, Attribute, Result};
 ///    }
 /// }
 /// ```
-pub(super) fn expand(cx: &ExpCtxt<'_>, contract: &ItemContract) -> Result<TokenStream> {
+pub(super) fn expand(cx: &mut ExpCtxt<'_>, contract: &ItemContract) -> Result<TokenStream> {
     let ItemContract { name, body, .. } = contract;
 
     let (sol_attrs, attrs) = contract.split_attrs()?;

--- a/crates/sol-macro-expander/src/expand/mod.rs
+++ b/crates/sol-macro-expander/src/expand/mod.rs
@@ -48,7 +48,7 @@ pub fn expand(ast: File) -> Result<TokenStream> {
     ExpCtxt::new(&ast).expand()
 }
 
-/// Mapping namespace -> ident -> t
+/// Mapping namespace -> ident -> T
 ///
 /// Keeps namespaced items. Namespace `None` represents global namespace (top-level items).
 /// Namespace `Some(ident)` represents items declared inside of a contract.

--- a/crates/sol-macro-expander/src/expand/mod.rs
+++ b/crates/sol-macro-expander/src/expand/mod.rs
@@ -447,13 +447,7 @@ impl<'ast> ExpCtxt<'ast> {
     fn custom_type(&self, name: &SolPath) -> &Type {
         match self.try_custom_type(name) {
             Some(item) => item,
-            None => abort!(
-                name.span(),
-                "unresolved custom type: {} {:?} {:?}",
-                name,
-                self.current_namespace,
-                self.custom_types
-            ),
+            None => abort!(name.span(), "unresolved custom type: {}", name),
         }
     }
 

--- a/crates/sol-macro-expander/src/expand/mod.rs
+++ b/crates/sol-macro-expander/src/expand/mod.rs
@@ -6,8 +6,8 @@ use crate::{
 };
 use alloy_sol_macro_input::{ContainsSolAttrs, SolAttrs};
 use ast::{
-    EventParameter, File, Item, ItemContract, ItemError, ItemEvent, ItemFunction, Parameters,
-    SolIdent, SolPath, Spanned, Type, VariableDeclaration, Visit,
+    EventParameter, File, Item, ItemError, ItemEvent, ItemFunction, Parameters, SolIdent, SolPath,
+    Spanned, Type, VariableDeclaration, Visit,
 };
 use indexmap::IndexMap;
 use proc_macro2::{Delimiter, Group, Ident, Punct, Spacing, Span, TokenStream, TokenTree};
@@ -429,7 +429,7 @@ impl<'ast> ExpCtxt<'ast> {
     }
 
     fn try_item(&self, name: &SolPath) -> Option<&Item> {
-        self.all_items.resolve(name, &self.current_namespace).map(|i| *i)
+        self.all_items.resolve(name, &self.current_namespace).copied()
     }
 
     /// Recursively resolves the given type by constructing a new one.

--- a/crates/sol-types/tests/macros/sol/json.rs
+++ b/crates/sol-types/tests/macros/sol/json.rs
@@ -69,17 +69,17 @@ fn seaport() {
     );
 }
 
+// https://etherscan.io/address/0x1111111254eeb25477b68fb85ed929f73a960582#code
+sol!(
+    #[sol(docs = false)]
+    AggregationRouterV5,
+    "../json-abi/tests/abi/AggregationRouterV5.json"
+);
+
 // Handle multiple identical error objects in the JSON ABI
 // https://github.com/alloy-rs/core/issues/344
 #[test]
 fn aggregation_router_v5() {
-    // https://etherscan.io/address/0x1111111254eeb25477b68fb85ed929f73a960582#code
-    sol!(
-        #[sol(docs = false)]
-        AggregationRouterV5,
-        "../json-abi/tests/abi/AggregationRouterV5.json"
-    );
-
     assert_eq!(
         <AggregationRouterV5::ETHTransferFailed as SolError>::SIGNATURE,
         "ETHTransferFailed()"
@@ -139,11 +139,12 @@ fn uniswap_v2_factory() {
     };
 }
 
+sol!(GnosisSafe, "../json-abi/tests/abi/GnosisSafe.json");
+
 // Fully qualify `SolInterface::NAME` which conflicted with the `NAME` call
 // https://github.com/alloy-rs/core/issues/361
 #[test]
 fn gnosis_safe() {
-    sol!(GnosisSafe, "../json-abi/tests/abi/GnosisSafe.json");
     let GnosisSafe::NAMECall {} = GnosisSafe::NAMECall {};
     let GnosisSafe::NAMEReturn { _0: _ } = GnosisSafe::NAMEReturn { _0: String::new() };
 }
@@ -199,13 +200,13 @@ fn zrx_token() {
     assert_eq!(ZRXToken::approveCall::SIGNATURE, "approve(address,uint256)");
 }
 
+// https://etherscan.io/address/0xBA12222222228d8Ba445958a75a0704d566BF2C8#code
+sol!(BalancerV2Vault, "../json-abi/tests/abi/BalancerV2Vault.json");
+
 // Handle contract **array** types in JSON ABI
 // https://github.com/alloy-rs/core/issues/585
 #[test]
 fn balancer_v2_vault() {
-    // https://etherscan.io/address/0xBA12222222228d8Ba445958a75a0704d566BF2C8#code
-    sol!(BalancerV2Vault, "../json-abi/tests/abi/BalancerV2Vault.json");
-
     let _ = BalancerV2Vault::PoolBalanceChanged {
         poolId: B256::ZERO,
         liquidityProvider: Address::ZERO,

--- a/crates/sol-types/tests/macros/sol/mod.rs
+++ b/crates/sol-types/tests/macros/sol/mod.rs
@@ -927,7 +927,6 @@ fn contract_derive_default() {
 }
 
 #[test]
-#[cfg(any())] // TODO: https://github.com/alloy-rs/core/issues/660
 fn contract_namespaces() {
     mod inner {
         alloy_sol_types::sol! {


### PR DESCRIPTION
## Motivation

Makes `sol!` macro respect namespaces.

## Solution

- `current_namespace` context variable is added to `ExpCtxt` which is switched when we enter/exit contract body during AST traversal or expansion.
- `all_items`, `custom_types` and `overloaded_items` are wrapped into `NamespacedMap` which resolves full `SolPath`s depending on current namespace


cc @DaniPopes please take a look and lmk if I should switch base to master instead

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
