### PR TITLE
fix: re-enable foldhash by default, but exclude it from zkvm

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -60,6 +60,7 @@ tiny-keccak = ["alloy-primitives/tiny-keccak"]
 map = ["alloy-primitives/map"]
 map-hashbrown = ["alloy-primitives/map-hashbrown"]
 map-indexmap = ["alloy-primitives/map-indexmap"]
+map-foldhash = ["alloy-primitives/map-foldhash"]
 map-fxhash = ["alloy-primitives/map-fxhash"]
 
 getrandom = ["alloy-primitives/getrandom"]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -95,7 +95,7 @@ criterion.workspace = true
 serde_json.workspace = true
 
 [features]
-default = ["std", "map"]
+default = ["std", "map", "map-foldhash"]
 std = [
     "bytes/std",
     "hex/std",

--- a/crates/primitives/src/map/mod.rs
+++ b/crates/primitives/src/map/mod.rs
@@ -115,7 +115,8 @@ cfg_if! {
 
 // Default hasher.
 cfg_if! {
-    if #[cfg(feature = "map-foldhash")] {
+    // TODO: Use `foldhash` in zkVM when it's supported.
+    if #[cfg(all(feature = "map-foldhash", not(target_os = "zkvm")))] {
         type DefaultHashBuilderInner = foldhash::fast::RandomState;
     } else if #[cfg(feature = "map-fxhash")] {
         type DefaultHashBuilderInner = FxBuildHasher;


### PR DESCRIPTION
Address all concerns raised in https://github.com/alloy-rs/core/pull/771#issuecomment-2424120800. This is the default hasher in hashbrown 0.15, it's better to make the fix in foldhash than here.