### PR TITLE
feat(sol-macro): add transient storage keyword support

### DIFF
--- a/crates/syn-solidity/src/attribute/mod.rs
+++ b/crates/syn-solidity/src/attribute/mod.rs
@@ -23,6 +23,7 @@ kw_enum! {
         Memory(kw::memory),
         Storage(kw::storage),
         Calldata(kw::calldata),
+        Transient(kw::transient),
     }
 }
 

--- a/crates/syn-solidity/src/kw.rs
+++ b/crates/syn-solidity/src/kw.rs
@@ -24,6 +24,7 @@ custom_keywords!(
     memory,
     storage,
     calldata,
+    transient,
 
     // Visibility
     external,

--- a/crates/syn-solidity/tests/contracts/TransientStorage.sol
+++ b/crates/syn-solidity/tests/contracts/TransientStorage.sol
@@ -1,0 +1,5 @@
+contract C {
+    function test() public {
+        uint transient x;
+    }
+}


### PR DESCRIPTION
Closes https://github.com/alloy-rs/core/issues/1024
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Allow `alloy_sol_macro` to parse `transient` keyword that has been introduced in `0.28.8`.

## Solution

Add transient as a keyword in the storage sub-category

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes


Side question: Is the Yul parsing still maintained ? If yes, is it ok to add `tstore` and `tload` opcodes ?