### PR TITLE
fix(sol-types): Fix `encode_topic_bytes` for byte slices whose length is a non-zero multiple of 32

### DIFF
--- a/crates/sol-types/src/types/event/topic.rs
+++ b/crates/sol-types/src/types/event/topic.rs
@@ -211,3 +211,33 @@ fn encode_topic_bytes(sl: &[u8], out: &mut Vec<u8>) {
     out.extend_from_slice(sl);
     out.extend(core::iter::repeat_n(0, padding));
 }
+
+#[cfg(test)]
+mod tests {
+    use super::encode_topic_bytes;
+
+    #[test]
+    fn encode_topic_bytes_empty() {
+        let mut out = Vec::new();
+        encode_topic_bytes(&[], &mut out);
+        assert_eq!(out, vec![0; 32]);
+    }
+
+    #[test]
+    fn encode_topic_bytes_remainder_modulo_32() {
+        let mut out = Vec::new();
+        encode_topic_bytes(&[0u8; 11], &mut out);
+        assert_eq!(out, vec![0; 32]);
+    }
+
+    #[test]
+    fn encode_topic_bytes_non_zero_multiple() {
+        let mut out = Vec::new();
+        encode_topic_bytes(&[0u8; 32], &mut out);
+        assert_eq!(out, vec![0; 32]);
+
+        let mut out = Vec::new();
+        encode_topic_bytes(&[0u8; 64], &mut out);
+        assert_eq!(out, vec![0; 64]);
+    }
+}

--- a/crates/sol-types/src/types/event/topic.rs
+++ b/crates/sol-types/src/types/event/topic.rs
@@ -206,10 +206,22 @@ impl EventTopic for () {
 all_the_tuples!(tuple_impls);
 
 fn encode_topic_bytes(sl: &[u8], out: &mut Vec<u8>) {
-    let padding = 32 - sl.len() % 32;
+    let padding = non_zero_padding(sl.len());
     out.reserve(sl.len() + padding);
     out.extend_from_slice(sl);
     out.extend(core::iter::repeat_n(0, padding));
+}
+
+#[inline(always)]
+const fn non_zero_padding(len: usize) -> usize {
+    if len == 0 {
+        return 32;
+    }
+
+    match len % 32 {
+        0 => 0,
+        r => 32 - r,
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Fixes https://github.com/alloy-rs/core/issues/998

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Fixes padding calculation in `encode_topic_bytes` which is used for encoding event topic preimages for byte sequences (i.e. `string` and `bytes` types) which are members of a composite event parameter type (e.g. structs and arrays).
See https://github.com/alloy-rs/core/issues/998 for details

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
