### PR TITLE
fix(sol-macro): correctly determine whether event parameters are hashes

### DIFF
--- a/crates/sol-types/src/types/event/mod.rs
+++ b/crates/sol-types/src/types/event/mod.rs
@@ -47,6 +47,7 @@ pub trait SolEvent: Sized {
     ///
     /// For non-anonymous events, this will be the first topic (`topic0`).
     /// For anonymous events, this is unused, but is still present.
+    #[doc(alias = "SELECTOR")]
     const SIGNATURE_HASH: FixedBytes<32>;
 
     /// Whether the event is anonymous.

--- a/crates/sol-types/tests/macros/sol/mod.rs
+++ b/crates/sol-types/tests/macros/sol/mod.rs
@@ -1084,3 +1084,67 @@ fn regression_nested_namespaced_structs() {
     assert_eq!(inner::C::libCNested1Call::SIGNATURE, format!("libCNested1({c_nested1})"));
     assert_eq!(inner::C::libCNested2Call::SIGNATURE, format!("libCNested2({c_nested2})"));
 }
+
+// https://github.com/alloy-rs/core/issues/734
+#[test]
+fn event_indexed_udvt() {
+    use alloy_primitives::aliases::*;
+
+    sol! {
+        type Currency is address;
+        type PoolId is bytes32;
+
+        event Initialize(
+            PoolId indexed id,
+            Currency indexed currency0,
+            Currency indexed currency1,
+            uint24 fee,
+            int24 tickSpacing,
+            address hooks,
+            uint160 sqrtPriceX96,
+            int24 tick
+        );
+    }
+
+    assert_eq!(
+        Initialize::SIGNATURE,
+        "Initialize(bytes32,address,address,uint24,int24,address,uint160,int24)",
+    );
+    assert_eq!(
+        Initialize::SIGNATURE_HASH,
+        b256!("dd466e674ea557f56295e2d0218a125ea4b4f0f6f3307b95f85e6110838d6438"),
+    );
+
+    let _ = Initialize {
+        id: B256::ZERO,
+        currency0: Address::ZERO,
+        currency1: Address::ZERO,
+        fee: U24::ZERO,
+        tickSpacing: I24::ZERO,
+        hooks: Address::ZERO,
+        sqrtPriceX96: U160::ZERO,
+        tick: I24::ZERO,
+    };
+}
+
+#[test]
+fn event_indexed_elementary_arrays() {
+    sol! {
+        event AddrArray(address[1] indexed x);
+        event AddrDynArray(address[] indexed x);
+
+        type MyAddress is address;
+        event AddrUdvtArray(MyAddress[1] indexed y);
+        event AddrUdvtDynArray(MyAddress[] indexed y);
+    }
+
+    assert_eq!(AddrArray::SIGNATURE, "AddrArray(address[1])");
+    let _ = AddrArray { x: B256::ZERO };
+    assert_eq!(AddrDynArray::SIGNATURE, "AddrDynArray(address[])");
+    let _ = AddrDynArray { x: B256::ZERO };
+
+    assert_eq!(AddrUdvtArray::SIGNATURE, "AddrUdvtArray(address[1])");
+    let _ = AddrUdvtArray { y: B256::ZERO };
+    assert_eq!(AddrUdvtDynArray::SIGNATURE, "AddrUdvtDynArray(address[])");
+    let _ = AddrUdvtDynArray { y: B256::ZERO };
+}


### PR DESCRIPTION
Currently we're determining whether an indexed parameter is encoded as a hash (B256) by checking whether it is abi-dynamic. However this:
1. does not account for custom types, so UDVTs are treated as a hash when they shouldn't;
2. is not entirely correct as it will accept elementary fixed arrays such as `address[2]`.

This is fixed by accounting for custom types and using `is_value_type` instead of whether it is ABI-dynamic. The [Solidity ABI spec](https://docs.soliditylang.org/en/latest/abi-spec.html#events) states:
> For all types of length at most 32 bytes, the EVENT_INDEXED_ARGS array contains the value directly, padded or sign-extended (for signed integers) to 32 bytes, just as for regular ABI encoding. However, for all “complex” types or types of dynamic length, including all arrays, string, bytes and structs, EVENT_INDEXED_ARGS will contain the Keccak hash of a special in-place encoded value (see [Encoding of Indexed Event Parameters](https://docs.soliditylang.org/en/latest/abi-spec.html#indexed-event-encoding)), rather than the encoded value directly.

Fixes #734.