### PR TITLE
feat: added `decode_log_validate` method

### DIFF
--- a/crates/sol-macro/doctests/events.rs
+++ b/crates/sol-macro/doctests/events.rs
@@ -81,8 +81,10 @@ fn event_rlp_roundtrip() {
     assert_eq!(rlp_decoded, rlpable_log.reserialize());
 
     let decoded_log = MyEvent::decode_log(&rlp_decoded).unwrap();
+    let validated_decoded_log = MyEvent::decode_log_validate(&rlp_decoded).unwrap();
 
-    assert_eq!(decoded_log, rlpable_log)
+    assert_eq!(decoded_log, rlpable_log);
+    assert_eq!(validated_decoded_log, rlpable_log);
 }
 
 fn assert_event_signature<T: SolEvent>(expected: &str) {

--- a/crates/sol-types/src/types/event/mod.rs
+++ b/crates/sol-types/src/types/event/mod.rs
@@ -216,8 +216,18 @@ pub trait SolEvent: Sized {
         Self::decode_raw_log(log.topics(), &log.data)
     }
 
+    /// Decode the event from the given log object with validation.
+    fn decode_log_data_validate(log: &LogData) -> Result<Self> {
+        Self::decode_raw_log_validate(log.topics(), &log.data)
+    }
+
     /// Decode the event from the given log object.
     fn decode_log(log: &Log) -> Result<Log<Self>> {
         Self::decode_log_data(&log.data).map(|data| Log { address: log.address, data })
+    }
+
+    /// Decode the event from the given log object with validation.
+    fn decode_log_validate(log: &Log) -> Result<Log<Self>> {
+        Self::decode_log_data_validate(&log.data).map(|data| Log { address: log.address, data })
     }
 }


### PR DESCRIPTION
closes #955 
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

There was no `decode_log_validate` method and user had to call `decode_raw_log_validate` manually
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Added `decode_log_validate` and `decode_log_data_validate` methods
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
