### PR TITLE
docs: enable some useful rustdoc features on docs.rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,9 +156,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-      - run: cargo doc --workspace --all-features --no-deps --document-private-items
+      - name: Build documentation
+        run: cargo doc --workspace --all-features --no-deps --document-private-items
         env:
-          RUSTDOCFLAGS: "--cfg docsrs -D warnings"
+          RUSTDOCFLAGS: --cfg docsrs -D warnings -Zunstable-options --show-type-layout --generate-link-to-definition
 
   fmt:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,6 @@ homepage = "https://github.com/alloy-rs/core"
 repository = "https://github.com/alloy-rs/core"
 exclude = ["tests"]
 
-[workspace.metadata.docs.rs]
-all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
-
 [workspace.lints.clippy]
 dbg-macro = "warn"
 manual-string-new = "warn"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,7 +15,11 @@ exclude.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = [
+    "-Zunstable-options",
+    "--generate-link-to-definition",
+    "--show-type-layout",
+]
 
 [lints]
 workspace = true

--- a/crates/dyn-abi/Cargo.toml
+++ b/crates/dyn-abi/Cargo.toml
@@ -15,7 +15,11 @@ exclude.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = [
+    "-Zunstable-options",
+    "--generate-link-to-definition",
+    "--show-type-layout",
+]
 
 [lints]
 workspace = true

--- a/crates/json-abi/Cargo.toml
+++ b/crates/json-abi/Cargo.toml
@@ -13,6 +13,14 @@ license.workspace = true
 repository.workspace = true
 exclude.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = [
+    "-Zunstable-options",
+    "--generate-link-to-definition",
+    "--show-type-layout",
+]
+
 [dependencies]
 alloy-primitives = { workspace = true, features = ["serde"] }
 alloy-sol-type-parser = { workspace = true, features = ["serde"] }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -15,7 +15,11 @@ exclude.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = [
+    "-Zunstable-options",
+    "--generate-link-to-definition",
+    "--show-type-layout",
+]
 
 [lints]
 workspace = true

--- a/crates/sol-macro-expander/Cargo.toml
+++ b/crates/sol-macro-expander/Cargo.toml
@@ -15,7 +15,11 @@ exclude.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = [
+    "-Zunstable-options",
+    "--generate-link-to-definition",
+    "--show-type-layout",
+]
 
 [lints]
 workspace = true

--- a/crates/sol-macro-input/Cargo.toml
+++ b/crates/sol-macro-input/Cargo.toml
@@ -13,6 +13,14 @@ license.workspace = true
 repository.workspace = true
 exclude.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = [
+    "-Zunstable-options",
+    "--generate-link-to-definition",
+    "--show-type-layout",
+]
+
 [dependencies]
 dunce = "1.0.4"
 heck = "0.5.0"

--- a/crates/sol-macro/Cargo.toml
+++ b/crates/sol-macro/Cargo.toml
@@ -18,7 +18,11 @@ proc-macro = true
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = [
+    "-Zunstable-options",
+    "--generate-link-to-definition",
+    "--show-type-layout",
+]
 
 [lints]
 workspace = true

--- a/crates/sol-type-parser/Cargo.toml
+++ b/crates/sol-type-parser/Cargo.toml
@@ -15,7 +15,11 @@ exclude.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = [
+    "-Zunstable-options",
+    "--generate-link-to-definition",
+    "--show-type-layout",
+]
 
 [lints]
 workspace = true

--- a/crates/sol-types/Cargo.toml
+++ b/crates/sol-types/Cargo.toml
@@ -15,7 +15,11 @@ exclude.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = [
+    "-Zunstable-options",
+    "--generate-link-to-definition",
+    "--show-type-layout",
+]
 
 [lints]
 workspace = true

--- a/crates/syn-solidity/Cargo.toml
+++ b/crates/syn-solidity/Cargo.toml
@@ -15,7 +15,11 @@ exclude.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = [
+    "-Zunstable-options",
+    "--generate-link-to-definition",
+    "--show-type-layout",
+]
 
 [lints]
 workspace = true


### PR DESCRIPTION
- [--generate-link-to-definition](https://doc.rust-lang.org/rustdoc/unstable-features.html#--generate-link-to-definition-generate-links-on-types-in-source-code)
- [--show-type-layout](https://doc.rust-lang.org/rustdoc/unstable-features.html#--show-type-layout-add-a-section-to-each-types-docs-describing-its-memory-layout)
- `--cfg docsrs` [is guaranteed to be enabled](https://docs.rs/about/builds#detecting-docsrs)
- `workspace.metadata` is not read