### PR TITLE
docs: fixed broken link

### DIFF
--- a/crates/sol-types/README.md
+++ b/crates/sol-types/README.md
@@ -13,7 +13,7 @@ This trait maps Solidity types to Rust types via the associated
 [`SolType::RustType`].
 
 The ABI encoding and decoding is implemented in the [`abi`] module, see [its
-documentation](abi) to learn how it works.
+documentation](src/abi) to learn how it works.
 
 [ABI]: https://docs.soliditylang.org/en/latest/abi-spec.html
 [EIP-712]: https://eips.ethereum.org/EIPS/eip-712


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

The relative link to the `abi` module in `README.md` was broken — GitHub couldn't resolve `abi` on its own.  
Switched it to `src/abi` so it correctly points to the actual folder.

## Solution

...

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
