### PR TITLE
Feat(primitive): moved some alloc:string to arrayvec::arrayString

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -29,6 +29,7 @@ bytes.workspace = true
 hex.workspace = true
 itoa.workspace = true
 ruint.workspace = true
+arrayvec.workspace=true
 
 # macros
 cfg-if.workspace = true

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -8,6 +8,9 @@
 #![cfg_attr(feature = "nightly", feature(hasher_prefixfree_extras))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+use arrayvec::ArrayString;
+/// A fixed-capacity string type with a maximum length of 80 characters.
+pub type String = ArrayString<80>;
 #[macro_use]
 extern crate alloc;
 
@@ -102,7 +105,7 @@ pub type B160 = FixedBytes<20>;
 // Not public API.
 #[doc(hidden)]
 pub mod private {
-    pub use alloc::vec::Vec;
+    // pub use alloc::vec::Vec;
     pub use core::{
         self,
         borrow::{Borrow, BorrowMut},

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -105,7 +105,7 @@ pub type B160 = FixedBytes<20>;
 // Not public API.
 #[doc(hidden)]
 pub mod private {
-    // pub use alloc::vec::Vec;
+    pub use alloc::vec::Vec;
     pub use core::{
         self,
         borrow::{Borrow, BorrowMut},

--- a/crates/primitives/src/signed/conversions.rs
+++ b/crates/primitives/src/signed/conversions.rs
@@ -1,5 +1,5 @@
 use super::{BigIntConversionError, ParseSignedError, Sign, Signed, utils::twos_complement};
-use alloc::string::String;
+use crate::String;
 use core::str::FromStr;
 use ruint::{ToUintError, Uint, UintTryFrom};
 

--- a/crates/primitives/src/signed/int.rs
+++ b/crates/primitives/src/signed/int.rs
@@ -1,6 +1,6 @@
 use super::{ParseSignedError, Sign, utils::*};
-use alloc::string::String;
-use core::fmt;
+use crate::String;
+use core::fmt::{self, Write};
 use ruint::{BaseConvertError, Uint, UintTryFrom, UintTryTo};
 
 /// Signed integer wrapping a `ruint::Uint`.
@@ -370,8 +370,9 @@ impl<const BITS: usize, const LIMBS: usize> Signed<BITS, LIMBS> {
     pub fn to_dec_string(&self) -> String {
         let sign = self.sign();
         let abs = self.unsigned_abs();
-
-        format!("{sign}{abs}")
+        let mut buf = String::new();
+        write!(&mut buf, "{sign}{abs}").unwrap();
+        buf
     }
 
     /// Convert from a hex string.
@@ -396,8 +397,9 @@ impl<const BITS: usize, const LIMBS: usize> Signed<BITS, LIMBS> {
     pub fn to_hex_string(&self) -> String {
         let sign = self.sign();
         let abs = self.unsigned_abs();
-
-        format!("{sign}0x{abs:x}")
+        let mut buf = String::new();
+        write!(&mut buf, "{sign}0x{abs:x}").unwrap();
+        buf
     }
 
     /// Splits a Signed into its absolute value and negative flag.


### PR DESCRIPTION
implementing #999

## Motivation

The issue was to move String from `alloc::string::String` to `arrayvec::arrayString`

## Solution

Changed String to fixed capacity stack based String `pub type String = ArrayString<80>;`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
