### PR TITLE
docs(sol-types): fix missing sol! doc link

### DIFF
--- a/crates/sol-types/README.md
+++ b/crates/sol-types/README.md
@@ -46,7 +46,9 @@ assert_eq!(data, decoded);
 
 The [`sol!`] procedural macro provides a convenient way to define
 custom [`SolType`]s and reference primitive ones. See
-[its documentation][sol!] for details on how to use it.
+[its documentation](sol!) for details on how to use it.
+
+[sol!]: https://docs.rs/alloy-sol-macro/latest/alloy_sol_macro/macro.sol.html
 
 ## [`SolStruct`]
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

The README is missing the link to the `sol!` documentation.

## Solution

Add link to `sol!` doc.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
