### PR TITLE
chore: asRef for Log

### DIFF
--- a/crates/primitives/src/log/mod.rs
+++ b/crates/primitives/src/log/mod.rs
@@ -139,6 +139,12 @@ impl<T> core::ops::DerefMut for Log<T> {
     }
 }
 
+impl<T> AsRef<Self> for Log<T> {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 impl Log {
     /// Creates a new log.
     #[inline]


### PR DESCRIPTION
adds `AsRef<Self>` for `Log`

this is useful for because we have layered logs types (rpc::Log) and we'd like to have `impl TxReveipt where T: AsRef<Log>` 

currently we use `Borrow` but this is semantically incorrect:

>Borrow also requires that Hash, Eq and Ord for a borrowed value are equivalent to those of the owned value. For this reason, if you want to borrow only a single field of a struct you can implement AsRef, but not Borrow.
https://doc.rust-lang.org/std/convert/trait.AsRef.html