### PR TITLE
feat(sol-macro)!: improve call return encoding

### DIFF
--- a/crates/sol-types/src/types/function.rs
+++ b/crates/sol-types/src/types/function.rs
@@ -44,6 +44,9 @@ pub trait SolCall: Sized {
     /// Tokenize the call's arguments.
     fn tokenize(&self) -> Self::Token<'_>;
 
+    /// Tokenize the call's return values.
+    fn tokenize_returns(ret: &Self::Return) -> Self::ReturnToken<'_>;
+
     /// The size of the encoded data in bytes, **without** its selector.
     #[inline]
     fn abi_encoded_size(&self) -> usize {
@@ -92,9 +95,15 @@ pub trait SolCall: Sized {
     /// ABI decode this call's return values from the given slice.
     fn abi_decode_returns(data: &[u8]) -> Result<Self::Return>;
 
+    /// ABI encode the call's return value.
+    #[inline]
+    fn abi_encode_returns(ret: &Self::Return) -> Vec<u8> {
+        crate::abi::encode_sequence(&Self::tokenize_returns(ret))
+    }
+
     /// ABI encode the call's return values.
     #[inline]
-    fn abi_encode_returns<'a, E>(e: &'a E) -> Vec<u8>
+    fn abi_encode_returns_tuple<'a, E>(e: &'a E) -> Vec<u8>
     where
         E: SolTypeValue<Self::ReturnTuple<'a>>,
     {

--- a/crates/sol-types/tests/macros/sol/mod.rs
+++ b/crates/sol-types/tests/macros/sol/mod.rs
@@ -181,6 +181,8 @@ fn ret_param_single_test() {
     let res = balanceOfNamedCall::abi_decode_returns(&data).unwrap();
 
     assert_eq!(res, U256::from(42));
+
+    assert_eq!(balanceOfCall::abi_encode_returns(&res), data);
 }
 
 #[test]
@@ -248,6 +250,8 @@ fn empty_call() {
 
     let depositCall {} = depositCall::abi_decode(&depositCall::SELECTOR).unwrap();
     let depositCall {} = depositCall::abi_decode_raw(&[]).unwrap();
+
+    assert!(depositCall::abi_encode_returns(&WETH::depositReturn {}).is_empty());
 }
 
 #[test]


### PR DESCRIPTION
Changes `SolCall::abi_encode_returns` to accept `Self::Return` instead of the tuple.

Fixes https://github.com/alloy-rs/core/issues/536.