### PR TITLE
feat: support Keccak with sha3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ thiserror = "1.0"
 k256 = { version = "0.13", default-features = false }
 keccak-asm = { version = "0.1.0", default-features = false }
 tiny-keccak = "2.0"
+sha3 = "0.10.8"
 
 # misc
 allocative = { version = "0.3.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,10 +67,11 @@ paste = "1.0"
 num_enum = "0.7"
 thiserror = "1.0"
 
+digest = "0.10"
 k256 = { version = "0.13", default-features = false }
 keccak-asm = { version = "0.1.0", default-features = false }
-tiny-keccak = "2.0"
-sha3 = "0.10.8"
+tiny-keccak = { version = "2.0", default-features = false }
+sha3 = { version = "0.10.8", default-features = false }
 
 # misc
 allocative = { version = "0.3.2", default-features = false }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -45,6 +45,7 @@ sol-types = ["dep:alloy-sol-types"]
 tiny-keccak = ["alloy-primitives/tiny-keccak"]
 native-keccak = ["alloy-primitives/native-keccak"]
 asm-keccak = ["alloy-primitives/asm-keccak"]
+sha3-keccak = ["alloy-primitives/sha3-keccak"]
 
 postgres = ["std", "alloy-primitives/postgres"]
 getrandom = ["alloy-primitives/getrandom"]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -28,6 +28,7 @@ itoa.workspace = true
 ruint.workspace = true
 tiny-keccak = { workspace = true, features = ["keccak"] }
 keccak-asm = { workspace = true, optional = true }
+sha3 = { workspace = true, optional = true }
 
 # macros
 derive_more = { workspace = true, features = [
@@ -97,6 +98,7 @@ std = [
 tiny-keccak = []
 native-keccak = []
 asm-keccak = ["dep:keccak-asm"]
+sha3-keccak = ["dep:sha3"]
 
 postgres = ["std", "dep:postgres-types", "ruint/postgres"]
 getrandom = ["dep:getrandom"]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -26,9 +26,6 @@ hex-literal.workspace = true
 hex.workspace = true
 itoa.workspace = true
 ruint.workspace = true
-tiny-keccak = { workspace = true, features = ["keccak"] }
-keccak-asm = { workspace = true, optional = true }
-sha3 = { workspace = true, optional = true }
 
 # macros
 derive_more = { workspace = true, features = [
@@ -47,6 +44,11 @@ derive_more = { workspace = true, features = [
     "display",
 ] }
 cfg-if.workspace = true
+
+# keccak256
+keccak-asm = { workspace = true, optional = true }
+sha3 = { workspace = true, optional = true }
+tiny-keccak = { workspace = true, features = ["keccak"] }
 
 # rlp
 alloy-rlp = { workspace = true, optional = true }
@@ -93,6 +95,7 @@ std = [
     "rand?/std",
     "serde?/std",
     "k256?/std",
+    "sha3?/std",
 ]
 
 tiny-keccak = []

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -10,6 +10,9 @@
 #[macro_use]
 extern crate alloc;
 
+#[cfg(feature = "sha3-keccak")]
+use sha3 as _;
+
 use tiny_keccak as _;
 
 #[cfg(feature = "postgres")]

--- a/crates/primitives/src/utils/mod.rs
+++ b/crates/primitives/src/utils/mod.rs
@@ -257,7 +257,7 @@ impl Keccak256 {
     /// Absorbs additional input. Can be called multiple times.
     #[inline]
     pub fn update(&mut self, bytes: impl AsRef<[u8]>) {
-        keccak256_state::State::update(&mut self.state, bytes.as_ref());
+        self.state.update(bytes.as_ref());
     }
 
     /// Pad and squeeze the state.

--- a/crates/primitives/src/utils/mod.rs
+++ b/crates/primitives/src/utils/mod.rs
@@ -13,16 +13,6 @@ pub use units::{
     format_ether, format_units, parse_ether, parse_units, ParseUnits, Unit, UnitsError,
 };
 
-cfg_if! {
-    if #[cfg(all(feature = "asm-keccak", not(miri)))] {
-        use keccak_asm::Digest as _;
-    } else if #[cfg(all(feature = "sha3-keccak", not(miri)))] {
-        use sha3::Digest as _;
-    } else {
-        use tiny_keccak::Hasher as _;
-    }
-}
-
 #[doc(hidden)]
 #[deprecated(since = "0.5.0", note = "use `Unit::ETHER.wei()` instead")]
 pub const WEI_IN_ETHER: crate::U256 = Unit::ETHER.wei_const();
@@ -155,7 +145,7 @@ pub fn keccak256<T: AsRef<[u8]>>(bytes: T) -> B256 {
         let mut output = MaybeUninit::<B256>::uninit();
 
         cfg_if! {
-            if #[cfg(all(feature = "native-keccak", not(feature = "sha3-keccak"), not(feature = "tiny-keccak"), not(miri)))] {
+            if #[cfg(all(feature = "native-keccak", not(any(feature = "sha3-keccak", feature = "tiny-keccak", miri))))] {
                 #[link(wasm_import_module = "vm_hooks")]
                 extern "C" {
                     /// When targeting VMs with native keccak hooks, the `native-keccak` feature
@@ -193,6 +183,45 @@ pub fn keccak256<T: AsRef<[u8]>>(bytes: T) -> B256 {
     keccak256(bytes.as_ref())
 }
 
+mod keccak256_state {
+    cfg_if::cfg_if! {
+        if #[cfg(all(feature = "asm-keccak", not(miri)))] {
+            pub(super) use keccak_asm::Digest;
+
+            pub(super) type State = keccak_asm::Keccak256;
+        } else if #[cfg(feature = "sha3-keccak")] {
+            pub(super) use sha3::Digest;
+
+            pub(super) type State = sha3::Keccak256;
+        } else {
+            pub(super) use tiny_keccak::Hasher as Digest;
+
+            /// Wraps `tiny_keccak::Keccak` to implement `Digest`-like API.
+            #[derive(Clone)]
+            pub(super) struct State(tiny_keccak::Keccak);
+
+            impl State {
+                #[inline]
+                pub(super) fn new() -> Self {
+                    Self(tiny_keccak::Keccak::v256())
+                }
+
+                #[inline]
+                pub(super) fn finalize_into(self, output: &mut [u8; 32]) {
+                    self.0.finalize(output);
+                }
+
+                #[inline]
+                pub(super) fn update(&mut self, bytes: &[u8]) {
+                    self.0.update(bytes);
+                }
+            }
+        }
+    }
+}
+#[allow(unused_imports)]
+use keccak256_state::Digest;
+
 /// Simple [`Keccak-256`] hasher.
 ///
 /// Note that the "native-keccak" feature is not supported for this struct, and will default to the
@@ -201,15 +230,7 @@ pub fn keccak256<T: AsRef<[u8]>>(bytes: T) -> B256 {
 /// [`Keccak-256`]: https://en.wikipedia.org/wiki/SHA-3
 #[derive(Clone)]
 pub struct Keccak256 {
-    #[cfg(all(feature = "asm-keccak", not(miri)))]
-    hasher: keccak_asm::Keccak256,
-    #[cfg(all(feature = "sha3-keccak", not(miri), not(all(feature = "asm-keccak", not(miri)))))]
-    hasher: sha3::Keccak256,
-    #[cfg(not(any(
-        all(feature = "asm-keccak", not(miri)),
-        all(feature = "sha3-keccak", not(miri)),
-    )))]
-    hasher: tiny_keccak::Keccak,
+    state: keccak256_state::State,
 }
 
 impl Default for Keccak256 {
@@ -230,22 +251,13 @@ impl Keccak256 {
     /// Creates a new [`Keccak256`] hasher.
     #[inline]
     pub fn new() -> Self {
-        cfg_if! {
-            if #[cfg(all(feature = "asm-keccak", not(miri)))] {
-                let hasher = keccak_asm::Keccak256::new();
-            } else if #[cfg(all(feature = "sha3-keccak", not(miri)))] {
-                let hasher = sha3::Keccak256::new();
-            } else {
-                let hasher = tiny_keccak::Keccak::v256();
-            }
-        }
-        Self { hasher }
+        Self { state: keccak256_state::State::new() }
     }
 
     /// Absorbs additional input. Can be called multiple times.
     #[inline]
     pub fn update(&mut self, bytes: impl AsRef<[u8]>) {
-        self.hasher.update(bytes.as_ref());
+        keccak256_state::State::update(&mut self.state, bytes.as_ref());
     }
 
     /// Pad and squeeze the state.
@@ -271,17 +283,9 @@ impl Keccak256 {
 
     /// Pad and squeeze the state into `output`.
     #[inline]
+    #[allow(clippy::useless_conversion)]
     pub fn finalize_into_array(self, output: &mut [u8; 32]) {
-        cfg_if! {
-            if #[cfg(all(feature = "asm-keccak", not(miri)))] {
-                self.hasher.finalize_into(output.into());
-            } else if #[cfg(all(feature = "sha3-keccak", not(miri)))] {
-                <sha3::Keccak256 as sha3::digest::DynDigest>::finalize_into(self.hasher, output)
-                    .unwrap();
-            } else {
-                self.hasher.finalize(output);
-            }
-        }
+        self.state.finalize_into(output.into());
     }
 
     /// Pad and squeeze the state into `output`.


### PR DESCRIPTION
Adds a new feature `sha3-keccak` to `alloy-primitives` that when enabled, uses `sha3` for Keccak. This can be desirable as in some cases `sha3` is faster.

This feature is added in a completely backward-compatible way: `tiny-keccak` is still the default, and downstream libs/apps will _not_ suddenly start using `sha3` by just doing `cargo update`.