### PR TITLE
chore(primitives): re-use ruint mask function

### DIFF
--- a/crates/primitives/src/signed/int.rs
+++ b/crates/primitives/src/signed/int.rs
@@ -104,7 +104,7 @@ impl<const BITS: usize, const LIMBS: usize> fmt::UpperHex for Signed<BITS, LIMBS
 
 impl<const BITS: usize, const LIMBS: usize> Signed<BITS, LIMBS> {
     /// Mask for the highest limb.
-    pub(crate) const MASK: u64 = mask(BITS);
+    pub(crate) const MASK: u64 = ruint::mask(BITS);
 
     /// Location of the sign bit within the highest limb.
     pub(crate) const SIGN_BIT: u64 = sign_bit(BITS);

--- a/crates/primitives/src/signed/utils.rs
+++ b/crates/primitives/src/signed/utils.rs
@@ -93,17 +93,3 @@ pub(super) const fn sign_bit(bits: usize) -> u64 {
         1 << (bits - 1)
     }
 }
-
-/// Mask to apply to the highest limb to get the correct number of bits.
-#[must_use]
-pub(super) const fn mask(bits: usize) -> u64 {
-    if bits == 0 {
-        return 0;
-    }
-    let bits = bits % 64;
-    if bits == 0 {
-        u64::MAX
-    } else {
-        (1 << bits) - 1
-    }
-}


### PR DESCRIPTION
the underline ruint crate already have mask method

## Motivation
DRY

## Solution
use ruint::mask

Fix #695

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
