### PR TITLE
fix(serde): add alias `v` for `yParity`

### DIFF
--- a/crates/primitives/src/signature/primitive_sig.rs
+++ b/crates/primitives/src/signature/primitive_sig.rs
@@ -341,6 +341,7 @@ mod signature_serde {
         s: U256,
         #[serde(rename = "yParity")]
         y_parity: Option<U64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         v: Option<U64>,
     }
 

--- a/crates/primitives/src/signature/primitive_sig.rs
+++ b/crates/primitives/src/signature/primitive_sig.rs
@@ -339,7 +339,7 @@ mod signature_serde {
     struct HumanReadableRepr {
         r: U256,
         s: U256,
-        #[serde(rename = "yParity")]
+        #[serde(rename = "yParity", alias = "v")]
         y_parity: U64,
     }
 

--- a/crates/primitives/src/signature/primitive_sig.rs
+++ b/crates/primitives/src/signature/primitive_sig.rs
@@ -358,7 +358,7 @@ mod signature_serde {
             if serializer.is_human_readable() {
                 HumanReadableRepr {
                     y_parity: Some(U64::from(self.y_parity as u64)),
-                    v: None,
+                    v: Some(U64::from(self.y_parity as u64)),
                     r: self.r,
                     s: self.s,
                 }
@@ -479,7 +479,7 @@ mod tests {
         let serialized = serde_json::to_string(&signature).unwrap();
         assert_eq!(
             serialized,
-            r#"{"r":"0xc569c92f176a3be1a6352dd5005bfc751dcb32f57623dd2a23693e64bf4447b0","s":"0x1a891b566d369e79b7a66eecab1e008831e22daa15f91a0a0cf4f9f28f47ee05","yParity":"0x1"}"#
+            r#"{"r":"0xc569c92f176a3be1a6352dd5005bfc751dcb32f57623dd2a23693e64bf4447b0","s":"0x1a891b566d369e79b7a66eecab1e008831e22daa15f91a0a0cf4f9f28f47ee05","yParity":"0x1","v":"0x1"}"#
         );
     }
 
@@ -495,7 +495,7 @@ mod tests {
             true,
         );
 
-        let expected = r#"{"r":"0xc569c92f176a3be1a6352dd5005bfc751dcb32f57623dd2a23693e64bf4447b0","s":"0x1a891b566d369e79b7a66eecab1e008831e22daa15f91a0a0cf4f9f28f47ee05","yParity":"0x1"}"#;
+        let expected = r#"{"r":"0xc569c92f176a3be1a6352dd5005bfc751dcb32f57623dd2a23693e64bf4447b0","s":"0x1a891b566d369e79b7a66eecab1e008831e22daa15f91a0a0cf4f9f28f47ee05","yParity":"0x1","v":"0x1"}"#;
 
         let serialized = serde_json::to_string(&signature).unwrap();
         assert_eq!(serialized, expected);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Geth responds with `v` for EIP-1559 transactions. This PR updates default serde impl for `PrimitiveSignature` to accept `v`  in place of `yParity`. Only 0/1 values for v would get correctly deserialized.

Additionaly, we now always serialize both `v` and `yParity` for compatibility as this is done in reth: https://github.com/paradigmxyz/reth/blob/bd8c4eceb20c39c6e501d06cf906469329340bb9/crates/rpc/rpc-types-compat/src/transaction/signature.rs#L29

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
