### PR TITLE
Implement `DerefMut` for `Log<T>`

### DIFF
--- a/crates/primitives/src/log/mod.rs
+++ b/crates/primitives/src/log/mod.rs
@@ -132,6 +132,13 @@ impl<T> core::ops::Deref for Log<T> {
     }
 }
 
+impl<T> core::ops::DerefMut for Log<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.data
+    }
+}
+
 impl Log {
     /// Creates a new log.
     #[inline]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Following #775, this implements `DerefMut` for `Log<T>` so that the methods taking `&mut self` won't have compilation errors.

Thanks @mattsse for pointing out that, this can be workarounded by accessing `log.data` directly.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

As above.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
