### PR TITLE
feat(primitives): supporting diesel @ 2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ bincode = "1.3"
 bytes = { version = "1", default-features = false }
 criterion = "0.5"
 derive_arbitrary = "1.3"
+diesel = "2.2"
 getrandom = "0.3"
 hex = { package = "const-hex", version = "1.14", default-features = false, features = [
     "alloc",

--- a/crates/primitives/CHANGELOG.md
+++ b/crates/primitives/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Features
 
 - [`primitives`] Impl Display for PrimitiveSig ([#892](https://github.com/alloy-rs/core/issues/892))
+- [`primitives`] Impl support for diesel @ 2.2 ([#876](https://github.com/alloy-rs/core/issues/876))
 
 ### Miscellaneous Tasks
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -96,6 +96,7 @@ postgres-types = { workspace = true, optional = true }
 
 # diesel
 diesel = { workspace = true, optional = true }
+diesel-derive-newtype = { workspace = true, optional = true }
 
 [dev-dependencies]
 bcs.workspace = true
@@ -166,7 +167,7 @@ arbitrary = [
     "indexmap?/arbitrary",
 ]
 postgres = ["std", "dep:postgres-types", "ruint/postgres"]
-diesel = ["std", "dep:diesel", "ruint/diesel"]
+diesel = ["std", "dep:diesel", "dep:diesel-derive-newtype", "ruint/diesel"]
 
 # `const-hex` compatibility feature for `hex`.
 # Should not be needed most of the time.

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -96,7 +96,6 @@ postgres-types = { workspace = true, optional = true }
 
 # diesel
 diesel = { workspace = true, optional = true }
-diesel-derive-newtype = { workspace = true, optional = true }
 
 [dev-dependencies]
 bcs.workspace = true
@@ -167,7 +166,7 @@ arbitrary = [
     "indexmap?/arbitrary",
 ]
 postgres = ["std", "dep:postgres-types", "ruint/postgres"]
-diesel = ["std", "dep:diesel", "dep:diesel-derive-newtype", "ruint/diesel"]
+diesel = ["std", "dep:diesel", "ruint/diesel"]
 
 # `const-hex` compatibility feature for `hex`.
 # Should not be needed most of the time.

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -94,6 +94,9 @@ allocative = { workspace = true, optional = true }
 # postgres
 postgres-types = { workspace = true, optional = true }
 
+# diesel
+diesel = { workspace = true, optional = true }
+
 [dev-dependencies]
 bcs.workspace = true
 bincode.workspace = true
@@ -163,6 +166,7 @@ arbitrary = [
     "indexmap?/arbitrary",
 ]
 postgres = ["std", "dep:postgres-types", "ruint/postgres"]
+diesel = ["std", "dep:diesel", "ruint/diesel"]
 
 # `const-hex` compatibility feature for `hex`.
 # Should not be needed most of the time.

--- a/crates/primitives/src/bits/fixed.rs
+++ b/crates/primitives/src/bits/fixed.rs
@@ -29,6 +29,8 @@ use hex::FromHex;
 )]
 #[cfg_attr(feature = "arbitrary", derive(derive_arbitrary::Arbitrary, proptest_derive::Arbitrary))]
 #[cfg_attr(feature = "allocative", derive(allocative::Allocative))]
+#[cfg_attr(feature = "diesel", derive(diesel::AsExpression, diesel::FromSqlRow))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Binary))]
 #[repr(transparent)]
 pub struct FixedBytes<const N: usize>(#[into_iterator(owned, ref, ref_mut)] pub [u8; N]);
 

--- a/crates/primitives/src/bits/macros.rs
+++ b/crates/primitives/src/bits/macros.rs
@@ -69,7 +69,6 @@ macro_rules! wrap_fixed_bytes {
                 $extra_derives,
             )*
         )]
-        #[cfg_attr(feature = "diesel", derive(diesel_derive_newtype::DieselNewType))]
         #[repr(transparent)]
         $vis struct $name(#[into_iterator(owned, ref, ref_mut)] pub $crate::FixedBytes<$n>);
 
@@ -185,6 +184,7 @@ macro_rules! wrap_fixed_bytes {
         $crate::impl_allocative!($name);
         $crate::impl_arbitrary!($name, $n);
         $crate::impl_rand!($name);
+        $crate::impl_diesel!($name, $n);
 
         impl $name {
             /// Array of Zero bytes.
@@ -693,6 +693,117 @@ macro_rules! impl_arbitrary {
 #[macro_export]
 #[cfg(not(feature = "arbitrary"))]
 macro_rules! impl_arbitrary {
+    ($t:ty, $n:literal) => {};
+}
+
+#[doc(hidden)]
+#[macro_export]
+#[cfg(feature = "diesel")]
+macro_rules! impl_diesel {
+    ($t:ty, $n:literal) => {
+        use $crate::private::diesel::{
+            backend::Backend,
+            deserialize::{FromSql, Result as DeserResult},
+            expression::AsExpression,
+            internal::derives::as_expression::Bound,
+            query_builder::bind_collector::RawBytesBindCollector,
+            serialize::{Output, Result as SerResult, ToSql},
+            sql_types::{Binary, Nullable, SingleValue},
+            Queryable,
+        };
+
+        impl<Db> ToSql<Binary, Db> for $t
+        where
+            for<'c> Db: Backend<BindCollector<'c> = RawBytesBindCollector<Db>>,
+        {
+            fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Db>) -> SerResult {
+                <$crate::FixedBytes<$n> as ToSql<Binary, Db>>::to_sql(&self.0, out)
+            }
+        }
+
+        impl<Db> FromSql<Binary, Db> for $t
+        where
+            Db: Backend,
+            *const [u8]: FromSql<Binary, Db>,
+        {
+            fn from_sql(bytes: Db::RawValue<'_>) -> DeserResult<Self> {
+                <$crate::FixedBytes<$n> as FromSql<Binary, Db>>::from_sql(bytes).map(Self)
+            }
+        }
+
+        // Note: the following impls are equivalent to the expanded derive macro produced by
+        // #[derive(diesel::AsExpression)]
+        impl<Db> ToSql<Nullable<Binary>, Db> for $t
+        where
+            for<'c> Db: Backend<BindCollector<'c> = RawBytesBindCollector<Db>>,
+        {
+            fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Db>) -> SerResult {
+                <$crate::FixedBytes<$n> as ToSql<Nullable<Binary>, Db>>::to_sql(&self.0, out)
+            }
+        }
+
+        impl AsExpression<Binary> for $t {
+            type Expression = Bound<Binary, Self>;
+            fn as_expression(self) -> Self::Expression {
+                Bound::new(self)
+            }
+        }
+
+        impl AsExpression<Nullable<Binary>> for $t {
+            type Expression = Bound<Nullable<Binary>, Self>;
+            fn as_expression(self) -> Self::Expression {
+                Bound::new(self)
+            }
+        }
+
+        impl AsExpression<Binary> for &$t {
+            type Expression = Bound<Binary, Self>;
+            fn as_expression(self) -> Self::Expression {
+                Bound::new(self)
+            }
+        }
+
+        impl AsExpression<Nullable<Binary>> for &$t {
+            type Expression = Bound<Nullable<Binary>, Self>;
+            fn as_expression(self) -> Self::Expression {
+                Bound::new(self)
+            }
+        }
+
+        impl AsExpression<Binary> for &&$t {
+            type Expression = Bound<Binary, Self>;
+            fn as_expression(self) -> Self::Expression {
+                Bound::new(self)
+            }
+        }
+
+        impl AsExpression<Nullable<Binary>> for &&$t {
+            type Expression = Bound<Nullable<Binary>, Self>;
+            fn as_expression(self) -> Self::Expression {
+                Bound::new(self)
+            }
+        }
+
+        // Note: the following impl is equivalent to the expanded derive macro produced by
+        // #[derive(diesel::Queryable)]
+        impl<Db, St> Queryable<St, Db> for $t
+        where
+            Db: Backend,
+            St: SingleValue,
+            Self: FromSql<St, Db>,
+        {
+            type Row = Self;
+            fn build(row: Self::Row) -> DeserResult<Self> {
+                Ok(row)
+            }
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+#[cfg(not(feature = "diesel"))]
+macro_rules! impl_diesel {
     ($t:ty, $n:literal) => {};
 }
 

--- a/crates/primitives/src/bits/macros.rs
+++ b/crates/primitives/src/bits/macros.rs
@@ -69,6 +69,7 @@ macro_rules! wrap_fixed_bytes {
                 $extra_derives,
             )*
         )]
+        #[cfg_attr(feature = "diesel", derive(diesel_derive_newtype::DieselNewType))]
         #[repr(transparent)]
         $vis struct $name(#[into_iterator(owned, ref, ref_mut)] pub $crate::FixedBytes<$n>);
 

--- a/crates/primitives/src/diesel.rs
+++ b/crates/primitives/src/diesel.rs
@@ -1,11 +1,10 @@
 //! Support for the [`diesel`](https://crates.io/crates/diesel) crate.
 //!
-//! Supports big-endian binary serialization via via the [`BYTEA`] Postgres type.
+//! Supports big-endian binary serialization via into sql_types::Binary.
 //! Similar to [`ruint`'s implementation](https://github.com/recmo/uint/blob/fd57517b36cda8341f7740dacab4b1ec186af948/src/support/diesel.rs)
 
-use crate::PrimitiveSignature;
+use crate::{FixedBytes, PrimitiveSignature};
 
-use super::FixedBytes;
 use diesel::{
     backend::Backend,
     deserialize::{FromSql, Result as DeserResult},

--- a/crates/primitives/src/diesel.rs
+++ b/crates/primitives/src/diesel.rs
@@ -3,7 +3,7 @@
 //! Supports big-endian binary serialization via into sql_types::Binary.
 //! Similar to [`ruint`'s implementation](https://github.com/recmo/uint/blob/fd57517b36cda8341f7740dacab4b1ec186af948/src/support/diesel.rs)
 
-use crate::{FixedBytes, PrimitiveSignature, SignatureError};
+use crate::{FixedBytes, Signature, SignatureError};
 
 use diesel::{
     backend::Backend,
@@ -35,7 +35,7 @@ where
     }
 }
 
-impl<Db: Backend> ToSql<Binary, Db> for PrimitiveSignature
+impl<Db: Backend> ToSql<Binary, Db> for Signature
 where
     for<'c> Db: Backend<BindCollector<'c> = RawBytesBindCollector<Db>>,
 {
@@ -45,7 +45,7 @@ where
     }
 }
 
-impl<Db: Backend> FromSql<Binary, Db> for PrimitiveSignature
+impl<Db: Backend> FromSql<Binary, Db> for Signature
 where
     *const [u8]: FromSql<Binary, Db>,
 {

--- a/crates/primitives/src/diesel.rs
+++ b/crates/primitives/src/diesel.rs
@@ -24,14 +24,14 @@ where
     }
 }
 
-impl<'a, const BITS: usize, Db: Backend> FromSql<Binary, Db> for FixedBytes<BITS>
+impl<const BITS: usize, Db: Backend> FromSql<Binary, Db> for FixedBytes<BITS>
 where
     *const [u8]: FromSql<Binary, Db>,
 {
     fn from_sql(bytes: Db::RawValue<'_>) -> DeserResult<Self> {
         let bytes: *const [u8] = FromSql::<Binary, Db>::from_sql(bytes)?;
         let bytes = unsafe { &*bytes };
-        Ok(Self::from_slice(&bytes))
+        Ok(Self::from_slice(bytes))
     }
 }
 
@@ -45,7 +45,7 @@ where
     }
 }
 
-impl<'a, Db: Backend> FromSql<Binary, Db> for PrimitiveSignature
+impl<Db: Backend> FromSql<Binary, Db> for PrimitiveSignature
 where
     *const [u8]: FromSql<Binary, Db>,
 {

--- a/crates/primitives/src/diesel.rs
+++ b/crates/primitives/src/diesel.rs
@@ -1,0 +1,35 @@
+//! Support for the [`diesel`](https://crates.io/crates/diesel) crate.
+//!
+//! Supports big-endian binary serialization via via the [`BYTEA`] Postgres type.
+//! Similar to [`ruint`'s implementation](https://github.com/recmo/uint/blob/fd57517b36cda8341f7740dacab4b1ec186af948/src/support/diesel.rs)
+
+use super::FixedBytes;
+use diesel::{
+    backend::Backend,
+    deserialize::{FromSql, Result as DeserResult},
+    query_builder::bind_collector::RawBytesBindCollector,
+    serialize::{IsNull, Output, Result as SerResult, ToSql},
+    sql_types::Binary,
+};
+use std::io::Write;
+
+impl<const BITS: usize, Db> ToSql<Binary, Db> for FixedBytes<BITS>
+where
+    for<'c> Db: Backend<BindCollector<'c> = RawBytesBindCollector<Db>>,
+{
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Db>) -> SerResult {
+        out.write_all(&self[..])?;
+        Ok(IsNull::No)
+    }
+}
+
+impl<'a, const BITS: usize, Db: Backend> FromSql<Binary, Db> for FixedBytes<BITS>
+where
+    *const [u8]: FromSql<Binary, Db>,
+{
+    fn from_sql(bytes: Db::RawValue<'_>) -> DeserResult<Self> {
+        let bytes: *const [u8] = FromSql::<Binary, Db>::from_sql(bytes)?;
+        let bytes = unsafe { &*bytes };
+        Ok(Self::from_slice(&bytes))
+    }
+}

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -19,6 +19,9 @@ use tiny_keccak as _;
 #[cfg(feature = "postgres")]
 pub mod postgres;
 
+#[cfg(feature = "diesel")]
+pub mod diesel;
+
 pub mod aliases;
 #[doc(no_inline)]
 pub use aliases::{

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -123,4 +123,7 @@ pub mod private {
 
     #[cfg(feature = "arbitrary")]
     pub use {arbitrary, derive_arbitrary, proptest, proptest_derive};
+
+    #[cfg(feature = "diesel")]
+    pub use diesel;
 }

--- a/crates/primitives/src/signature/sig.rs
+++ b/crates/primitives/src/signature/sig.rs
@@ -13,6 +13,8 @@ const SECP256K1N_ORDER: U256 =
 
 /// An Ethereum ECDSA signature.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[cfg_attr(feature = "diesel", derive(diesel::AsExpression, diesel::FromSqlRow))]
+#[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Binary))]
 pub struct Signature {
     y_parity: bool,
     r: U256,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

This PR adds diesel support for `alloy-primitives`, covering the following:
- add diesel dep, gated behind new `diesel` feature
- bump ruint dep by a patch version to include its diesel support, also gated behind the `diesel` feature
- manually implementing diesel-related traits where needed, similar to [the PR adding diesel support to ruint](https://github.com/recmo/uint/pull/404)
- macro-deriving diesel-related traits where possible, for `FixedBytes`, `Address` (via the macro that creates it), and `PrimitiveSignature`
- `PrimitiveSignature` encoded via erc2098

I had most of this code already written for another project and wanted to contribute it upstream. I noticed issue #876 had some activity but didn't see any indications of a PR so I hope this doesn’t overlap with anyone else’s efforts! 🫡 

I've posted a public example showing basic usage via diesel's postgres support [here](https://github.com/sinasab/diesel_alloy_test) in case it's useful; happy to provide any more details to get this over the line! 😁 

## Solution

The solution handles serializing/deserializing the common types exposed in `alloy-primitives` via diesel's `sql_types::Binary`. `ToSql` and `FromSql` need to be manually implemented, but some of the other traits can be derived either directly with macros `diesel` provides or via the helper lib, `diesel-derive-newtype`. 

Note that the implementation in [ruint](https://github.com/recmo/uint/blob/main/src/support/diesel.rs) inlines all of the code generated from the derive macros; I can do that here too, but figured the macros were cleaner to start with.

Closes https://github.com/alloy-rs/core/issues/876.