### PR TITLE
fix(primitives): Remove undefined behavior in FixedBytes

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -7,7 +7,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(hasher_prefixfree_extras))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-#![cfg_attr(any(feature = "getrandom", feature = "rand"), feature(maybe_uninit_array_assume_init))]
 
 #[macro_use]
 extern crate alloc;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(hasher_prefixfree_extras))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(any(feature = "getrandom", feature = "rand"), feature(maybe_uninit_array_assume_init))]
 
 #[macro_use]
 extern crate alloc;


### PR DESCRIPTION
## Motivation

Currently, the code for generating random `FixedBytes` primitives is incorrect. It calls `assume_init` directly on an uninitialized array, which invokes immediate undefined behavior.

Note that it doesn't matter that we technically never explicitly read from the array before randomizing. An uninitialized byte array is always invalid and violates Rust rules. Refer to the [docs for MaybeUninit](https://doc.rust-lang.org/core/mem/union.MaybeUninit.html).

## Solution

We should follow the documentation of [`MaybeUninit::assume_init`](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#method.assume_init) and make sure every element was written to. Since we're initializing arrays, I used `[MaybeUninit<u8>; N]` (idiomatic for Rust), together with `array_assume_init` (currently unstable, I added a cfg_attr-gated #![feature]).

Luckily `getrandom` provides a function for randomizing uninitialized arrays, so I could use the MaybeUninit array directly. For `rand`, I couldn't find an equivalent, so I implemented the `Fill` trait manually via a wrapper.

## PR Checklist

- [ ] Added Tests (covered by existing tests)
- [x] Added Documentation (no pub doc changes, only added safety comments)
- [ ] Breaking changes (none)
