### PR TITLE
feat(sol-macro): inherit attributes from contract

### DIFF
--- a/crates/sol-macro-expander/src/expand/function.rs
+++ b/crates/sol-macro-expander/src/expand/function.rs
@@ -36,7 +36,7 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, function: &ItemFunction) -> Result<TokenS
     if name.is_none() {
         // ignore functions without names (modifiers...)
         return Ok(quote!());
-    };
+    }
 
     let returns = returns.as_ref().map(|r| &r.returns).unwrap_or_default();
 

--- a/crates/sol-macro-input/src/attr.rs
+++ b/crates/sol-macro-input/src/attr.rs
@@ -215,18 +215,23 @@ impl SolAttrs {
 
     /// Merges `other` into `self`. `other` takes precedence over `self`.
     ///
-    /// This is used when parsing items inside nested contracts.
+    /// This is used to inherit the contract's attributes when expanding its items.
     pub fn merge(&mut self, other: &SolAttrs) {
         fn merge_opt<T: Clone>(a: &mut Option<T>, b: &Option<T>) {
             if let Some(b) = b {
                 *a = Some(b.clone());
             }
         }
+        fn merge_vec<T: Clone>(a: &mut Option<Vec<T>>, b: &Option<Vec<T>>) {
+            if let Some(b) = b {
+                a.get_or_insert_default().extend(b.iter().cloned());
+            }
+        }
         let (a, b) = (self, other);
         merge_opt(&mut a.rpc, &b.rpc);
         merge_opt(&mut a.abi, &b.abi);
         merge_opt(&mut a.all_derives, &b.all_derives);
-        merge_opt(&mut a.extra_derives, &b.extra_derives);
+        merge_vec(&mut a.extra_derives, &b.extra_derives);
         merge_opt(&mut a.extra_methods, &b.extra_methods);
         merge_opt(&mut a.docs, &b.docs);
         merge_opt(&mut a.alloy_sol_types, &b.alloy_sol_types);

--- a/crates/sol-macro-input/src/attr.rs
+++ b/crates/sol-macro-input/src/attr.rs
@@ -76,7 +76,7 @@ pub fn parse_derives(attr: &Attribute) -> Punctuated<Path, Token![,]> {
 // 5. document the attribute in the [`sol!`] macro docs.
 
 /// `#[sol(...)]` attributes.
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SolAttrs {
     /// `#[sol(rpc)]`
     pub rpc: Option<bool>,
@@ -211,6 +211,32 @@ impl SolAttrs {
             })?;
         }
         Ok((this, others))
+    }
+
+    /// Merges `other` into `self`. `other` takes precedence over `self`.
+    ///
+    /// This is used when parsing items inside nested contracts.
+    pub fn merge(&mut self, other: &SolAttrs) {
+        fn merge_opt<T: Clone>(a: &mut Option<T>, b: &Option<T>) {
+            if let Some(b) = b {
+                *a = Some(b.clone());
+            }
+        }
+        let (a, b) = (self, other);
+        merge_opt(&mut a.rpc, &b.rpc);
+        merge_opt(&mut a.abi, &b.abi);
+        merge_opt(&mut a.all_derives, &b.all_derives);
+        merge_opt(&mut a.extra_derives, &b.extra_derives);
+        merge_opt(&mut a.extra_methods, &b.extra_methods);
+        merge_opt(&mut a.docs, &b.docs);
+        merge_opt(&mut a.alloy_sol_types, &b.alloy_sol_types);
+        merge_opt(&mut a.alloy_contract, &b.alloy_contract);
+        merge_opt(&mut a.rename, &b.rename);
+        merge_opt(&mut a.rename_all, &b.rename_all);
+        merge_opt(&mut a.bytecode, &b.bytecode);
+        merge_opt(&mut a.deployed_bytecode, &b.deployed_bytecode);
+        merge_opt(&mut a.type_check, &b.type_check);
+        merge_opt(&mut a.ignore_unlinked, &b.ignore_unlinked);
     }
 }
 

--- a/crates/sol-types/tests/macros/sol/mod.rs
+++ b/crates/sol-types/tests/macros/sol/mod.rs
@@ -1360,3 +1360,21 @@ fn extra_derives() {
     let s = MyStruct { a: U256::ZERO };
     let _ = format!("{s:#?}");
 }
+
+#[test]
+fn inherit_attrs() {
+    sol! {
+        #![sol(extra_derives(PartialEq, Eq))]
+
+        #[sol(extra_derives(Debug))]
+        contract C {
+            struct MyStruct {
+                uint256 a;
+            }
+        }
+    }
+
+    let a = C::MyStruct { a: U256::ZERO };
+    let b = C::MyStruct { a: U256::ZERO };
+    assert_eq!(a, b, "{a:#?} != {b:#?}");
+}


### PR DESCRIPTION
Inherit `#[sol(...)]` from contract when expanding that contract's attributes.