### PR TITLE
fix: don't enable foldhash by default

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -95,7 +95,7 @@ criterion.workspace = true
 serde_json.workspace = true
 
 [features]
-default = ["std", "map-foldhash"]
+default = ["std", "map"]
 std = [
     "bytes/std",
     "hex/std",


### PR DESCRIPTION
Fixes https://github.com/alloy-rs/core/issues/767