### PR TITLE
docs: hide hex_literal export

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -61,6 +61,7 @@ pub use signature::{Parity, Signature};
 pub mod utils;
 pub use utils::{eip191_hash_message, keccak256, Keccak256};
 
+#[doc(hidden)] // Use `hex` directly instead!
 pub mod hex_literal;
 
 #[doc(no_inline)]


### PR DESCRIPTION
This should've never been public, since it only contains one public item (the `hex!` macro) which we already re-export at the root.