### PR TITLE
Add custom serialization for Address

### DIFF
--- a/crates/dyn-abi/src/eip712/typed_data.rs
+++ b/crates/dyn-abi/src/eip712/typed_data.rs
@@ -292,6 +292,55 @@ mod tests {
     }
 
     #[test]
+    fn test_full_domain_contract_format() {
+        let json = json!({
+            "types": {
+                "EIP712Domain": [
+                    {
+                        "name": "name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "version",
+                        "type": "string"
+                    },
+                    {
+                        "name": "chainId",
+                        "type": "uint256"
+                    },
+                    {
+                        "name": "verifyingContract",
+                        "type": "address"
+                    },
+                    {
+                        "name": "salt",
+                        "type": "bytes32"
+                    }
+                ]
+            },
+            "primaryType": "EIP712Domain",
+            "domain": {
+                "name": "example.metamask.io",
+                "version": "1",
+                "chainId": 1,
+                "verifyingContract": "0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359"
+            },
+            "message": {}
+        });
+
+        let typed_data: TypedData = serde_json::from_value(json).unwrap();
+
+        let serialized_contract = typed_data.domain.verifying_contract.unwrap();
+        assert_eq!(serialized_contract.to_string(), "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359");
+
+        let hash = typed_data.eip712_signing_hash().unwrap();
+        assert_eq!(
+            hex::encode(&hash[..]),
+            "4863a6e9735dee205f3010f78d613c425a26ae2db6e4cf207f88b5d26735d378",
+        );
+    }
+
+    #[test]
     fn test_minimal_message() {
         let json = json!({
             "types": {

--- a/crates/primitives/src/bits/macros.rs
+++ b/crates/primitives/src/bits/macros.rs
@@ -595,6 +595,9 @@ macro_rules! impl_allocative {
 #[macro_export]
 #[cfg(feature = "serde")]
 macro_rules! impl_serde {
+    (Address) => {
+        // Use custom implementation for Address
+    };
     ($t:ty) => {
         #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
         impl $crate::private::serde::Serialize for $t {

--- a/crates/primitives/src/bits/serde.rs
+++ b/crates/primitives/src/bits/serde.rs
@@ -1,6 +1,5 @@
 use super::{Address, FixedBytes};
-use alloc::string::String;
-use core::{fmt, str::FromStr};
+use core::fmt;
 use serde::{
     de::{self, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
@@ -11,8 +10,12 @@ impl Serialize for Address {
     where
         S: Serializer,
     {
-        let checksum_address = self.to_checksum(None);
-        serializer.serialize_str(&checksum_address)
+        if serializer.is_human_readable() {
+            let checksum_address = self.to_checksum_buffer(None);
+            serializer.serialize_str(checksum_address.as_str())
+        } else {
+            serializer.serialize_bytes(self.as_slice())
+        }
     }
 }
 

--- a/crates/primitives/src/bits/serde.rs
+++ b/crates/primitives/src/bits/serde.rs
@@ -21,8 +21,7 @@ impl<'de> Deserialize<'de> for Address {
     where
         D: Deserializer<'de>,
     {
-        let s = String::deserialize(deserializer)?;
-        Self::from_str(&s).map_err(serde::de::Error::custom)
+        Deserialize::deserialize(deserializer).map(Self)
     }
 }
 


### PR DESCRIPTION
## Motivation

Partially closes https://github.com/foundry-rs/foundry/issues/8715
We want to serialize Address type in checksum format. 

## Solution
Solution is to implement a custom serialization function for `Address` type. 

I ran into some issues: 
1) The `impl_serde` macro conflicts with `impl Serialize for Address` (`Address` is wrapped with the `wrap_fixed_bytes` macro which calls `impl_serde`), so I added a workaround in `impl_serde` to bypass `Address` type. Another solution would be to just move the impl directly into the macro- if preferred. 

2) There's another type `EIP712Domain` which uses the type `Address`, I wanted to double check that it is okay for this to also be serialized in checksum format, I added another unit test to make it explicit.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
