### PR TITLE
chore: add `KECCAK256_EMPTY` from `revm::primitives`

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -62,7 +62,7 @@ pub use signature::PrimitiveSignature;
 pub use signature::{normalize_v, to_eip155_v, Signature, SignatureError};
 
 pub mod utils;
-pub use utils::{eip191_hash_message, keccak256, Keccak256, KECCAK_EMPTY};
+pub use utils::{eip191_hash_message, keccak256, Keccak256, KECCAK256_EMPTY};
 
 #[doc(hidden)] // Use `hex` directly instead!
 pub mod hex_literal;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -62,7 +62,7 @@ pub use signature::PrimitiveSignature;
 pub use signature::{normalize_v, to_eip155_v, Signature, SignatureError};
 
 pub mod utils;
-pub use utils::{eip191_hash_message, keccak256, Keccak256};
+pub use utils::{eip191_hash_message, keccak256, Keccak256, KECCAK_EMPTY};
 
 #[doc(hidden)] // Use `hex` directly instead!
 pub mod hex_literal;

--- a/crates/primitives/src/utils/mod.rs
+++ b/crates/primitives/src/utils/mod.rs
@@ -25,7 +25,7 @@ pub type Units = Unit;
 pub const EIP191_PREFIX: &str = "\x19Ethereum Signed Message:\n";
 
 /// The [Keccak-256](keccak256) hash of the empty string `""`.
-pub const KECCAK_EMPTY: B256 =
+pub const KECCAK256_EMPTY: B256 =
     b256!("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");
 
 /// Tries to create a [`Vec`] containing the arguments.

--- a/crates/primitives/src/utils/mod.rs
+++ b/crates/primitives/src/utils/mod.rs
@@ -24,6 +24,10 @@ pub type Units = Unit;
 /// The prefix used for hashing messages according to EIP-191.
 pub const EIP191_PREFIX: &str = "\x19Ethereum Signed Message:\n";
 
+/// The [Keccak-256](keccak256) hash of the empty string `""`.
+pub const KECCAK_EMPTY: B256 =
+    b256!("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");
+
 /// Tries to create a [`Vec`] containing the arguments.
 #[macro_export]
 macro_rules! try_vec {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

From: https://github.com/bluealloy/revm/blob/main/crates/primitives/src/constants.rs

This constant is used quite a bit in Foundry and now requires `revm::primitives` whereas all other primitives are better imported from `alloy::primitives` directly leaving this one.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Adds `KECCAK256_EMPTY` constant

Checked using `chisel`:

```
chisel
Welcome to Chisel! Type `!help` to show available commands.
➜ keccak256("")
Type: bytes32
└ Data: 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
```

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes