### PR TITLE
chore: remove feature(doc_auto_cfg)

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -5,7 +5,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[doc(inline)]
 pub use alloy_primitives as primitives;

--- a/crates/dyn-abi/src/lib.rs
+++ b/crates/dyn-abi/src/lib.rs
@@ -14,7 +14,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[macro_use]
 extern crate alloc;

--- a/crates/json-abi/src/lib.rs
+++ b/crates/json-abi/src/lib.rs
@@ -14,7 +14,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::literal_string_with_formatting_args)] // TODO: https://github.com/rust-lang/rust-clippy/issues/13885
 
 #[macro_use]

--- a/crates/primitives/src/bits/macros.rs
+++ b/crates/primitives/src/bits/macros.rs
@@ -5,7 +5,7 @@
 /// type-confused for another named `FixedBytes`.
 ///
 /// **NOTE:** This macro currently requires:
-/// - `#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]` at the top level of the crate.
+/// - `#![cfg_attr(docsrs, feature(doc_cfg))]` at the top level of the crate.
 /// - The `derive_more` crate in scope.
 ///
 /// # Examples

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -6,7 +6,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly", feature(hasher_prefixfree_extras))]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[macro_use]
 extern crate alloc;

--- a/crates/sol-macro-expander/src/lib.rs
+++ b/crates/sol-macro-expander/src/lib.rs
@@ -5,7 +5,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![allow(clippy::missing_const_for_fn, rustdoc::broken_intra_doc_links)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod expand;
 mod utils;

--- a/crates/sol-macro-input/src/lib.rs
+++ b/crates/sol-macro-input/src/lib.rs
@@ -4,7 +4,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/alloy-rs/core/main/assets/favicon.ico"
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 extern crate syn_solidity as ast;
 

--- a/crates/sol-macro/src/lib.rs
+++ b/crates/sol-macro/src/lib.rs
@@ -12,7 +12,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/alloy-rs/core/main/assets/favicon.ico"
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[macro_use]
 extern crate proc_macro_error2;

--- a/crates/sol-type-parser/src/lib.rs
+++ b/crates/sol-type-parser/src/lib.rs
@@ -5,7 +5,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[macro_use]
 extern crate alloc;

--- a/crates/sol-types/src/lib.rs
+++ b/crates/sol-types/src/lib.rs
@@ -5,7 +5,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[allow(unused_extern_crates)]
 extern crate self as alloy_sol_types;

--- a/crates/syn-solidity/src/lib.rs
+++ b/crates/syn-solidity/src/lib.rs
@@ -5,7 +5,7 @@
 )]
 #![allow(missing_docs, missing_copy_implementations, clippy::missing_const_for_fn)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 extern crate proc_macro;
 

--- a/tests/core-sol/src/lib.rs
+++ b/tests/core-sol/src/lib.rs
@@ -3,7 +3,7 @@
 //! This has to be in a separate crate where `alloy_sol_types` is not provided as a dependency.
 
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, allow(unexpected_cfgs))]
 
 use alloy_core::{primitives::wrap_fixed_bytes, sol};


### PR DESCRIPTION
```rust
error[E0557]: feature has been removed
 --> ...
  |
L | #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
  |                                      ^^^^^^^^^^^^ feature has been removed
  |
  = note: removed in 1.58.0; see <https://github.com/rust-lang/rust/pull/138907> for more information
  = note: merged into `doc_cfg`
```