### PR TITLE
chore(primitives): remove rustc-hash workaround

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ sha3 = { version = "0.10.8", default-features = false }
 hashbrown = { version = "0.15", default-features = false }
 indexmap = { version = "2.5", default-features = false }
 foldhash = { version = "0.1", default-features = false }
-rustc-hash = { version = "2.0", default-features = false }
+rustc-hash = { version = "2.1", default-features = false }
 
 # misc
 allocative = { version = "0.3.2", default-features = false }

--- a/crates/primitives/src/map/mod.rs
+++ b/crates/primitives/src/map/mod.rs
@@ -65,40 +65,7 @@ cfg_if! {
 
         cfg_if! {
             if #[cfg(all(feature = "std", feature = "rand"))] {
-                // use rustc_hash::FxRandomState as FxBuildHasherInner;
-
-                // TODO: Polyfill for https://github.com/rust-lang/rustc-hash/pull/52/
-                #[allow(missing_debug_implementations, missing_copy_implementations)]
-                #[doc(hidden)]
-                #[derive(Clone)]
-                pub struct FxBuildHasherInner(usize);
-
-                impl Default for FxBuildHasherInner {
-                    // Copied from `FxRandomState::new`.
-                    fn default() -> Self {
-                        use rand::Rng;
-                        use std::{cell::Cell, thread_local};
-
-                        thread_local!(static SEED: Cell<usize> = {
-                            Cell::new(rand::thread_rng().gen())
-                        });
-
-                        SEED.with(|seed| {
-                            let s = seed.get();
-                            seed.set(s.wrapping_add(1));
-                            Self(s)
-                        })
-                    }
-                }
-
-                impl core::hash::BuildHasher for FxBuildHasherInner {
-                    type Hasher = rustc_hash::FxHasher;
-
-                    #[inline]
-                    fn build_hasher(&self) -> Self::Hasher {
-                        rustc_hash::FxHasher::with_seed(self.0)
-                    }
-                }
+                use rustc_hash::FxRandomState as FxBuildHasherInner;
             } else {
                 use rustc_hash::FxBuildHasher as FxBuildHasherInner;
             }
@@ -115,7 +82,7 @@ cfg_if! {
 
 // Default hasher.
 cfg_if! {
-    // TODO: Use `foldhash` in zkVM when it's supported.
+    // TODO: Use `foldhash` in zkVM when it's supported. https://github.com/orlp/foldhash/issues/13
     if #[cfg(all(feature = "map-foldhash", not(target_os = "zkvm")))] {
         type DefaultHashBuilderInner = foldhash::fast::RandomState;
     } else if #[cfg(feature = "map-fxhash")] {


### PR DESCRIPTION
Linked PR was released in 2.1.0.