### PR TITLE
fix: custom eip712 parsing allowing `:`

### DIFF
--- a/crates/dyn-abi/Cargo.toml
+++ b/crates/dyn-abi/Cargo.toml
@@ -26,9 +26,9 @@ workspace = true
 
 [dependencies]
 alloy-json-abi.workspace = true
-alloy-sol-type-parser.workspace = true
 alloy-sol-types.workspace = true
 alloy-primitives.workspace = true
+alloy-sol-type-parser = { workspace = true, features = ["eip712"] }
 
 itoa.workspace = true
 winnow.workspace = true

--- a/crates/dyn-abi/src/eip712/parser.rs
+++ b/crates/dyn-abi/src/eip712/parser.rs
@@ -45,7 +45,7 @@ impl<'a> PropDef<'a> {
     pub fn parse(input: &'a str) -> Result<Self, Error> {
         let (ty, name) =
             input.rsplit_once(' ').ok_or_else(|| Error::invalid_property_def(input))?;
-        Ok(PropDef { ty: ty.trim().try_into()?, name: name.trim() })
+        Ok(PropDef { ty: TypeSpecifier::parse_eip712(ty.trim())?, name: name.trim() })
     }
 }
 

--- a/crates/dyn-abi/src/eip712/resolver.rs
+++ b/crates/dyn-abi/src/eip712/resolver.rs
@@ -46,7 +46,7 @@ impl PropertyDef {
         N: Into<String>,
     {
         let type_name = type_name.into();
-        TypeSpecifier::parse(type_name.as_str())?;
+        TypeSpecifier::parse_eip712(type_name.as_str())?;
         Ok(Self::new_unchecked(type_name, name))
     }
 
@@ -115,7 +115,7 @@ impl TypeDef {
     #[inline]
     pub fn new<S: Into<String>>(type_name: S, props: Vec<PropertyDef>) -> Result<Self> {
         let type_name = type_name.into();
-        RootType::parse(type_name.as_str())?;
+        RootType::parse_eip712(type_name.as_str())?;
         Ok(Self { type_name, props })
     }
 
@@ -366,7 +366,7 @@ impl Resolver {
         if self.detect_cycle(type_name, &mut context) {
             return Err(Error::circular_dependency(type_name));
         }
-        let root_type = type_name.rsplit(':').next().unwrap().try_into()?;
+        let root_type = RootType::parse_eip712(type_name)?;
         let mut resolution = vec![];
         self.linearize_into(&mut resolution, root_type)?;
         Ok(resolution)
@@ -378,7 +378,7 @@ impl Resolver {
         if self.detect_cycle(type_name, &mut Default::default()) {
             return Err(Error::circular_dependency(type_name));
         }
-        self.unchecked_resolve(&type_name.try_into()?)
+        self.unchecked_resolve(&TypeSpecifier::parse_eip712(type_name)?)
     }
 
     /// Resolve a type into a [`crate::DynSolType`] without checking for cycles.
@@ -410,7 +410,7 @@ impl Resolver {
         let prop_names: Vec<_> = ty.prop_names().map(str::to_string).collect();
         let tuple: Vec<_> = ty
             .prop_types()
-            .map(|ty| self.unchecked_resolve(&ty.try_into()?))
+            .map(|ty| self.unchecked_resolve(&TypeSpecifier::parse_eip712(ty)?))
             .collect::<Result<_, _>>()?;
 
         Ok(DynSolType::CustomStruct { name: ty.type_name.clone(), prop_names, tuple })

--- a/crates/dyn-abi/src/eip712/typed_data.rs
+++ b/crates/dyn-abi/src/eip712/typed_data.rs
@@ -20,10 +20,8 @@ impl<'de> Deserialize<'de> for Eip712Types {
         let map: BTreeMap<String, Vec<PropertyDef>> = BTreeMap::deserialize(deserializer)?;
 
         for key in map.keys() {
-            // keys can further be qualified with a colon, e.g. "EIP712Domain:MyType"
-            let id = key.rsplit(':').next().unwrap();
             // ensure that all types are valid specifiers
-            let _ = TypeSpecifier::parse(id).map_err(serde::de::Error::custom)?;
+            let _ = TypeSpecifier::parse_eip712(key).map_err(serde::de::Error::custom)?;
         }
 
         Ok(Self(map))

--- a/crates/sol-type-parser/Cargo.toml
+++ b/crates/sol-type-parser/Cargo.toml
@@ -35,4 +35,5 @@ serde_json.workspace = true
 default = ["std"]
 std = ["winnow/std"]
 serde = ["dep:serde"]
-debug = ["std"] # intentionally doesn't enable `winnow/debug`
+debug = ["std"]       # intentionally doesn't enable `winnow/debug`
+eip712 = []

--- a/crates/sol-type-parser/src/ident.rs
+++ b/crates/sol-type-parser/src/ident.rs
@@ -76,6 +76,32 @@ where
     Ok(input.next_slice(len))
 }
 
+/// Returns `true` if the given character is valid in an EIP-712 identifier.
+/// EIP-712 identifiers can contain colons for namespacing.
+#[cfg(feature = "eip712")]
+#[inline]
+const fn is_eip712_id_continue(c: char) -> bool {
+    matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '$' | ':')
+}
+
+/// Parses an EIP-712 identifier (which may contain colons).
+#[cfg(feature = "eip712")]
+#[inline]
+pub(crate) fn eip712_identifier_parser<'a, I>(input: &mut I) -> ModalResult<&'a str>
+where
+    I: Stream<Slice = &'a str> + AsBStr,
+{
+    let mut chars = input.as_bstr().iter().map(|b| *b as char);
+
+    let Some(true) = chars.next().map(is_id_start) else {
+        return Err(ErrMode::from_input(input));
+    };
+
+    // 1 for the first character, we know it's ASCII
+    let len = 1 + chars.take_while(|c| is_eip712_id_continue(*c)).count();
+    Ok(input.next_slice(len))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/sol-type-parser/src/root.rs
+++ b/crates/sol-type-parser/src/root.rs
@@ -85,7 +85,7 @@ impl<'a> RootType<'a> {
                     return Self("uint8");
                 }
 
-                // Normalize the `uint` aliases to the canonical `uint256`
+                // Normalize the `u?int` aliases to the canonical `u?int256`
                 match ident {
                     "uint" => Self("uint256"),
                     "int" => Self("int256"),

--- a/crates/sol-type-parser/src/root.rs
+++ b/crates/sol-type-parser/src/root.rs
@@ -119,7 +119,7 @@ impl<'a> RootType<'a> {
                     return Self("uint8");
                 }
 
-                // Normalize the `uint` aliases to the canonical `uint256`
+                // Normalize the `u?int` aliases to the canonical `u?int256`
                 match ident {
                     "uint" => Self("uint256"),
                     "int" => Self("int256"),

--- a/crates/sol-type-parser/src/root.rs
+++ b/crates/sol-type-parser/src/root.rs
@@ -85,7 +85,7 @@ impl<'a> RootType<'a> {
                     return Self("uint8");
                 }
 
-                // Normalize the `u?int` aliases to the canonical `u?int256`
+                // Normalize the `uint` aliases to the canonical `uint256`
                 match ident {
                     "uint" => Self("uint256"),
                     "int" => Self("int256"),
@@ -110,13 +110,16 @@ impl<'a> RootType<'a> {
             use crate::ident::eip712_identifier_parser;
 
             eip712_identifier_parser(input).map(|ident| {
-                // Keep the same normalization logic
+                // Workaround for enums in library function params or returns.
+                // See: https://github.com/alloy-rs/core/pull/386
+                // See ethabi workaround: https://github.com/rust-ethereum/ethabi/blob/b1710adc18f5b771d2d2519c87248b1ba9430778/ethabi/src/param_type/reader.rs#L162-L167
                 if input.starts_with('.') {
                     let _ = input.next_token();
                     let _ = eip712_identifier_parser(input);
                     return Self("uint8");
                 }
 
+                // Normalize the `uint` aliases to the canonical `uint256`
                 match ident {
                     "uint" => Self("uint256"),
                     "int" => Self("int256"),

--- a/crates/sol-type-parser/src/stem.rs
+++ b/crates/sol-type-parser/src/stem.rs
@@ -53,6 +53,17 @@ impl<'a> TypeStem<'a> {
         }
     }
 
+    /// [`winnow`] parser for EIP-712 types.
+    #[cfg(feature = "eip712")]
+    pub(crate) fn eip712_parser(input: &mut Input<'a>) -> ModalResult<Self> {
+        let name = "TypeStem::eip712";
+        if input.starts_with('(') || input.starts_with("tuple(") {
+            trace(name, TupleSpecifier::eip712_parser).parse_next(input).map(Self::Tuple)
+        } else {
+            trace(name, RootType::eip712_parser).parse_next(input).map(Self::Root)
+        }
+    }
+
     /// [`winnow`] parser for this type.
     pub(crate) fn parser(input: &mut Input<'a>) -> ModalResult<Self> {
         let name = "TypeStem";

--- a/crates/sol-type-parser/src/tuple.rs
+++ b/crates/sol-type-parser/src/tuple.rs
@@ -70,6 +70,20 @@ impl<'a> TupleSpecifier<'a> {
         preceded(opt("tuple"), tuple_parser(TypeSpecifier::parser)).parse_next(input)
     }
 
+    /// [`winnow`] parser for EIP-712 types.
+    #[cfg(feature = "eip712")]
+    pub(crate) fn eip712_parser(input: &mut Input<'a>) -> ModalResult<Self> {
+        trace("TupleSpecifier::eip712", spanned(Self::parse_eip712_types))
+            .parse_next(input)
+            .map(|(span, types)| Self { span, types })
+    }
+
+    #[cfg(feature = "eip712")]
+    #[inline]
+    fn parse_eip712_types(input: &mut Input<'a>) -> ModalResult<Vec<TypeSpecifier<'a>>> {
+        preceded(opt("tuple"), tuple_parser(TypeSpecifier::eip712_parser)).parse_next(input)
+    }
+
     /// Returns the tuple specifier as a string.
     #[inline]
     pub const fn span(&self) -> &'a str {

--- a/crates/sol-type-parser/src/type_spec.rs
+++ b/crates/sol-type-parser/src/type_spec.rs
@@ -113,6 +113,36 @@ impl<'a> TypeSpecifier<'a> {
         .map(|(span, (stem, sizes))| Self { span, stem, sizes })
     }
 
+    /// Parse a type specifier from a string, allowing EIP-712 style identifiers with colons.
+    #[cfg(feature = "eip712")]
+    #[inline]
+    pub fn parse_eip712(s: &'a str) -> Result<Self> {
+        Self::eip712_parser.parse(new_input(s)).map_err(Error::parser)
+    }
+
+    /// [`winnow`] parser for EIP-712 types (allows colons in identifiers).
+    #[cfg(feature = "eip712")]
+    pub(crate) fn eip712_parser(input: &mut Input<'a>) -> ModalResult<Self> {
+        trace(
+            "TypeSpecifier::eip712",
+            spanned(|input: &mut Input<'a>| {
+                let stem = TypeStem::eip712_parser(input)?;
+                let sizes = if input.starts_with('[') {
+                    repeat(
+                        1..,
+                        delimited(str_parser("["), array_size_parser, cut_err(str_parser("]"))),
+                    )
+                    .parse_next(input)?
+                } else {
+                    Vec::new()
+                };
+                Ok((stem, sizes))
+            }),
+        )
+        .parse_next(input)
+        .map(|(span, (stem, sizes))| Self { span, stem, sizes })
+    }
+
     /// Returns the type stem as a string.
     #[inline]
     pub const fn span(&self) -> &'a str {


### PR DESCRIPTION
ref:
- https://github.com/foundry-rs/foundry/issues/10765

`:` in names causing `TypeSpecifier` identifier parsing to fail, not sure how this should be solved.

there are two aspects to this issue, is a `A:B` entry valid, and how should this be resolved and hashed