### PR TITLE
Implement conversion from `Word` for `DynSolValue`

### DIFF
--- a/crates/dyn-abi/src/dynamic/value.rs
+++ b/crates/dyn-abi/src/dynamic/value.rs
@@ -117,6 +117,13 @@ impl From<Vec<u8>> for DynSolValue {
     }
 }
 
+impl From<Word> for DynSolValue {
+    #[inline]
+    fn from(value: Word) -> Self {
+        Self::FixedBytes(value, 32)
+    }
+}
+
 impl From<String> for DynSolValue {
     #[inline]
     fn from(value: String) -> Self {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->


```rs
let uint = U256::ZERO;
let address = Address::ZERO;
let word = B256::ZERO;

input(uint); // works
input(address); // works
input(word); // the trait bound `dynamic::value::DynSolValue: std::convert::From<alloy_primitives::FixedBytes<32>>` is not satisfied

fn input(v: impl Into<DynSolValue>) {}
```


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Implemented conversion from `Word` for `DynSolValue`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
