### PR TITLE
feat(`sol-macro-expander`): increase resolve limit to 128

### DIFF
--- a/crates/sol-macro-expander/src/expand/mod.rs
+++ b/crates/sol-macro-expander/src/expand/mod.rs
@@ -36,7 +36,7 @@ mod var_def;
 mod to_abi;
 
 /// The limit for the number of times to resolve a type.
-const RESOLVE_LIMIT: usize = 32;
+const RESOLVE_LIMIT: usize = 128;
 
 /// The [`sol!`] expansion implementation.
 ///


### PR DESCRIPTION
We ran into issues with the resolve limit when working on our migration from ethers-rs to alloy in
https://github.com/EspressoSystems/espresso-sequencer/pull/2456

The specific command we run is

    forge bind --skip test --skip script --libraries \
    contracts/src/libraries/PlonkVerifier.sol:PlonkVerifier:0xB0bfeE1e1A7Ef832149EDe013B34AD6248176385 \
    --alloy --contracts ./contracts/src/ --crate-name \
    contract-bindings-alloy --bindings-path contract-bindings-alloy
    --select \
    "^LightClient$|^LightClientArbitrum$|^LightClientStateUpdateVK$|^FeeContract$|PlonkVerifier$|^ERC1967Proxy$|^LightClientMock$|^LightClientStateUpdateVKMock$|^PlonkVerifier2$|^PermissionedStakeTable$"
    --overwrite --force

And it outputs

    [⠊] Compiling...
    [⠔] Compiling 36 files with Solc 0.8.28
    [⠒] Solc 0.8.28 finished in 1.53s
    Compiler run successful!
    Generating bindings for 11 contracts
    The application panicked (crashed).
    Message:  proc-macro-error2 API cannot be used outside of `entry_point` invocation, perhaps you forgot to annotate your #[proc_macro] function with `#[proc_macro_error]
    Location: /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro-error2-2.0.1/src/lib.rs:483

    This is a bug. Consider reporting it at
    https://github.com/foundry-rs/foundry

Setting the higher resolve limit allows us to succesfully generate the bindings.

cc @rob-maron 
