### PR TITLE
feat: add inner mut

### DIFF
--- a/crates/primitives/src/sealed.rs
+++ b/crates/primitives/src/sealed.rs
@@ -95,6 +95,14 @@ impl<T> Sealed<T> {
         &self.inner
     }
 
+    /// Returns mutable access to the inner type.
+    ///
+    /// Caution: Modifying the inner type can cause side-effects on the `seal` hash.
+    #[inline(always)]
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
     /// Get the hash.
     #[inline(always)]
     pub const fn seal(&self) -> B256 {


### PR DESCRIPTION
while this kinda defeats the purpose of a shielded inner type, this follows similar convention that we have for `Signed` etc.

and this can be useful for testing and for things like:

https://github.com/paradigmxyz/reth/blob/06453c9553de20fe39e41554f842987bfe9ae650/crates/optimism/rpc/src/eth/transaction.rs#L151-L170

we could also mark this as doc(hidden)

