### PR TITLE
chore: fix warning in generated code

### DIFF
--- a/crates/sol-macro-expander/src/expand/mod.rs
+++ b/crates/sol-macro-expander/src/expand/mod.rs
@@ -877,6 +877,7 @@ fn expand_from_into_tuples<P>(
 
     quote! {
         #[doc(hidden)]
+        #[allow(dead_code)]
         type UnderlyingSolTuple<'a> = #sol_tuple;
         #[doc(hidden)]
         type UnderlyingRustTuple<'a> = #rust_tuple;


### PR DESCRIPTION
Without this change, the generated code is creating a lot of warning like these on `nightly` rust:

```
warning: type alias `UnderlyingSolTuple` is never used
    --> crates/bindings/src/utilities.rs:2643:18
     |
2643 |             type UnderlyingSolTuple<'a> = ();
     |                  ^^^^^^^^^^^^^^^^^^
```