### PR TITLE
test: re-enable miri on foldhash

### DIFF
--- a/crates/primitives/src/map/fixed.rs
+++ b/crates/primitives/src/map/fixed.rs
@@ -204,7 +204,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore = "foldhash queries time (orlp/foldhash#4)")]
     fn fb_hasher() {
         // Just by running it once we test that it compiles and that debug assertions are correct.
         ruint::const_for!(N in [ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
@@ -215,7 +214,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore = "foldhash queries time (orlp/foldhash#4)")]
     fn map() {
         let mut map = AddressHashMap::<bool>::default();
         map.insert(Address::ZERO, true);

--- a/crates/primitives/src/map/mod.rs
+++ b/crates/primitives/src/map/mod.rs
@@ -153,7 +153,6 @@ mod tests {
     use super::*;
 
     #[test]
-    #[cfg_attr(miri, ignore = "foldhash queries time (orlp/foldhash#4)")]
     fn default_hasher_builder_traits() {
         let hash_builder = <DefaultHashBuilder as Default>::default();
         let _hash_builder2 = <DefaultHashBuilder as Clone>::clone(&hash_builder);

--- a/tests/core-sol/src/lib.rs
+++ b/tests/core-sol/src/lib.rs
@@ -65,7 +65,6 @@ sol! {
 }
 
 #[test]
-#[cfg_attr(miri, ignore = "foldhash queries time (orlp/foldhash#4)")]
 fn do_stuff() {
     let mut set = alloy_core::primitives::map::HashSet::<MyStruct>::default();
     set.insert(Default::default());


### PR DESCRIPTION
Fixed in the latest foldhash release.