### PR TITLE
feat: add `is_dynamic` method to `DynSolType`

### DIFF
--- a/crates/dyn-abi/src/dynamic/ty.rs
+++ b/crates/dyn-abi/src/dynamic/ty.rs
@@ -558,6 +558,23 @@ impl DynSolType {
         self.abi_decode_inner(&mut Decoder::new(data), DynToken::decode_sequence_populate)
     }
 
+    /// Returns `true` if this type is dynamically sized type.
+    pub fn is_dynamic(&self) -> bool {
+        match self {
+            Self::Address
+            | Self::Function
+            | Self::Bool
+            | Self::Uint(..)
+            | Self::Int(..)
+            | Self::FixedBytes(..) => false,
+            Self::Bytes | Self::String | Self::Array(_) => true,
+            Self::Tuple(tuple) => tuple.iter().any(Self::is_dynamic),
+            Self::FixedArray(inner, _) => inner.is_dynamic(),
+            #[cfg(feature = "eip712")]
+            Self::CustomStruct { tuple, .. } => tuple.iter().any(Self::is_dynamic),
+        }
+    }
+
     /// Calculate the minimum number of ABI words necessary to encode this
     /// type.
     pub fn minimum_words(&self) -> usize {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

The `DynSolType` implementation was not exposing a method to check if the type is dynamically sized.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add a method with an implementation similar to the one in [DynSolValue](https://github.com/alloy-rs/core/blob/main/crates/dyn-abi/src/dynamic/value.rs)

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
