### PR TITLE
Fix lint `alloy-json-abi`

### DIFF
--- a/crates/json-abi/src/internal_type.rs
+++ b/crates/json-abi/src/internal_type.rs
@@ -277,7 +277,7 @@ const VISITOR_EXPECTED: &str = "a valid internal type";
 
 pub(crate) struct ItVisitor;
 
-impl<'de> Visitor<'de> for ItVisitor {
+impl Visitor<'_> for ItVisitor {
     type Value = InternalType;
 
     fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Failing CI due to lint warning `clippy::needless_lifetimes`.

## Solution

Fixes lint warnings for `alloy-json-abi`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
