### PR TITLE
feat: expose `returns` field for `DynSolCall` type

### DIFF
--- a/crates/dyn-abi/src/dynamic/call.rs
+++ b/crates/dyn-abi/src/dynamic/call.rs
@@ -44,6 +44,11 @@ impl DynSolCall {
         self.method.as_deref()
     }
 
+    /// Get the types of the call's returns.
+    pub const fn returns(&self) -> &DynSolReturns {
+        &self.returns
+    }
+
     /// ABI encode the given values as function params.
     pub fn abi_encode_input(&self, values: &[DynSolValue]) -> Result<Vec<u8>> {
         encode_typeck(&self.parameters, values).map(prefix_selector(self.selector))


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

The `DynSolCall` implementation was not exposing the `returns` field. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add a method to get the `returns` field

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
