### PR TITLE
Add environment variable checks for WORKSPACE_ROOT and CRATE_ROOT in changelog script

### DIFF
--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+: "${WORKSPACE_ROOT:?WORKSPACE_ROOT is not set}"
+: "${CRATE_ROOT:?CRATE_ROOT is not set}"
+
 run_unless_dry_run() {
     if [ "$DRY_RUN" = "true" ]; then
         echo "skipping due to dry run: $*" >&2


### PR DESCRIPTION
This PR adds explicit checks at the beginning of scripts/changelog.sh to ensure that the environment variables WORKSPACE_ROOT and CRATE_ROOT are set before proceeding. If either variable is unset, the script will exit with a clear error message. This improves the script's robustness and helps prevent accidental misconfiguration or unexpected behavior when running the changelog generation process.