### PR TITLE
Derive rlp en-/decoding for `Sealed<T>`

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -128,7 +128,7 @@ map-fxhash = ["map", "dep:rustc-hash"]
 getrandom = ["dep:getrandom"]
 k256 = ["dep:k256"]
 rand = ["dep:rand", "getrandom", "ruint/rand", "rustc-hash?/rand"]
-rlp = ["dep:alloy-rlp", "ruint/alloy-rlp"]
+rlp = ["alloy-rlp/derive", "ruint/alloy-rlp"]
 serde = [
     "dep:serde",
     "bytes/serde",

--- a/crates/primitives/src/sealed.rs
+++ b/crates/primitives/src/sealed.rs
@@ -5,6 +5,7 @@ use crate::B256;
 /// We do not implement any specific hashing algorithm here. Instead types
 /// implement the [`Sealable`] trait to provide define their own hash.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "rlp", derive(alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Sealed<T> {
     /// The inner item


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

RLP encoding of `Sealed<T>`. Ref https://github.com/paradigmxyz/reth/issues/11123.

## Solution

Enables feature `derive` for `alloy-rlp` dep, to derive en-/decoding of `Sealed<T>`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
