### PR TITLE
chore: add hash_ref function to sealed.rs

### DIFF
--- a/crates/primitives/src/sealed.rs
+++ b/crates/primitives/src/sealed.rs
@@ -107,6 +107,12 @@ impl<T> Sealed<T> {
         self.seal
     }
 
+    /// Get the hash.
+    #[inline(always)]
+    pub const fn hash_ref(&self) -> &B256 {
+        &self.seal
+    }
+
     /// Unseal the inner item, discarding the hash.
     #[inline(always)]
     #[allow(clippy::missing_const_for_fn)] // false positive


### PR DESCRIPTION
## Changes

- Introduced a new `hash_ref()` method on `Sealed<T>` to expose a reference to the internal `seal` hash.
- This addition enables consumers to access the hash without incurring a copy, which is useful when only a reference is needed.

## Motivation

This change supports [reth#15250](https://github.com/paradigmxyz/reth/pull/15250), where `OpTxEnvelope::Deposit` will implement `SignedTransaction`. Since the `hash()` method on `Sealed<TxDeposit>` returns by value, `hash_ref()` allows returning a borrowed hash to satisfy trait requirements (`&TxHash`)
