### PR TITLE
fix: array size evaluation with modulo operator

### DIFF
--- a/crates/sol-macro-expander/src/expand/ty.rs
+++ b/crates/sol-macro-expander/src/expand/ty.rs
@@ -424,7 +424,7 @@ impl<'a> ArraySizeEvaluator<'a> {
                 lhs.checked_mul(rhs).ok_or_else(|| EE::ArithmeticOverflow.into())
             }
             ast::BinOp::Div(..) => lhs.checked_div(rhs).ok_or_else(|| EE::DivisionByZero.into()),
-            ast::BinOp::Rem(..) => lhs.checked_div(rhs).ok_or_else(|| EE::DivisionByZero.into()),
+            ast::BinOp::Rem(..) => lhs.checked_rem(rhs).ok_or_else(|| EE::DivisionByZero.into()),
             _ => Err(EE::UnsupportedExpr.into()),
         }
     }


### PR DESCRIPTION
The following code:

```rust
alloy_sol_types::sol! {
    struct Struc {
        uint256[11 % 8] arr;
    }
}

let _ = Struc {
    arr: [Default::default(); 11 % 8],
};
```

did not compile with the following error:

```
error[E0308]: mismatched types
 --> src\main.rs:9:10
  |
9 |     arr: [Default::default(); 11 % 8],
  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an array with a size of 1, found one with a size of 3
  |
  = note: expected array `[alloy_sol_types::private::Uint<256, 4>; 1]`
             found array `[alloy_sol_types::private::Uint<256, 4>; 3]`
```
