### PR TITLE
Make Signature::new a const fn

### DIFF
--- a/crates/primitives/src/signature/sig.rs
+++ b/crates/primitives/src/signature/sig.rs
@@ -114,8 +114,7 @@ impl Signature {
     }
 
     /// Instantiate a new signature from `r`, `s`, and `v` values.
-    #[allow(clippy::missing_const_for_fn)]
-    pub fn new(r: U256, s: U256, v: Parity) -> Self {
+    pub const fn new(r: U256, s: U256, v: Parity) -> Self {
         Self { r, s, v }
     }
 


### PR DESCRIPTION
## Motivation

Before https://github.com/alloy-rs/core/pull/719 Signature fields were public and it was possible to create `Signature { r, s, odd_y_parity }` in a const context.

## Solution

Make `Signature::new` a const fn.

## PR Checklist

- [x] ~~Added Tests~~ no need.
- [x] ~~Added Documentation~~ no need.
- [x] ~~Breaking changes~~ no need.
