### PR TITLE
Derive `Arbitrary` for `Sealed<T>`

### DIFF
--- a/crates/primitives/src/sealed.rs
+++ b/crates/primitives/src/sealed.rs
@@ -6,6 +6,7 @@ use crate::B256;
 /// implement the [`Sealable`] trait to provide define their own hash.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(derive_arbitrary::Arbitrary, proptest_derive::Arbitrary))]
 pub struct Sealed<T> {
     /// The inner item
     inner: T,

--- a/crates/primitives/src/sealed.rs
+++ b/crates/primitives/src/sealed.rs
@@ -68,7 +68,7 @@ impl<T> Sealed<T> {
     }
 }
 
-#[cfg(any(test, feature = "arbitrary"))]
+#[cfg(feature = "arbitrary")]
 impl<'a, T> arbitrary::Arbitrary<'a> for Sealed<T>
 where
     T: for<'b> arbitrary::Arbitrary<'b> + Sealable,

--- a/crates/primitives/src/sealed.rs
+++ b/crates/primitives/src/sealed.rs
@@ -6,7 +6,7 @@ use crate::B256;
 /// implement the [`Sealable`] trait to provide define their own hash.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "arbitrary", derive(derive_arbitrary::Arbitrary, proptest_derive::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(proptest_derive::Arbitrary))]
 pub struct Sealed<T> {
     /// The inner item
     inner: T,
@@ -65,6 +65,16 @@ impl<T> Sealed<T> {
     #[allow(clippy::missing_const_for_fn)] // false positive
     pub fn unseal(self) -> T {
         self.into_inner()
+    }
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a, T> arbitrary::Arbitrary<'a> for Sealed<T>
+where
+    T: for<'b> arbitrary::Arbitrary<'b> + Sealable,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(T::arbitrary(u)?.seal_slow())
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`Arbitrary` is required trait bound for reth integration of `Sealed<T>`. Ref https://github.com/paradigmxyz/reth/issues/11123.

## Solution

Derives `Arbitrary` for `Sealed<T>`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
