### PR TITLE
feat(sol-macro): allow standard library macros for string literals

### DIFF
--- a/crates/sol-macro-input/Cargo.toml
+++ b/crates/sol-macro-input/Cargo.toml
@@ -25,6 +25,7 @@ rustdoc-args = [
 dunce = "1.0.4"
 heck = "0.5.0"
 hex.workspace = true
+macro-string = "0.1"
 proc-macro2.workspace = true
 syn.workspace = true
 syn-solidity.workspace = true

--- a/crates/sol-macro/doctests/json.rs
+++ b/crates/sol-macro/doctests/json.rs
@@ -36,6 +36,9 @@ sol! {
     }
 }
 
+// And:
+// sol!(MyJsonContract, concat!(env!("CARGO_MANIFEST_DIR"), "/path/to/MyJsonContract.json"));
+
 #[test]
 fn abigen() {
     assert_eq!(MyJsonContract1::fooCall::SIGNATURE, MyJsonContract2::fooCall::SIGNATURE);

--- a/crates/sol-macro/src/lib.rs
+++ b/crates/sol-macro/src/lib.rs
@@ -49,7 +49,8 @@ use syn::parse_macro_input;
 ///   format](#json-abi).
 ///
 /// Note:
-/// - relative file system paths are rooted at the `CARGO_MANIFEST_DIR` environment variable
+/// - relative file system paths are rooted at the `CARGO_MANIFEST_DIR` environment variable by
+///   default; you can specify absolute paths using the `concat!` and `env!` macros,
 /// - no casing convention is enforced for any identifier,
 /// - unnamed arguments will be given a name based on their index in the list, e.g. `_0`, `_1`...
 /// - a current limitation for certain items is that custom types, like structs, must be defined in
@@ -105,6 +106,9 @@ use syn::parse_macro_input;
 /// Note that the `sol` attribute does not compose like other Rust attributes, for example
 /// `#[cfg_attr]` will **NOT** work, as it is parsed and extracted from the input separately.
 /// This is a limitation of the proc-macro API.
+///
+/// Wherever a string literal is expected, common standard library macros that operate on string
+/// literals are also supported, such as `concat!` and `env!`.
 ///
 /// List of all `#[sol(...)]` supported values:
 /// - `rpc [ = <bool = false>]` (contracts and alike only): generates a structs with methods to
@@ -235,6 +239,9 @@ use syn::parse_macro_input;
 /// Note that only valid JSON is supported, and not the human-readable ABI
 /// format, also used by [`abigen!`][abigen]. This should instead be easily converted to
 /// [normal Solidity input](#solidity).
+///
+/// Both the raw JSON input and the file system path can be specified with standard library macros
+/// like `concat!` and `env!`.
 ///
 /// Prefer using [Solidity input](#solidity) when possible, as the JSON ABI
 /// format omits some information which is useful to this macro, such as enum

--- a/crates/sol-types/tests/macros/sol/json.rs
+++ b/crates/sol-types/tests/macros/sol/json.rs
@@ -10,7 +10,7 @@ fn large_array() {
         #[sol(abi)]
         #[derive(Debug)]
         LargeArray,
-        "../json-abi/tests/abi/LargeArray.json"
+        concat!(env!("CARGO_MANIFEST_DIR"), "/../json-abi/tests/abi/LargeArray.json")
     );
 
     let call = LargeArray::callWithLongArrayCall { longArray: [0; 128] };
@@ -239,3 +239,14 @@ fn balancer_v2_vault() {
 // fn smartsession_bootstrap() {
 //     sol!(Bootstrap, "../json-abi/tests/abi/Bootstrap.json");
 // }
+
+#[test]
+fn inner_macros() {
+    sol!(
+        #[sol(all_derives)]
+        Name,
+        concat!("[", "]"),
+    );
+    #[allow(unused_imports)]
+    use Name::*;
+}

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,9 @@
 [advisories]
 version = 2
 yanked = "warn"
-ignore = []
+ignore = [
+    "RUSTSEC-2024-0436" # paste - no longer maintained
+]
 
 [bans]
 multiple-versions = "warn"


### PR DESCRIPTION
Use [macro-string](https://docs.rs/macro-string) to allow standard library macros such as concat!, env!, and include_str! wherever a string literal is expected in the macro input.

Closes https://github.com/alloy-rs/core/issues/738.
Closes https://github.com/alloy-rs/core/issues/659.