### PR TITLE
Fix lint `alloy-primitives`

### DIFF
--- a/crates/primitives/src/bits/fixed.rs
+++ b/crates/primitives/src/bits/fixed.rs
@@ -41,7 +41,7 @@ impl<const N: usize> Default for FixedBytes<N> {
     }
 }
 
-impl<'a, const N: usize> Default for &'a FixedBytes<N> {
+impl<const N: usize> Default for &FixedBytes<N> {
     #[inline]
     fn default() -> Self {
         &FixedBytes::ZERO

--- a/crates/primitives/src/signature/sig.rs
+++ b/crates/primitives/src/signature/sig.rs
@@ -440,7 +440,7 @@ impl<'de> serde::Deserialize<'de> for Signature {
             {
                 struct FieldVisitor;
 
-                impl<'de> serde::de::Visitor<'de> for FieldVisitor {
+                impl serde::de::Visitor<'_> for FieldVisitor {
                     type Value = Field;
 
                     fn expecting(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Failing CI due to lint warning `clippy::needless_lifetimes`.

## Solution

Fixes lint warnings for `alloy-primitives`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
