### PR TITLE
fix: re-enable foldhash on zkvm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ sha3 = { version = "0.10.8", default-features = false }
 # maps
 hashbrown = { version = "0.15", default-features = false }
 indexmap = { version = "2.5", default-features = false }
-foldhash = { version = "0.1", default-features = false }
+foldhash = { version = "0.1.4", default-features = false }
 rustc-hash = { version = "2.1", default-features = false }
 
 # misc

--- a/crates/primitives/src/map/mod.rs
+++ b/crates/primitives/src/map/mod.rs
@@ -82,8 +82,7 @@ cfg_if! {
 
 // Default hasher.
 cfg_if! {
-    // TODO: Use `foldhash` in zkVM when it's supported. https://github.com/orlp/foldhash/issues/13
-    if #[cfg(all(feature = "map-foldhash", not(target_os = "zkvm")))] {
+    if #[cfg(feature = "map-foldhash")] {
         type DefaultHashBuilderInner = foldhash::fast::RandomState;
     } else if #[cfg(feature = "map-fxhash")] {
         type DefaultHashBuilderInner = FxBuildHasher;


### PR DESCRIPTION
As of [v.0.1.4](https://github.com/orlp/foldhash/compare/v0.1.3...v0.1.4), the `foldhash` dependency has fixed the issue on `zkvm` targets originally reported in https://github.com/alloy-rs/core/issues/767. As such, the implemented workaround is no longer necessary as of this release and has been removed in this PR.