### PR TITLE
feat(primitives): add some more utility methods to PrimitiveSignature

### DIFF
--- a/crates/primitives/src/signature/error.rs
+++ b/crates/primitives/src/signature/error.rs
@@ -1,4 +1,4 @@
-use core::convert::Infallible;
+use core::{convert::Infallible, fmt};
 
 /// Errors in signature parsing or verification.
 #[derive(Debug)]
@@ -43,8 +43,8 @@ impl core::error::Error for SignatureError {
     }
 }
 
-impl core::fmt::Display for SignatureError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+impl fmt::Display for SignatureError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             #[cfg(feature = "k256")]
             Self::K256(e) => e.fmt(f),

--- a/crates/primitives/src/signature/utils.rs
+++ b/crates/primitives/src/signature/utils.rs
@@ -9,6 +9,7 @@ pub const fn to_eip155_v(v: u8, chain_id: ChainId) -> ChainId {
 /// Attempts to normalize the v value to a boolean parity value.
 ///
 /// Returns `None` if the value is invalid for any of the known Ethereum parity encodings.
+#[inline]
 pub const fn normalize_v(v: u64) -> Option<bool> {
     if !is_valid_v(v) {
         return None;
@@ -69,6 +70,7 @@ pub(crate) const fn normalize_v_to_recid(v: u64) -> k256::ecdsa::RecoveryId {
 }
 
 /// Normalize the v value to a single byte.
+#[inline]
 pub(crate) const fn normalize_v_to_byte(v: u64) -> u8 {
     match v {
         // Case 1: raw/bare


### PR DESCRIPTION


Add `normalized_s`, `from_raw`, and simplify existing implementations.

