### PR TITLE
Remove unsafe code from macro expansions

### DIFF
--- a/crates/sol-macro-expander/src/expand/contract.rs
+++ b/crates/sol-macro-expander/src/expand/contract.rs
@@ -714,8 +714,8 @@ impl CallLikeExpander<'_> {
                     Self::SELECTORS.binary_search(&selector).is_ok()
                 }
 
-                #[inline(never)]
-                #[allow(unsafe_code, non_snake_case)]
+                #[inline]
+                #[allow(non_snake_case)]
                 fn abi_decode_raw(
                     selector: [u8; 4],
                     data: &[u8],


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

- The `sol!` macro cannot be used in projects with strict unsafe code policies.
- The current unsafe implementation of `abi_decode_raw` is not efficient: binary search (`O(log n)`) is slower than a simple jump table (`O(1)` or `O(n)` at worst, for e.g. [compare the MIR/asm output](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=0b66ad61f00025c8e9c1e4a1a93a2ab2)).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Switch `abi_decode_raw` to use a constant jump table instead of a runtime binary search.
- Generate safe code to convert between enum variants and `u8` statically.
- Make the `as_u8` function constant.
- Additionally, allow `clippy::empty_structs_with_brackets` in the generated code.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
