### PR TITLE
Revert "Add custom serialization for Address"

### DIFF
--- a/crates/dyn-abi/src/eip712/typed_data.rs
+++ b/crates/dyn-abi/src/eip712/typed_data.rs
@@ -292,55 +292,6 @@ mod tests {
     }
 
     #[test]
-    fn test_full_domain_contract_format() {
-        let json = json!({
-            "types": {
-                "EIP712Domain": [
-                    {
-                        "name": "name",
-                        "type": "string"
-                    },
-                    {
-                        "name": "version",
-                        "type": "string"
-                    },
-                    {
-                        "name": "chainId",
-                        "type": "uint256"
-                    },
-                    {
-                        "name": "verifyingContract",
-                        "type": "address"
-                    },
-                    {
-                        "name": "salt",
-                        "type": "bytes32"
-                    }
-                ]
-            },
-            "primaryType": "EIP712Domain",
-            "domain": {
-                "name": "example.metamask.io",
-                "version": "1",
-                "chainId": 1,
-                "verifyingContract": "0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359"
-            },
-            "message": {}
-        });
-
-        let typed_data: TypedData = serde_json::from_value(json).unwrap();
-
-        let serialized_contract = typed_data.domain.verifying_contract.unwrap();
-        assert_eq!(serialized_contract.to_string(), "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359");
-
-        let hash = typed_data.eip712_signing_hash().unwrap();
-        assert_eq!(
-            hex::encode(&hash[..]),
-            "4863a6e9735dee205f3010f78d613c425a26ae2db6e4cf207f88b5d26735d378",
-        );
-    }
-
-    #[test]
     fn test_minimal_message() {
         let json = json!({
             "types": {

--- a/crates/primitives/src/bits/macros.rs
+++ b/crates/primitives/src/bits/macros.rs
@@ -595,9 +595,6 @@ macro_rules! impl_allocative {
 #[macro_export]
 #[cfg(feature = "serde")]
 macro_rules! impl_serde {
-    (Address) => {
-        // Use custom implementation for Address
-    };
     ($t:ty) => {
         #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
         impl $crate::private::serde::Serialize for $t {

--- a/crates/primitives/src/bits/serde.rs
+++ b/crates/primitives/src/bits/serde.rs
@@ -1,32 +1,9 @@
-use super::{Address, FixedBytes};
+use super::FixedBytes;
 use core::fmt;
 use serde::{
     de::{self, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
-
-impl Serialize for Address {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        if serializer.is_human_readable() {
-            let checksum_address = self.to_checksum_buffer(None);
-            serializer.serialize_str(checksum_address.as_str())
-        } else {
-            serializer.serialize_bytes(self.as_slice())
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for Address {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Deserialize::deserialize(deserializer).map(Self)
-    }
-}
 
 impl<const N: usize> Serialize for FixedBytes<N> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -90,8 +67,6 @@ impl<'de, const N: usize> Deserialize<'de> for FixedBytes<N> {
 
 #[cfg(test)]
 mod tests {
-    use core::str::FromStr;
-
     use super::*;
     use alloc::string::ToString;
     use serde::Deserialize;
@@ -111,14 +86,6 @@ mod tests {
         let val = serde_json::to_value(bytes).unwrap();
         assert_eq!(val, serde_json::json! {"0x000000000123456789abcdef"});
         assert_eq!(serde_json::from_value::<FixedBytes<12>>(val).unwrap(), bytes);
-    }
-
-    #[test]
-    fn serde_address() {
-        let address = Address::from_str("0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359").unwrap();
-        let ser = serde_json::to_string(&address).unwrap();
-        // serialize in checksum format
-        assert_eq!(ser, "\"0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359\"");
     }
 
     #[test]


### PR DESCRIPTION
Reverts alloy-rs/core#742

this has been received badly and also messes a lot with rpc responses, making it harder to add cross client solutions.