### PR TITLE
perf(sol-macro): improve abi expansion

### DIFF
--- a/crates/sol-macro-expander/src/expand/error.rs
+++ b/crates/sol-macro-expander/src/expand/error.rs
@@ -52,7 +52,6 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, error: &ItemError) -> Result<TokenStream>
                 impl alloy_sol_types::JsonAbiExt for #name {
                     type Abi = alloy_sol_types::private::alloy_json_abi::Error;
 
-                    #[inline]
                     fn abi() -> Self::Abi {
                         #error
                     }

--- a/crates/sol-macro-expander/src/expand/event.rs
+++ b/crates/sol-macro-expander/src/expand/event.rs
@@ -139,7 +139,6 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, event: &ItemEvent) -> Result<TokenStream>
                 impl alloy_sol_types::JsonAbiExt for #name {
                     type Abi = alloy_sol_types::private::alloy_json_abi::Event;
 
-                    #[inline]
                     fn abi() -> Self::Abi {
                         #event
                     }

--- a/crates/sol-macro-expander/src/expand/function.rs
+++ b/crates/sol-macro-expander/src/expand/function.rs
@@ -91,7 +91,6 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, function: &ItemFunction) -> Result<TokenS
                 impl alloy_sol_types::JsonAbiExt for #call_name {
                     type Abi = alloy_sol_types::private::alloy_json_abi::Function;
 
-                    #[inline]
                     fn abi() -> Self::Abi {
                         #function
                     }

--- a/crates/sol-types/src/lib.rs
+++ b/crates/sol-types/src/lib.rs
@@ -116,4 +116,14 @@ pub mod private {
     }
 
     pub struct AssertTypeEq<T>(pub T);
+
+    #[inline(never)]
+    pub fn str_to_owned(s: &str) -> String {
+        s.to_owned()
+    }
+
+    #[inline(never)]
+    pub fn make_btree_map<K: Ord, V>(items: Vec<(K, V)>) -> BTreeMap<K, V> {
+        BTreeMap::from_iter(items)
+    }
 }

--- a/crates/sol-types/tests/macros/sol/abi.rs
+++ b/crates/sol-types/tests/macros/sol/abi.rs
@@ -562,3 +562,38 @@ fn eparam(s: &str, indexed: bool) -> EventParam {
         indexed,
     }
 }
+
+#[test]
+fn special_funcs() {
+    sol! {
+        #[sol(abi)]
+        contract NoAttrs {
+            fallback() external;
+            receive() external;
+        }
+
+        #[sol(abi)]
+        contract WithAttrs {
+            fallback() external payable;
+            receive() external payable;
+        }
+    }
+
+    assert_eq!(
+        NoAttrs::abi::fallback(),
+        Some(Fallback { state_mutability: StateMutability::NonPayable })
+    );
+    assert_eq!(
+        NoAttrs::abi::receive(),
+        Some(Receive { state_mutability: StateMutability::Payable })
+    );
+
+    assert_eq!(
+        WithAttrs::abi::fallback(),
+        Some(Fallback { state_mutability: StateMutability::Payable })
+    );
+    assert_eq!(
+        WithAttrs::abi::receive(),
+        Some(Receive { state_mutability: StateMutability::Payable })
+    );
+}


### PR DESCRIPTION
Use the `#item::abi()` functions instead of re-expanding every function inside of the contract's ABI. Also expand it lazily with a static array of function pointers to avoid inlining