### PR TITLE
fix: do not rely on bytes dependency in `wrap_fixed_bytes!`

### DIFF
--- a/crates/primitives/src/bits/macros.rs
+++ b/crates/primitives/src/bits/macros.rs
@@ -4,8 +4,9 @@
 /// This functionally creates a new named `FixedBytes` that cannot be
 /// type-confused for another named `FixedBytes`.
 ///
-/// **NOTE:** This macro currently requires `#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]`
-/// at the top level of the crate where it is used.
+/// **NOTE:** This macro currently requires:
+/// - `#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]` at the top level of the crate.
+/// - The `derive_more` crate in scope.
 ///
 /// # Examples
 ///

--- a/crates/primitives/src/bits/macros.rs
+++ b/crates/primitives/src/bits/macros.rs
@@ -590,7 +590,7 @@ macro_rules! impl_serde {
         #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
         impl $crate::private::serde::Serialize for $t {
             #[inline]
-            fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            fn serialize<S: $crate::private::serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
                 $crate::private::serde::Serialize::serialize(&self.0, serializer)
             }
         }

--- a/crates/primitives/src/bits/macros.rs
+++ b/crates/primitives/src/bits/macros.rs
@@ -542,7 +542,7 @@ macro_rules! impl_rlp {
             }
 
             #[inline]
-            fn encode(&self, out: &mut dyn bytes::BufMut) {
+            fn encode(&self, out: &mut dyn $crate::private::alloy_rlp::BufMut) {
                 $crate::private::alloy_rlp::Encodable::encode(&self.0, out)
             }
         }

--- a/crates/primitives/src/bits/macros.rs
+++ b/crates/primitives/src/bits/macros.rs
@@ -4,6 +4,9 @@
 /// This functionally creates a new named `FixedBytes` that cannot be
 /// type-confused for another named `FixedBytes`.
 ///
+/// **NOTE:** This macro currently requires `#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]`
+/// at the top level of the crate where it is used.
+///
 /// # Examples
 ///
 /// ```

--- a/crates/primitives/src/bits/macros.rs
+++ b/crates/primitives/src/bits/macros.rs
@@ -590,7 +590,10 @@ macro_rules! impl_serde {
         #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
         impl $crate::private::serde::Serialize for $t {
             #[inline]
-            fn serialize<S: $crate::private::serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            fn serialize<S: $crate::private::serde::Serializer>(
+                &self,
+                serializer: S,
+            ) -> Result<S::Ok, S::Error> {
                 $crate::private::serde::Serialize::serialize(&self.0, serializer)
             }
         }

--- a/tests/core-sol/Cargo.toml
+++ b/tests/core-sol/Cargo.toml
@@ -12,4 +12,4 @@ exclude.workspace = true
 
 [dependencies]
 alloy-core = { workspace = true, features = ["sol-types", "json", "map"] }
-derive_more = "2" # https://github.com/alloy-rs/core/pull/918#issuecomment-2743739367
+derive_more = { version = "2", default-features = false } # https://github.com/alloy-rs/core/pull/918#issuecomment-2743739367

--- a/tests/core-sol/Cargo.toml
+++ b/tests/core-sol/Cargo.toml
@@ -12,3 +12,4 @@ exclude.workspace = true
 
 [dependencies]
 alloy-core = { workspace = true, features = ["sol-types", "json", "map"] }
+derive_more = "2" # https://github.com/alloy-rs/core/pull/918#issuecomment-2743739367

--- a/tests/core-sol/src/lib.rs
+++ b/tests/core-sol/src/lib.rs
@@ -3,6 +3,7 @@
 //! This has to be in a separate crate where `alloy_sol_types` is not provided as a dependency.
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 use alloy_core::{primitives::wrap_fixed_bytes, sol};
 

--- a/tests/core-sol/src/lib.rs
+++ b/tests/core-sol/src/lib.rs
@@ -6,7 +6,7 @@
 
 use alloy_core::{primitives::wrap_fixed_bytes, sol};
 
-wrap_fixed_bytes!{
+wrap_fixed_bytes! {
     struct MyFixedBytes<32>;
 }
 

--- a/tests/core-sol/src/lib.rs
+++ b/tests/core-sol/src/lib.rs
@@ -4,7 +4,11 @@
 
 #![no_std]
 
-use alloy_core::sol;
+use alloy_core::{primitives::wrap_fixed_bytes, sol};
+
+wrap_fixed_bytes!{
+    struct MyFixedBytes<32>;
+}
 
 type _MyUint = sol!(uint32);
 type _MyTuple = sol!((_MyUint, bytes, bool, string, bytes32, (address, uint64)));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

`wrap_fixed_bytes` can't be used without `bytes` as a dependency.

there's similar issue with `derive_more` but I'm unsure how we can handle this given that it seems to rely on `derive_more` being available internally

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
