### PR TITLE
fix: Turn off derive_more default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ quote = "1.0"
 syn = "2.0"
 
 cfg-if = "1.0.0"
-derive_more = { version = "1.0", features = ["full"] }
+derive_more = { version = "1.0", default-features = false, features = ["display"] }
 hex-literal = "0.4"
 paste = "1.0"
 num_enum = "0.7"


### PR DESCRIPTION
### Description

Turns off default-features for the `derive_more` dep to support `no_std`.