### PR TITLE
feat: prepare reth Signature migration to alloy

### DIFF
--- a/crates/primitives/src/signature/parity.rs
+++ b/crates/primitives/src/signature/parity.rs
@@ -16,16 +16,16 @@ pub enum Parity {
     Parity(bool),
 }
 
+impl Default for Parity {
+    fn default() -> Self {
+        Self::Parity(false)
+    }
+}
+
 #[cfg(feature = "k256")]
 impl From<k256::ecdsa::RecoveryId> for Parity {
     fn from(value: k256::ecdsa::RecoveryId) -> Self {
         Self::Parity(value.is_y_odd())
-    }
-}
-
-impl Default for Parity {
-    fn default() -> Self {
-        Self::Parity(false)
     }
 }
 

--- a/crates/primitives/src/signature/parity.rs
+++ b/crates/primitives/src/signature/parity.rs
@@ -23,6 +23,12 @@ impl From<k256::ecdsa::RecoveryId> for Parity {
     }
 }
 
+impl Default for Parity {
+    fn default() -> Self {
+        Self::Parity(false)
+    }
+}
+
 impl TryFrom<U64> for Parity {
     type Error = <Self as TryFrom<u64>>::Error;
     fn try_from(value: U64) -> Result<Self, Self::Error> {

--- a/crates/primitives/src/signature/sig.rs
+++ b/crates/primitives/src/signature/sig.rs
@@ -3,7 +3,7 @@
 use crate::{
     hex,
     signature::{Parity, SignatureError},
-    uint, U256,
+    uint, Bytes, U256,
 };
 use alloc::vec::Vec;
 use core::str::FromStr;
@@ -314,6 +314,11 @@ impl Signature {
         sig
     }
 
+    /// Turn this signature into its hex-encoded representation.
+    pub fn as_hex_bytes(&self) -> Bytes {
+        self.as_bytes().into()
+    }
+
     /// Sets the recovery ID by normalizing a `v` value.
     #[inline]
     pub fn with_parity<T: Into<Parity>>(self, parity: T) -> Self {
@@ -588,6 +593,7 @@ mod tests {
 
     #[cfg(feature = "rlp")]
     use alloy_rlp::{Decodable, Encodable};
+    use hex::FromHex;
 
     #[test]
     #[cfg(feature = "k256")]
@@ -781,5 +787,23 @@ mod tests {
 
         // Assert that the length of the Signature matches the expected length
         assert_eq!(sig.length(), 69);
+    }
+
+    #[test]
+    fn test_as_hex_bytes() {
+        let signature = Signature::new(
+            U256::from_str(
+                "18515461264373351373200002665853028612451056578545711640558177340181847433846",
+            )
+            .unwrap(),
+            U256::from_str(
+                "46948507304638947509940763649030358759909902576025900602547168820602576006531",
+            )
+            .unwrap(),
+            Parity::Parity(false),
+        );
+
+        let expected = Bytes::from_hex("0x28ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa63627667cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d831b").unwrap();
+        assert_eq!(signature.as_hex_bytes(), expected);
     }
 }

--- a/crates/primitives/src/signature/sig.rs
+++ b/crates/primitives/src/signature/sig.rs
@@ -3,7 +3,7 @@
 use crate::{
     hex,
     signature::{Parity, SignatureError},
-    uint, Bytes, U256,
+    uint, U256,
 };
 use alloc::vec::Vec;
 use core::str::FromStr;
@@ -314,11 +314,6 @@ impl Signature {
         sig
     }
 
-    /// Turn this signature into its hex-encoded representation.
-    pub fn as_hex_bytes(&self) -> Bytes {
-        self.as_bytes().into()
-    }
-
     /// Sets the recovery ID by normalizing a `v` value.
     #[inline]
     pub fn with_parity<T: Into<Parity>>(self, parity: T) -> Self {
@@ -588,6 +583,8 @@ impl proptest::arbitrary::Arbitrary for Signature {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
+    use crate::Bytes;
+
     use super::*;
     use std::str::FromStr;
 
@@ -809,7 +806,7 @@ mod tests {
     }
 
     #[test]
-    fn test_as_hex_bytes() {
+    fn test_as_bytes() {
         let signature = Signature::new(
             U256::from_str(
                 "18515461264373351373200002665853028612451056578545711640558177340181847433846",
@@ -823,6 +820,6 @@ mod tests {
         );
 
         let expected = Bytes::from_hex("0x28ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa63627667cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d831b").unwrap();
-        assert_eq!(signature.as_hex_bytes(), expected);
+        assert_eq!(signature.as_bytes(), **expected);
     }
 }

--- a/crates/primitives/src/signature/sig.rs
+++ b/crates/primitives/src/signature/sig.rs
@@ -795,6 +795,42 @@ mod tests {
         assert_eq!(sig.length(), 69);
     }
 
+    #[cfg(feature = "rlp")]
+    #[test]
+    fn test_rlp_vrs_len() {
+        let signature = Signature::default();
+        assert_eq!(3, signature.rlp_vrs_len());
+    }
+
+    #[cfg(feature = "rlp")]
+    #[test]
+    fn test_encode_and_decode() {
+        let signature = Signature::default();
+
+        let mut encoded = Vec::new();
+        signature.encode(&mut encoded);
+        assert_eq!(encoded.len(), signature.length());
+        let decoded = Signature::decode(&mut &*encoded).unwrap();
+        assert_eq!(signature, decoded);
+    }
+
+    #[test]
+    fn ensure_size_equals_sum_of_fields() {
+        let signature = Signature::new(
+            U256::from_str(
+                "18515461264373351373200002665853028612451056578545711640558177340181847433846",
+            )
+            .unwrap(),
+            U256::from_str(
+                "46948507304638947509940763649030358759909902576025900602547168820602576006531",
+            )
+            .unwrap(),
+            Parity::Parity(false),
+        );
+
+        assert!(signature.size() >= 65);
+    }
+
     #[test]
     fn test_as_hex_bytes() {
         let signature = Signature::new(

--- a/crates/primitives/src/signature/sig.rs
+++ b/crates/primitives/src/signature/sig.rs
@@ -356,6 +356,12 @@ impl Signature {
         self.write_rlp_v(out);
         self.write_rlp_rs(out);
     }
+
+    /// Calculates a heuristic for the in-memory size of the [Signature].
+    #[inline]
+    pub const fn size(&self) -> usize {
+        core::mem::size_of::<Self>()
+    }
 }
 
 #[cfg(feature = "rlp")]

--- a/crates/primitives/src/signature/sig.rs
+++ b/crates/primitives/src/signature/sig.rs
@@ -356,12 +356,6 @@ impl Signature {
         self.write_rlp_v(out);
         self.write_rlp_rs(out);
     }
-
-    /// Calculates a heuristic for the in-memory size of the [Signature].
-    #[inline]
-    pub const fn size(&self) -> usize {
-        core::mem::size_of::<Self>()
-    }
 }
 
 #[cfg(feature = "rlp")]
@@ -812,23 +806,6 @@ mod tests {
         assert_eq!(encoded.len(), signature.length());
         let decoded = Signature::decode(&mut &*encoded).unwrap();
         assert_eq!(signature, decoded);
-    }
-
-    #[test]
-    fn ensure_size_equals_sum_of_fields() {
-        let signature = Signature::new(
-            U256::from_str(
-                "18515461264373351373200002665853028612451056578545711640558177340181847433846",
-            )
-            .unwrap(),
-            U256::from_str(
-                "46948507304638947509940763649030358759909902576025900602547168820602576006531",
-            )
-            .unwrap(),
-            Parity::Parity(false),
-        );
-
-        assert!(signature.size() >= 65);
     }
 
     #[test]

--- a/crates/primitives/src/signature/sig.rs
+++ b/crates/primitives/src/signature/sig.rs
@@ -13,7 +13,7 @@ const SECP256K1N_ORDER: U256 =
     uint!(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141_U256);
 
 /// An Ethereum ECDSA signature.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, Default, PartialEq, Eq)]
 pub struct Signature {
     v: Parity,
     r: U256,

--- a/crates/primitives/src/signature/sig.rs
+++ b/crates/primitives/src/signature/sig.rs
@@ -13,7 +13,7 @@ const SECP256K1N_ORDER: U256 =
     uint!(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141_U256);
 
 /// An Ethereum ECDSA signature.
-#[derive(Clone, Copy, Debug, Hash, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct Signature {
     v: Parity,
     r: U256,
@@ -789,14 +789,14 @@ mod tests {
     #[cfg(feature = "rlp")]
     #[test]
     fn test_rlp_vrs_len() {
-        let signature = Signature::default();
-        assert_eq!(3, signature.rlp_vrs_len());
+        let signature = Signature::test_signature();
+        assert_eq!(67, signature.rlp_vrs_len());
     }
 
     #[cfg(feature = "rlp")]
     #[test]
     fn test_encode_and_decode() {
-        let signature = Signature::default();
+        let signature = Signature::test_signature();
 
         let mut encoded = Vec::new();
         signature.encode(&mut encoded);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

To achieve https://github.com/paradigmxyz/reth/issues/10750 and replace reth Signature type by alloy one, 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

The following is needed:

- impl Default for Parity
- impl Hash and Default for Signature
- add as_hex_bytes() and size() to Signature

I also moved some unit tests from reth to alloy.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
