### PR TITLE
feat(`sol!`)!: gen unit/tuple structs for call types with 0/1 param

### DIFF
--- a/crates/sol-macro-expander/src/expand/function.rs
+++ b/crates/sol-macro-expander/src/expand/function.rs
@@ -60,12 +60,12 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, function: &ItemFunction) -> Result<TokenS
     let call_tuple = expand_tuple_types(parameters.types(), cx).0;
     let return_tuple = expand_tuple_types(returns.types(), cx).0;
 
-    let converts = expand_from_into_tuples(&call_name, parameters, cx, true);
+    let converts = expand_from_into_tuples(&call_name, parameters, cx, false);
     let return_converts = expand_from_into_tuples(&return_name, returns, cx, true);
 
     let signature = cx.function_signature(function);
     let selector = crate::utils::selector(&signature);
-    let tokenize_impl = expand_tokenize(parameters, cx, true);
+    let tokenize_impl = expand_tokenize(parameters, cx, false);
 
     let call_doc = docs.then(|| {
         let selector = hex::encode_prefixed(selector.array.as_slice());
@@ -97,6 +97,23 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, function: &ItemFunction) -> Result<TokenS
         }
     });
 
+    let call_struct = if parameters.is_empty() {
+        quote! {
+            pub struct #call_name;
+        }
+    } else if parameters.len() == 1 {
+        let ty = cx.expand_rust_type(&parameters[0].ty);
+        quote! {
+            pub struct #call_name(pub #ty);
+        }
+    } else {
+        quote! {
+            pub struct #call_name {
+                #(#call_fields),*
+            }
+        }
+    };
+
     let alloy_sol_types = &cx.crates.sol_types;
 
     let tokens = quote! {
@@ -104,9 +121,7 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, function: &ItemFunction) -> Result<TokenS
         #call_doc
         #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields)]
         #[derive(Clone)]
-        pub struct #call_name {
-            #(#call_fields),*
-        }
+        #call_struct
 
         #(#return_attrs)*
         #return_doc

--- a/crates/sol-macro-expander/src/expand/function.rs
+++ b/crates/sol-macro-expander/src/expand/function.rs
@@ -101,7 +101,7 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, function: &ItemFunction) -> Result<TokenS
         quote! {
             pub struct #call_name;
         }
-    } else if parameters.len() == 1 {
+    } else if parameters.len() == 1 && parameters[0].name.is_none() {
         let ty = cx.expand_rust_type(&parameters[0].ty);
         quote! {
             pub struct #call_name(pub #ty);

--- a/crates/sol-macro/doctests/function_like.rs
+++ b/crates/sol-macro/doctests/function_like.rs
@@ -29,14 +29,14 @@ fn function() {
     let _ = overloaded_0Call {};
     assert_call_signature::<overloaded_0Call>("overloaded()");
 
-    let _ = overloaded_1Call { _0: U256::from(1) };
+    let _ = overloaded_1Call(U256::from(1));
     assert_call_signature::<overloaded_1Call>("overloaded(uint256)");
 
-    let _ = overloaded_2Call { _0: "hello".into() };
+    let _ = overloaded_2Call("hello".into());
     assert_call_signature::<overloaded_2Call>("overloaded(string)");
 
     // Exactly the same as `function variableGetter(uint256) returns (bool)`.
-    let _ = variableGetterCall { k: U256::from(2) };
+    let _ = variableGetterCall(U256::from(2));
     assert_call_signature::<variableGetterCall>("variableGetter(uint256)");
     let _ = variableGetterReturn { v: false };
 }

--- a/crates/sol-macro/doctests/function_like.rs
+++ b/crates/sol-macro/doctests/function_like.rs
@@ -36,7 +36,7 @@ fn function() {
     assert_call_signature::<overloaded_2Call>("overloaded(string)");
 
     // Exactly the same as `function variableGetter(uint256) returns (bool)`.
-    let _ = variableGetterCall(U256::from(2));
+    let _ = variableGetterCall { k: U256::from(2) };
     assert_call_signature::<variableGetterCall>("variableGetter(uint256)");
     let _ = variableGetterReturn { v: false };
 }

--- a/crates/sol-types/tests/macros/sol/json.rs
+++ b/crates/sol-types/tests/macros/sol/json.rs
@@ -13,7 +13,7 @@ fn large_array() {
         "../json-abi/tests/abi/LargeArray.json"
     );
 
-    let call = LargeArray::callWithLongArrayCall { longArray: [0; 128] };
+    let call = LargeArray::callWithLongArrayCall([0; 128]);
     let _ = format!("{call:#?}");
 
     assert_eq!(LargeArray::callWithLongArrayCall::SIGNATURE, "callWithLongArray(uint64[128])");

--- a/crates/sol-types/tests/macros/sol/json.rs
+++ b/crates/sol-types/tests/macros/sol/json.rs
@@ -13,7 +13,7 @@ fn large_array() {
         "../json-abi/tests/abi/LargeArray.json"
     );
 
-    let call = LargeArray::callWithLongArrayCall([0; 128]);
+    let call = LargeArray::callWithLongArrayCall { longArray: [0; 128] };
     let _ = format!("{call:#?}");
 
     assert_eq!(LargeArray::callWithLongArrayCall::SIGNATURE, "callWithLongArray(uint64[128])");

--- a/crates/sol-types/tests/macros/sol/mod.rs
+++ b/crates/sol-types/tests/macros/sol/mod.rs
@@ -260,7 +260,7 @@ fn getter_names() {
     let _ = Getters::mapCall(B256::ZERO);
     let _ = Getters::mapReturn { _0: String::new() };
 
-    let _ = Getters::mapWithNamesCall(B256::ZERO);
+    let _ = Getters::mapWithNamesCall { k: B256::ZERO };
     let _ = Getters::mapWithNamesReturn { v: String::new() };
 
     let _ = Getters::nestedMapWithNamesCall { k1: B256::ZERO, k2: U256::ZERO };
@@ -543,7 +543,7 @@ fn most_rust_keywords() {
                 assert_eq!($raw::NAME, stringify!($kw));
                 assert_ne!($raw::NAME, stringify!($raw));
                 assert_eq!(<[<$kw Call>]>::SIGNATURE, concat!(stringify!($kw), "(bytes1)"));
-                let _ = [<$kw Call>]([0u8; 1].into());
+                let _ = [<$kw Call>] { $raw: [0u8; 1].into()};
                 assert_eq!(error::$raw::SIGNATURE, concat!(stringify!($kw), "(bytes2)"));
                 let _ = error::$raw { $raw: [0u8; 2].into() };
                 assert_eq!(event::$raw::SIGNATURE, concat!(stringify!($kw), "(bytes3)"));
@@ -923,7 +923,7 @@ fn contract_derive_default() {
     }
 
     let MyContract::f1Call(_) = MyContract::f1Call::default();
-    let MyContract::f2Call(_) = MyContract::f2Call::default();
+    let MyContract::f2Call { b: _ } = MyContract::f2Call::default();
     let MyContract::e1 {} = MyContract::e1::default();
     let MyContract::e2 {} = MyContract::e2::default();
     #[allow(clippy::default_constructed_unit_structs)]
@@ -995,11 +995,11 @@ fn regression_overloads() {
         }
     }
 
-    let _ = Vm::getNonce_0Call(Address::ZERO);
+    let _ = Vm::getNonce_0Call { account: Address::ZERO };
     let _ = Vm::getNonce_0Return { nonce: 0 };
     assert_eq!(Vm::getNonce_0Call::SIGNATURE, "getNonce(address)");
 
-    let _ = Vm::getNonce_1Call(Vm::Wallet { stuff: U256::ZERO });
+    let _ = Vm::getNonce_1Call { wallet: Vm::Wallet { stuff: U256::ZERO } };
     let _ = Vm::getNonce_1Return { nonce: 0 };
     assert_eq!(Vm::getNonce_1Call::SIGNATURE, "getNonce((uint256))");
 }
@@ -1015,7 +1015,7 @@ fn normal_paths() {
         function func(I.S memory stuff);
     }
 
-    let _ = funcCall(I::S { x: U256::ZERO });
+    let _ = funcCall { stuff: I::S { x: U256::ZERO } };
 }
 
 #[test]

--- a/crates/sol-types/tests/macros/sol/mod.rs
+++ b/crates/sol-types/tests/macros/sol/mod.rs
@@ -254,13 +254,13 @@ fn getter_names() {
     let _ = Getters::valueCall {};
     let _ = Getters::valueReturn { value: String::new() };
 
-    let _ = Getters::arrayCall { _0: U256::ZERO };
+    let _ = Getters::arrayCall(U256::ZERO);
     let _ = Getters::arrayReturn { _0: String::new() };
 
-    let _ = Getters::mapCall { _0: B256::ZERO };
+    let _ = Getters::mapCall(B256::ZERO);
     let _ = Getters::mapReturn { _0: String::new() };
 
-    let _ = Getters::mapWithNamesCall { k: B256::ZERO };
+    let _ = Getters::mapWithNamesCall(B256::ZERO);
     let _ = Getters::mapWithNamesReturn { v: String::new() };
 
     let _ = Getters::nestedMapWithNamesCall { k1: B256::ZERO, k2: U256::ZERO };
@@ -497,17 +497,17 @@ fn rust_keywords() {
                 bytes32 box;
             }
 
-            function mod(address impl) returns (bool is, bool fn);
+            function mod(address impl, address some) returns (bool is, bool fn);
         }
     }
     use r#dyn::*;
 
     let _ = r#const { r#unsafe: true, r#box: Default::default() };
-    let m = modCall { r#impl: Address::ZERO };
+    let m = modCall { r#impl: Address::ZERO, some: Address::ZERO };
     let _ = dynCalls::r#mod(m);
     let _ = modReturn { is: true, r#fn: false };
     assert_eq!(r#const::NAME, "const");
-    assert_eq!(modCall::SIGNATURE, "mod(address)");
+    assert_eq!(modCall::SIGNATURE, "mod(address,address)");
 }
 
 #[test]
@@ -543,7 +543,7 @@ fn most_rust_keywords() {
                 assert_eq!($raw::NAME, stringify!($kw));
                 assert_ne!($raw::NAME, stringify!($raw));
                 assert_eq!(<[<$kw Call>]>::SIGNATURE, concat!(stringify!($kw), "(bytes1)"));
-                let _ = [<$kw Call>] { $raw: [0u8; 1].into() };
+                let _ = [<$kw Call>]([0u8; 1].into());
                 assert_eq!(error::$raw::SIGNATURE, concat!(stringify!($kw), "(bytes2)"));
                 let _ = error::$raw([0u8; 2].into());
                 assert_eq!(event::$raw::SIGNATURE, concat!(stringify!($kw), "(bytes3)"));
@@ -914,16 +914,16 @@ fn contract_derive_default() {
     sol! {
         #[derive(Debug, Default)]
         contract MyContract {
-            function f1();
-            function f2();
+            function f1(address);
+            function f2(address b);
             event e1();
             event e2();
             error c();
         }
     }
 
-    let MyContract::f1Call {} = MyContract::f1Call::default();
-    let MyContract::f2Call {} = MyContract::f2Call::default();
+    let MyContract::f1Call(_) = MyContract::f1Call::default();
+    let MyContract::f2Call(_) = MyContract::f2Call::default();
     let MyContract::e1 {} = MyContract::e1::default();
     let MyContract::e2 {} = MyContract::e2::default();
     #[allow(clippy::default_constructed_unit_structs)]
@@ -995,11 +995,11 @@ fn regression_overloads() {
         }
     }
 
-    let _ = Vm::getNonce_0Call { account: Address::ZERO };
+    let _ = Vm::getNonce_0Call(Address::ZERO);
     let _ = Vm::getNonce_0Return { nonce: 0 };
     assert_eq!(Vm::getNonce_0Call::SIGNATURE, "getNonce(address)");
 
-    let _ = Vm::getNonce_1Call { wallet: Vm::Wallet { stuff: U256::ZERO } };
+    let _ = Vm::getNonce_1Call(Vm::Wallet { stuff: U256::ZERO });
     let _ = Vm::getNonce_1Return { nonce: 0 };
     assert_eq!(Vm::getNonce_1Call::SIGNATURE, "getNonce((uint256))");
 }
@@ -1015,7 +1015,7 @@ fn normal_paths() {
         function func(I.S memory stuff);
     }
 
-    let _ = funcCall { stuff: I::S { x: U256::ZERO } };
+    let _ = funcCall(I::S { x: U256::ZERO });
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes #880 
Stacked over #883 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

```rust
sol! {
    function totalSupply() returns (uint256);
    function balanceOf(address) returns (uint256);
}

// Unit struct
pub struct totalSupplyCall;

// Tuple struct
pub struct balanceOfCall(pub Address); // Loses name of the param

// Previously, 
pub struct totalSupplyCall {};
pub struct balanceOfCall { owner: Address }; 
```

- Bindings for calls with 2 or more params left unchanged.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
