### PR TITLE
fix: `Sealed::hash` serde

### DIFF
--- a/crates/primitives/src/sealed.rs
+++ b/crates/primitives/src/sealed.rs
@@ -14,7 +14,7 @@ pub struct Sealed<T> {
     #[deref]
     #[cfg_attr(feature = "serde", serde(flatten))]
     inner: T,
-    #[cfg_attr(feature = "serde", serde(flatten, alias = "hash"))]
+    #[cfg_attr(feature = "serde", serde(rename = "hash"))]
     /// Its hash.
     seal: B256,
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`flatten` is wrong here, and making it always (de)serialize as hash allows us to reuse it for transactions and blocks.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
