### PR TITLE
fix(sol-macro): remove #[automatically_derived] from non-trait impls

### DIFF
--- a/crates/sol-macro-expander/src/expand/contract.rs
+++ b/crates/sol-macro-expander/src/expand/contract.rs
@@ -414,7 +414,6 @@ pub(super) fn expand(cx: &mut ExpCtxt<'_>, contract: &ItemContract) -> Result<To
             }
 
             /// Instantiation and getters/setters.
-            #[automatically_derived]
             impl #generic_p_n #name<P, N> {
                 #[doc = #new_fn_doc]
                 #[inline]
@@ -458,7 +457,6 @@ pub(super) fn expand(cx: &mut ExpCtxt<'_>, contract: &ItemContract) -> Result<To
             }
 
             /// Function calls.
-            #[automatically_derived]
             impl #generic_p_n #name<P, N> {
                 /// Creates a new call builder using this contract instance's provider and address.
                 ///
@@ -474,7 +472,6 @@ pub(super) fn expand(cx: &mut ExpCtxt<'_>, contract: &ItemContract) -> Result<To
             }
 
             /// Event filters.
-            #[automatically_derived]
             impl #generic_p_n #name<P, N> {
                 /// Creates a new event filter using this contract instance's provider and address.
                 ///
@@ -917,7 +914,6 @@ impl CallLikeExpander<'_> {
                 )*
             }
 
-            #[automatically_derived]
             impl #name {
                 /// All the selectors of this enum.
                 ///
@@ -958,7 +954,6 @@ impl CallLikeExpander<'_> {
             let methods = variants.iter().zip(types).map(generate_variant_methods);
             tokens.extend(conversions);
             tokens.extend(quote! {
-                #[automatically_derived]
                 impl #name {
                     #(#methods)*
                 }

--- a/crates/sol-macro-expander/src/expand/udt.rs
+++ b/crates/sol-macro-expander/src/expand/udt.rs
@@ -62,7 +62,6 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, udt: &ItemUdt) -> Result<TokenStream> {
                 }
             }
 
-            #[automatically_derived]
             impl #name {
                 /// The Solidity type name.
                 pub const NAME: &'static str = stringify!(@name);


### PR DESCRIPTION
This triggers an `unused_attributes` warning in the latest stable version.

```rust
warning: `#[automatically_derived]` attribute cannot be used on inherent impl blocks
 --> src/main.rs:4:1
  |
4 | #[automatically_derived]
  | ^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
  = help: `#[automatically_derived]` can only be applied to trait impl blocks
  = note: `#[warn(unused_attributes)]` (part of `#[warn(unused)]`) on by default
```