### PR TITLE
fix(`sol!`): pass correct call_struct to call_builder in expansion

### DIFF
--- a/crates/sol-macro-expander/src/expand/contract.rs
+++ b/crates/sol-macro-expander/src/expand/contract.rs
@@ -987,20 +987,14 @@ fn call_builder_method(f: &ItemFunction, cx: &ExpCtxt<'_>) -> TokenStream {
     let doc = format!("Creates a new call builder for the [`{name}`] function.");
 
     let call_struct = if f.parameters.is_empty() {
-        quote! {
-            pub struct #call_name;
-        }
+        quote! { #call_name }
     } else if f.parameters.len() == 1 && f.parameters[0].name.is_none() {
-        let ty = cx.expand_rust_type(&f.parameters[0].ty);
-        quote! {
-            pub struct #call_name(pub #ty);
-        }
+        let param_name = quote! { _0 };
+        quote! { #call_name(#param_name) }
     } else {
         let call_fields = param_names1.clone();
         quote! {
-            pub struct #call_name {
-                #(#call_fields),*
-            }
+            #call_name { #(#call_fields),* }
         }
     };
     quote! {

--- a/crates/sol-macro-expander/src/expand/contract.rs
+++ b/crates/sol-macro-expander/src/expand/contract.rs
@@ -989,8 +989,7 @@ fn call_builder_method(f: &ItemFunction, cx: &ExpCtxt<'_>) -> TokenStream {
     let call_struct = if f.parameters.is_empty() {
         quote! { #call_name }
     } else if f.parameters.len() == 1 && f.parameters[0].name.is_none() {
-        let param_name = quote! { _0 };
-        quote! { #call_name(#param_name) }
+        quote! { #call_name(_0) }
     } else {
         let call_fields = param_names1.clone();
         quote! {

--- a/crates/sol-macro-expander/src/expand/contract.rs
+++ b/crates/sol-macro-expander/src/expand/contract.rs
@@ -996,7 +996,7 @@ fn call_builder_method(f: &ItemFunction, cx: &ExpCtxt<'_>) -> TokenStream {
             pub struct #call_name(pub #ty);
         }
     } else {
-        let call_fields = super::expand_fields(&f.parameters, cx);
+        let call_fields = param_names1.clone();
         quote! {
             pub struct #call_name {
                 #(#call_fields),*

--- a/crates/sol-macro/src/lib.rs
+++ b/crates/sol-macro/src/lib.rs
@@ -116,10 +116,6 @@ use syn::parse_macro_input;
 ///   default behavior of [`abigen`]. This makes use of the [`alloy-contract`](https://github.com/alloy-rs/alloy)
 ///   crate.
 ///
-///   N.B: at the time of writing, the `alloy-contract` crate is not yet released on `crates.io`,
-///   and its API is completely unstable and subject to change, so this feature is not yet
-///   recommended for use.
-///
 ///   Generates the following items inside of the `{contract_name}` module:
 ///   - `struct {contract_name}Instance<P: Provider> { ... }`
 ///     - `pub fn new(...) -> {contract_name}Instance<P>` + getters and setters


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

After #884, call types are expanded depending on the number of params.

This change isn't propagated to `rpc` expansion code where call_builder is called.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Generate the correct call struct like #884
- Pass it to `call_builder` 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
