### PR TITLE
feat(json-abi): add Param.name() accessor

### DIFF
--- a/crates/json-abi/src/param.rs
+++ b/crates/json-abi/src/param.rs
@@ -118,6 +118,13 @@ impl Param {
         Ok(Self { ty: ty.into(), name: name.into(), components, internal_type })
     }
 
+    /// The name of the parameter. This function always returns either an empty
+    /// slice, or a valid Solidity identifier.
+    #[inline]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
     /// The internal type of the parameter.
     #[inline]
     pub const fn internal_type(&self) -> Option<&InternalType> {


### PR DESCRIPTION
Adds `Param.name()` for accessing the parameter name.

There is already `Param.name` field but it is hidden in docs.
