### PR TITLE
fix: eip712 string interface prefix

### DIFF
--- a/crates/sol-types/tests/macros/sol/eip712.rs
+++ b/crates/sol-types/tests/macros/sol/eip712.rs
@@ -63,3 +63,30 @@ fn encode_data_nesting() {
         "25c3d40a39e639a4d0b6e4d2ace5e1281e039c88494d97d8d08f99a6ea75d775".parse::<B256>().unwrap()
     )
 }
+
+#[test]
+fn test_eip712_interface_prefix() {
+    sol! {
+        interface IParentInterfaceA {
+            struct ParentStructA {
+                uint256 numberA;
+            }
+        }
+
+        interface IParentInterfaceB {
+            struct ParentStructB {
+                uint256 numberB;
+            }
+        }
+
+        struct MyStruct {
+            IParentInterfaceA.ParentStructA structA;
+            IParentInterfaceB.ParentStructB structB;
+        }
+    }
+
+    assert_eq!(
+        MyStruct::eip712_encode_type(),
+        "MyStruct(ParentStructA structA,ParentStructB structB)ParentStructA(uint256 numberA)ParentStructB(uint256 numberB)"
+    );
+}

--- a/crates/syn-solidity/src/variable/mod.rs
+++ b/crates/syn-solidity/src/variable/mod.rs
@@ -78,7 +78,15 @@ impl VariableDeclaration {
 
     /// Formats `self` as an EIP-712 field: `<ty> <name>`
     pub fn fmt_eip712(&self, f: &mut impl Write) -> fmt::Result {
-        write!(f, "{}", self.ty)?;
+        // According to EIP-712, type strings should only contain struct name, not interface prefix
+        match &self.ty {
+            crate::Type::Custom(path) => {
+                write!(f, "{}", path.last())?;
+            }
+            _ => {
+                write!(f, "{}", self.ty)?;
+            }
+        }
         if let Some(name) = &self.name {
             write!(f, " {name}")?;
         }


### PR DESCRIPTION
fixes #948

When calculating the eip712 type string for example struct

```sol
interface IParentInterfaceA {
    struct ParentStructA {
        uint256 numberA;
    }
}

interface IParentInterfaceB {
    struct ParentStructB {
        uint256 numberB;
    }
}

interface IMyInterface is IParentInterfaceA, IParentInterfaceB {
    struct MyStruct {
        ParentStructA structA;
        ParentStructB structB;
    }
}
```

Expected: `"MyStruct(ParentStructA structA, ParentStructB structB)ParentStructA(uint256 numberA)ParentStructB(uint256 numberB)"`
Incorrect: `"MyStruct(IParentInterfaceA.ParentStructA structA, IParentInterfaceB.ParentStructB structB)ParentStructA(uint256 numberA)ParentStructB(uint256 numberB)"`

This PR fixes the problem by removing the interface prefix string while calculating the eip712 type string