### PR TITLE
docs: fix param type in example comment

### DIFF
--- a/crates/json-abi/src/abi.rs
+++ b/crates/json-abi/src/abi.rs
@@ -84,7 +84,7 @@ impl JsonAbi {
     ///     "function transferFrom(address from, address to, uint value)",
     ///     "function balanceOf(address owner)(uint balance)",
     ///     "event Transfer(address indexed from, address indexed to, address value)",
-    ///     "error InsufficientBalance(account owner, uint balance)",
+    ///     "error InsufficientBalance(address owner, uint balance)",
     ///     "function addPerson(tuple(string, uint16) person)",
     ///     "function addPeople(tuple(string, uint16)[] person)",
     ///     "function getPerson(uint id)(tuple(string, uint16))",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

You have made just a small mistake.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Replace `account` with `address` type because there is no account type in solidity.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Easy to understand!

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
