### PR TITLE
feat(primitives): add borsh support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,9 @@ alloy-sol-type-parser = { version = "1.3.1", path = "crates/sol-type-parser", de
 alloy-sol-types = { version = "1.3.1", path = "crates/sol-types", default-features = false }
 syn-solidity = { version = "1.3.1", path = "crates/syn-solidity", default-features = false }
 
+# borsh
+borsh = { version = "1.5", default-features = false }
+
 # serde
 serde = { version = "1.0", default-features = false, features = ["alloc"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -160,6 +160,7 @@ serde = [
 ]
 borsh = [
     "dep:borsh",
+    "ruint/borsh",
 ]
 
 allocative = ["dep:allocative"]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -55,6 +55,9 @@ keccak-asm = { workspace = true, optional = true }
 sha3 = { workspace = true, optional = true }
 tiny-keccak = { workspace = true, features = ["keccak"] }
 
+# borsh
+borsh = { workspace = true, optional = true }
+
 # rlp
 alloy-rlp = { workspace = true, optional = true }
 
@@ -154,6 +157,9 @@ serde = [
     "hashbrown?/serde",
     "indexmap?/serde",
     "rand?/serde",
+]
+borsh = [
+    "dep:borsh",
 ]
 
 allocative = ["dep:allocative"]

--- a/crates/primitives/src/bits/borsh.rs
+++ b/crates/primitives/src/bits/borsh.rs
@@ -25,6 +25,7 @@ impl<const N: usize> BorshDeserialize for FixedBytes<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec::Vec;
 
     #[test]
     fn roundtrip_fixedbytes() {

--- a/crates/primitives/src/bits/borsh.rs
+++ b/crates/primitives/src/bits/borsh.rs
@@ -1,0 +1,40 @@
+use super::FixedBytes;
+use borsh::{
+    BorshDeserialize, BorshSerialize,
+    io::{Error, Read, Write},
+};
+
+#[cfg_attr(docsrs, doc(cfg(feature = "borsh")))]
+impl<const N: usize> BorshSerialize for FixedBytes<N> {
+    #[inline]
+    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+        writer.write_all(self.as_slice())
+    }
+}
+
+#[cfg_attr(docsrs, doc(cfg(feature = "borsh")))]
+impl<const N: usize> BorshDeserialize for FixedBytes<N> {
+    #[inline]
+    fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self, Error> {
+        let mut buf = [0u8; N];
+        reader.read_exact(&mut buf)?;
+        Ok(Self(buf))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_fixedbytes() {
+        let v = FixedBytes::<4>::new([1, 2, 3, 4]);
+        let mut out = Vec::new();
+        BorshSerialize::serialize(&v, &mut out).unwrap();
+        assert_eq!(out, [1, 2, 3, 4]);
+
+        let mut slice = out.as_slice();
+        let de = <FixedBytes<4> as BorshDeserialize>::deserialize_reader(&mut slice).unwrap();
+        assert_eq!(de, v);
+    }
+}

--- a/crates/primitives/src/bits/macros.rs
+++ b/crates/primitives/src/bits/macros.rs
@@ -227,6 +227,7 @@ macro_rules! wrap_fixed_bytes {
         }
 
         $crate::impl_fb_traits!($name, $n);
+        $crate::impl_borsh!($name, $n);
         $crate::impl_rlp!($name, $n);
         $crate::impl_serde!($name);
         $crate::impl_allocative!($name);
@@ -631,6 +632,41 @@ macro_rules! impl_rlp {
 #[cfg(not(feature = "rlp"))]
 macro_rules! impl_rlp {
     ($t:ty, $n:literal) => {};
+}
+
+#[doc(hidden)]
+#[macro_export]
+#[cfg(feature = "borsh")]
+macro_rules! impl_borsh {
+    ($t:ty, $n:literal) => {
+        #[cfg_attr(docsrs, doc(cfg(feature = "borsh")))]
+        impl $crate::private::borsh::BorshSerialize for $t {
+            #[inline]
+            fn serialize<W: $crate::private::borsh::io::Write>(
+                &self,
+                writer: &mut W,
+            ) -> Result<(), $crate::private::borsh::io::Error> {
+                <$crate::FixedBytes<$n> as $crate::private::borsh::BorshSerialize>::serialize(&self.0, writer)
+            }
+        }
+
+        #[cfg_attr(docsrs, doc(cfg(feature = "borsh")))]
+        impl $crate::private::borsh::BorshDeserialize for $t {
+            #[inline]
+            fn deserialize_reader<R: $crate::private::borsh::io::Read>(
+                reader: &mut R,
+            ) -> Result<Self, $crate::private::borsh::io::Error> {
+                <$crate::FixedBytes<$n> as $crate::private::borsh::BorshDeserialize>::deserialize_reader(reader).map(Self)
+            }
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+#[cfg(not(feature = "borsh"))]
+macro_rules! impl_borsh {
+    ($($t:tt)*) => {};
 }
 
 #[doc(hidden)]

--- a/crates/primitives/src/bits/mod.rs
+++ b/crates/primitives/src/bits/mod.rs
@@ -13,6 +13,9 @@ pub use fixed::FixedBytes;
 mod function;
 pub use function::Function;
 
+#[cfg(feature = "borsh")]
+mod borsh;
+
 #[cfg(feature = "rlp")]
 mod rlp;
 

--- a/crates/primitives/src/bytes/borsh.rs
+++ b/crates/primitives/src/bytes/borsh.rs
@@ -1,4 +1,5 @@
 use super::Bytes;
+use alloc::vec::Vec;
 use borsh::{
     BorshDeserialize, BorshSerialize,
     io::{Error, Read, Write},

--- a/crates/primitives/src/bytes/borsh.rs
+++ b/crates/primitives/src/bytes/borsh.rs
@@ -1,0 +1,74 @@
+use super::Bytes;
+use borsh::{
+    BorshDeserialize, BorshSerialize,
+    io::{Error, Read, Write},
+};
+
+#[cfg_attr(docsrs, doc(cfg(feature = "borsh")))]
+impl BorshSerialize for Bytes {
+    #[inline]
+    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+        // Use the same approach as Vec<u8>: write length first, then data
+        let bytes = self.as_ref();
+        bytes.serialize(writer)
+    }
+}
+
+#[cfg_attr(docsrs, doc(cfg(feature = "borsh")))]
+impl BorshDeserialize for Bytes {
+    #[inline]
+    fn deserialize_reader<R: Read>(reader: &mut R) -> Result<Self, Error> {
+        // Deserialize as Vec<u8> first, then convert to Bytes
+        let vec = Vec::<u8>::deserialize_reader(reader)?;
+        Ok(Self::from(vec))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_bytes() {
+        let original_data = vec![1, 2, 3, 4, 5];
+        let bytes = Bytes::from(original_data.clone());
+
+        let mut serialized = Vec::new();
+        BorshSerialize::serialize(&bytes, &mut serialized).unwrap();
+
+        let mut slice = serialized.as_slice();
+        let deserialized = Bytes::deserialize_reader(&mut slice).unwrap();
+
+        assert_eq!(deserialized.as_ref(), original_data.as_slice());
+        assert_eq!(deserialized, bytes);
+    }
+
+    #[test]
+    fn roundtrip_empty_bytes() {
+        let bytes = Bytes::new();
+
+        let mut serialized = Vec::new();
+        BorshSerialize::serialize(&bytes, &mut serialized).unwrap();
+
+        let mut slice = serialized.as_slice();
+        let deserialized = Bytes::deserialize_reader(&mut slice).unwrap();
+
+        assert_eq!(deserialized, bytes);
+        assert!(deserialized.is_empty());
+    }
+
+    #[test]
+    fn borsh_consistency_with_vec() {
+        let data = vec![10, 20, 30, 40];
+        let bytes = Bytes::from(data.clone());
+
+        let mut bytes_serialized = Vec::new();
+        let mut vec_serialized = Vec::new();
+
+        BorshSerialize::serialize(&bytes, &mut bytes_serialized).unwrap();
+        BorshSerialize::serialize(&data, &mut vec_serialized).unwrap();
+
+        // Should produce identical serialization since we delegate to Vec<u8>
+        assert_eq!(bytes_serialized, vec_serialized);
+    }
+}

--- a/crates/primitives/src/bytes/mod.rs
+++ b/crates/primitives/src/bytes/mod.rs
@@ -6,6 +6,9 @@ use core::{
     ops::{Deref, DerefMut, RangeBounds},
 };
 
+#[cfg(feature = "borsh")]
+mod borsh;
+
 #[cfg(feature = "rlp")]
 mod rlp;
 

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -124,6 +124,9 @@ pub mod private {
     #[cfg(feature = "serde")]
     pub use serde;
 
+    #[cfg(feature = "borsh")]
+    pub use borsh;
+
     #[cfg(feature = "arbitrary")]
     pub use {arbitrary, proptest, proptest_derive};
 


### PR DESCRIPTION
## Motivation
Close #992 

## Solution

- Added borsh as a dependency in Cargo.toml files for the main crate and primitives.
- Implemented borsh serialization and deserialization macros in the primitives library.
- Implemented borsh serialization and deserialization for `FixedBytes`

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
