### PR TITLE
feat(sol-macro-expander): add `Clone` trait to enum contracts containers

### DIFF
--- a/crates/sol-macro-expander/src/expand/contract.rs
+++ b/crates/sol-macro-expander/src/expand/contract.rs
@@ -166,6 +166,7 @@ pub(super) fn expand(cx: &mut ExpCtxt<'_>, contract: &ItemContract) -> Result<To
         let mut attrs = enum_attrs.clone();
         let doc_str = format!("Container for all the [`{name}`](self) function calls.");
         attrs.push(parse_quote!(#[doc = #doc_str]));
+        attrs.push(parse_quote!(#[derive(Clone)]));
         enum_expander.expand(ToExpand::Functions(&functions), attrs)
     });
 
@@ -173,6 +174,7 @@ pub(super) fn expand(cx: &mut ExpCtxt<'_>, contract: &ItemContract) -> Result<To
         let mut attrs = enum_attrs.clone();
         let doc_str = format!("Container for all the [`{name}`](self) custom errors.");
         attrs.push(parse_quote!(#[doc = #doc_str]));
+        attrs.push(parse_quote!(#[derive(Clone)]));
         enum_expander.expand(ToExpand::Errors(&errors), attrs)
     });
 
@@ -180,6 +182,7 @@ pub(super) fn expand(cx: &mut ExpCtxt<'_>, contract: &ItemContract) -> Result<To
         let mut attrs = enum_attrs;
         let doc_str = format!("Container for all the [`{name}`](self) events.");
         attrs.push(parse_quote!(#[doc = #doc_str]));
+        attrs.push(parse_quote!(#[derive(Clone)]));
         enum_expander.expand(ToExpand::Events(&events), attrs)
     });
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The `enum` containers associated to contracts function calls, custom errors and events, don't implement the `Clone` trait while the underlying `struct`s do.
Having the `Clone` trait propagated at this higher level is generally useful.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Add `#[derive(Clone)]` where the containers are defined.

## PR Checklist

- [ ] Added Tests
    - No pre-existing test on which traits are implemented.
- [ ] Added Documentation
    - No pre-existing documentation on which traits are implemented in the custom containers.
- [ ] Breaking changes
    - Not a breaking change