### PR TITLE
Fix typos in documentation and test cases

### DIFF
--- a/crates/primitives/src/signed/int.rs
+++ b/crates/primitives/src/signed/int.rs
@@ -13,7 +13,7 @@ use ruint::{BaseConvertError, Uint, UintTryFrom, UintTryTo};
 ///
 /// ## Aliases
 ///
-/// We provide aliases for every bit-width divisble by 8, from 8 to 256. These
+/// We provide aliases for every bit-width divisible by 8, from 8 to 256. These
 /// are located in [`crate::aliases`] and are named `I256`, `I248` etc. Most
 /// users will want [`crate::I256`].
 ///

--- a/crates/sol-type-parser/src/parameter.rs
+++ b/crates/sol-type-parser/src/parameter.rs
@@ -250,13 +250,13 @@ mod tests {
     #[test]
     fn parse_storage() {
         assert_eq!(
-            ParameterSpecifier::parse("foo storag"),
+            ParameterSpecifier::parse("foo storage"),
             Ok(ParameterSpecifier {
-                span: "foo storag",
+                span: "foo storage",
                 ty: TypeSpecifier::parse("foo").unwrap(),
                 storage: None,
                 indexed: false,
-                name: Some("storag")
+                name: Some("storage")
             })
         );
         assert_eq!(
@@ -299,6 +299,6 @@ mod tests {
                 name: "bar".into()
             })
         );
-        ParameterSpecifier::parse("foo storag bar").unwrap_err();
+        ParameterSpecifier::parse("foo storage bar").unwrap_err();
     }
 }


### PR DESCRIPTION
- Corrected a typo in documentation: "divisble" → "divisible" in `crates/primitives/src/signed/int.rs`.
- Fixed typos in test inputs and expected values in `crates/sol-type-parser/src/parameter.rs`: corrected "storag" to "storage".
