### PR TITLE
fix(`sol-expander`): map `self` to `this` in codegen

### DIFF
--- a/crates/syn-solidity/src/ident/mod.rs
+++ b/crates/syn-solidity/src/ident/mod.rs
@@ -107,6 +107,15 @@ impl SolIdent {
 
         if matches!(s, "_" | "self" | "Self" | "super" | "crate") {
             new_raw = false;
+
+            // `self` renamed to `this` as `r#self` is not accepted by rust.
+            // See: <https://internals.rust-lang.org/t/raw-identifiers-dont-work-for-all-identifiers/9094/4>
+            if matches!(s, "self") {
+                s = "this";
+            }
+            if matches!(s, "Self") {
+                s = "This";
+            }
         }
 
         if new_raw {
@@ -185,6 +194,20 @@ mod tests {
             assert_eq!(id.to_string(), s);
             assert_eq!(id.as_string(), s);
         }
+    }
+
+    // <https://github.com/alloy-rs/core/issues/902>
+    #[test]
+    fn self_keywords() {
+        let id: SolIdent = syn::parse_str("self").unwrap();
+        assert_eq!(id, SolIdent::new("this"));
+        assert_eq!(id.to_string(), "this");
+        assert_eq!(id.as_string(), "this");
+
+        let id: SolIdent = syn::parse_str("Self").unwrap();
+        assert_eq!(id, SolIdent::new("This"));
+        assert_eq!(id.to_string(), "This");
+        assert_eq!(id.as_string(), "This");
     }
 
     #[test]

--- a/tests/core-sol/src/lib.rs
+++ b/tests/core-sol/src/lib.rs
@@ -128,6 +128,10 @@ pub mod no_missing_docs {
     }
 }
 
+// <https://github.com/alloy-rs/core/issues/902>
+sol! {
+    function f(address self) returns (uint256);
+}
 #[test]
 fn do_stuff() {
     let mut set = alloy_core::primitives::map::B256Map::<MyStruct>::default();
@@ -139,4 +143,7 @@ fn do_stuff() {
         Default::default(),
     );
     assert_eq!(set.len(), 1);
+
+    // self renamed to `this` as `r#self` is not accepted by rust. See: <https://internals.rust-lang.org/t/raw-identifiers-dont-work-for-all-identifiers/9094/4>
+    let _f_call = fCall { this: Default::default() };
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Closes #902 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Rust does not accept the raw identifier for `self` i.e `r#self`. See: https://internals.rust-lang.org/t/raw-identifiers-dont-work-for-all-identifiers/9094/4

- Map `self` to `this`.

```rust
sol! {
  function something(address self) returns (uint256);  // Previously failed to compile
}

// Now generates
pub struct somethingCall { this: Address };
```


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
