### PR TITLE
fix(parser): add `no_std` support for `CustomError`

### DIFF
--- a/crates/sol-type-parser/src/input.rs
+++ b/crates/sol-type-parser/src/input.rs
@@ -24,6 +24,8 @@ impl fmt::Display for CustomError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for CustomError {}
+#[cfg(not(feature = "std"))]
+impl core::error::Error for CustomError {}
 
 pub type Input<'a> = winnow::Stateful<&'a str, RecursionCheck>;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Closes #717.

## Solution
`impl core::error::Error for CustomError`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
