### PR TITLE
Derive `Deref` for `Sealed<T>`

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -43,6 +43,7 @@ derive_more = { workspace = true, features = [
     "into",
     "into_iterator",
     "display",
+    "deref",
 ] }
 paste.workspace = true
 

--- a/crates/primitives/src/sealed.rs
+++ b/crates/primitives/src/sealed.rs
@@ -1,24 +1,19 @@
+use derive_more::Deref;
+
 use crate::B256;
 
 /// A consensus hashable item, with its memoized hash.
 ///
 /// We do not implement any specific hashing algorithm here. Instead types
 /// implement the [`Sealable`] trait to provide define their own hash.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Deref)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Sealed<T> {
     /// The inner item
+    #[deref]
     inner: T,
     /// Its hash.
     seal: B256,
-}
-
-impl<T> core::ops::Deref for Sealed<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        self.inner()
-    }
 }
 
 impl<T> Sealed<T> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Reduce LOC for boilerplate code

## Solution

Removes manual `Deref` impl in favour of `derive_more::Deref`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
