### PR TITLE
fix(`sol!`)!: gen unit struct for no param events

### DIFF
--- a/crates/sol-macro-expander/src/expand/event.rs
+++ b/crates/sol-macro-expander/src/expand/event.rs
@@ -146,14 +146,24 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, event: &ItemEvent) -> Result<TokenStream>
 
     let alloy_sol_types = &cx.crates.sol_types;
 
+    let event_struct = if event.parameters.is_empty() {
+        quote! {
+            pub struct #name;
+        }
+    } else {
+        quote! {
+            pub struct #name {
+                #(#fields,)*
+            }
+        }
+    };
+
     let tokens = quote! {
         #(#attrs)*
         #doc
         #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields, clippy::style)]
         #[derive(Clone)]
-        pub struct #name {
-            #( #fields, )*
-        }
+        #event_struct
 
         #[allow(non_camel_case_types, non_snake_case, clippy::pub_underscore_fields, clippy::style)]
         const _: () = {

--- a/crates/sol-types/tests/macros/sol/mod.rs
+++ b/crates/sol-types/tests/macros/sol/mod.rs
@@ -924,8 +924,10 @@ fn contract_derive_default() {
 
     let MyContract::f1Call {} = MyContract::f1Call::default();
     let MyContract::f2Call {} = MyContract::f2Call::default();
-    let MyContract::e1 {} = MyContract::e1::default();
-    let MyContract::e2 {} = MyContract::e2::default();
+    #[allow(clippy::default_constructed_unit_structs)]
+    let MyContract::e1 = MyContract::e1::default();
+    #[allow(clippy::default_constructed_unit_structs)]
+    let MyContract::e2 = MyContract::e2::default();
     #[allow(clippy::default_constructed_unit_structs)]
     let MyContract::c {} = MyContract::c::default();
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes #879 
Stacked over #883 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- If event does not contain any params, generate a unit struct instead of an empty struct.

```rust
sol! {
   event Empty();
}

// New 
pub struct Empty;

// Previous 
pub struct Empty {};
```

Bindings for events with params remain unchanged.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
