### PR TITLE
fix(sol-macro): expand all getter return types

### DIFF
--- a/crates/sol-macro-expander/src/expand/var_def.rs
+++ b/crates/sol-macro-expander/src/expand/var_def.rs
@@ -43,12 +43,7 @@ fn expand_returns(cx: &ExpCtxt<'_>, f: &mut ItemFunction) -> Result<()> {
     if let Type::Custom(name) = ty {
         ty = cx.custom_type(name);
     }
-
-    // skip if not tuple with complex types
     let Type::Tuple(tup) = ty else { return Ok(()) };
-    if !tup.types.iter().any(type_is_complex) {
-        return Ok(());
-    }
 
     // retain only non-complex types
     // TODO: assign return types' names from the original struct
@@ -103,6 +98,8 @@ fn expand_returns(cx: &ExpCtxt<'_>, f: &mut ItemFunction) -> Result<()> {
 ///     }
 /// }
 /// ```
+///
+/// Ref: <https://github.com/ethereum/solidity/blob/9d7cc42bc1c12bb43e9dccf8c6c36833fdfcbbca/libsolidity/ast/Types.cpp#L2887-L2891>
 fn type_is_complex(ty: &Type) -> bool {
     matches!(ty, Type::Mapping(_) | Type::Array(_))
 }

--- a/crates/sol-types/tests/macros/sol/mod.rs
+++ b/crates/sol-types/tests/macros/sol/mod.rs
@@ -1171,3 +1171,55 @@ fn event_check_signature() {
     assert!(MyEventAnonymous::ANONYMOUS);
     let MyEventAnonymous {} = MyEventAnonymous::decode_raw_log(no_topics, &[], false).unwrap();
 }
+
+// https://github.com/alloy-rs/core/issues/811
+#[test]
+fn mapping_getters() {
+    sol! {
+        #![sol(all_derives)]
+
+        contract TestIbc {
+            /// ConnectionId -> Connection
+            mapping(uint32 => Connection) public connections;
+            /// ChannelId -> Channel
+            mapping(uint32 => Channel) public channels;
+
+            enum ConnectionState {
+                Unspecified,
+                Init,
+                TryOpen,
+                Open
+            }
+
+            struct Connection {
+                ConnectionState state;
+                uint32 client_id;
+                uint32 counterparty_client_id;
+                uint32 counterparty_connection_id;
+            }
+
+            enum ChannelState {
+                Unspecified,
+                Init,
+                TryOpen,
+                Open,
+                Closed
+            }
+
+            struct Channel {
+                ChannelState state;
+                uint32 connection_id;
+                uint32 counterparty_channel_id;
+                bytes counterparty_port_id;
+                string version;
+            }
+        }
+    }
+
+    assert_eq!(TestIbc::connectionsCall::SIGNATURE, "connections(uint32)");
+    let _ = TestIbc::connectionsReturn { _0: 0u8, _1: 0u32, _2: 0u32, _3: 0u32 };
+
+    assert_eq!(TestIbc::channelsCall::SIGNATURE, "channels(uint32)");
+    let _ =
+        TestIbc::channelsReturn { _0: 0u8, _1: 0u32, _2: 0u32, _3: bytes![], _4: String::new() };
+}


### PR DESCRIPTION
Fixes https://github.com/alloy-rs/core/issues/811

Logic was implemented slightly incorrectly from https://github.com/ethereum/solidity/blob/9d7cc42bc1c12bb43e9dccf8c6c36833fdfcbbca/libsolidity/ast/Types.cpp#L2852

This is a breaking change for the generated return type structs of some mapping getters, but it should be fine since it was incorrect before too