### PR TITLE
Feature/alloc feature

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -25,6 +25,7 @@ rustdoc-args = [
 workspace = true
 
 [dependencies]
+arrayvec.workspace=true
 bytes.workspace = true
 hex.workspace = true
 itoa.workspace = true

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -135,6 +135,7 @@ alloc = [
     "proptest?/alloc",
     "ruint/alloc",
     "serde?/alloc",
+    "hex/alloc",
 ]
 nightly = [
     "foldhash?/nightly",

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -114,6 +114,7 @@ serde_json.workspace = true
 [features]
 default = ["std", "map", "map-foldhash"]
 std = [
+    "alloc",
     "bytes/std",
     "hex/std",
     "ruint/std",
@@ -128,6 +129,11 @@ std = [
     "rustc-hash?/std",
     "serde?/std",
     "sha3?/std",
+]
+alloc = [
+    "proptest?/alloc",
+    "ruint/alloc",
+    "serde?/alloc",
 ]
 nightly = [
     "foldhash?/nightly",

--- a/crates/primitives/src/bits/address.rs
+++ b/crates/primitives/src/bits/address.rs
@@ -289,7 +289,6 @@ impl Address {
     /// let checksummed: &str = buffer.format(&address, Some(1));
     /// assert_eq!(checksummed, "0xD8Da6bf26964Af9d7EEd9e03e53415d37AA96045");
     /// ```
-    #[cfg(feature = "alloc")]
     #[inline]
     pub fn to_checksum_buffer(&self, chain_id: Option<u64>) -> AddressChecksumBuffer {
         // SAFETY: The buffer is initialized by `format`.
@@ -307,7 +306,6 @@ impl Address {
     // > [...] If the chain id passed to the function belongs to a network that opted for using this
     // > checksum variant, prefix the address with the chain id and the `0x` separator before
     // > calculating the hash. [...]
-    #[cfg(feature = "alloc")]
     #[allow(clippy::wrong_self_convention)]
     fn to_checksum_inner(&self, buf: &mut [u8; 42], chain_id: Option<u64>) {
         buf[0] = b'0';
@@ -570,7 +568,6 @@ impl AddressChecksumBuffer {
     /// Calculates the checksum of an address into the buffer.
     ///
     /// See [`Address::to_checksum_buffer`] for more information.
-    #[cfg(feature = "alloc")]
     #[inline]
     pub fn format(&mut self, address: &Address, chain_id: Option<u64>) -> &mut str {
         address.to_checksum_inner(unsafe { self.0.assume_init_mut() }, chain_id);

--- a/crates/primitives/src/bits/address.rs
+++ b/crates/primitives/src/bits/address.rs
@@ -1,7 +1,7 @@
 use crate::{FixedBytes, aliases::U160, utils::keccak256};
+use core::borrow::Borrow;
 #[cfg(feature = "alloc")]
 use alloc::{
-    borrow::Borrow,
     string::{String, ToString},
 };
 use core::{fmt, mem::MaybeUninit, str};
@@ -103,7 +103,6 @@ impl From<Address> for U160 {
     }
 }
 
-#[cfg(feature = "alloc")]
 impl fmt::Display for Address {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let checksum = self.to_checksum_buffer(None);
@@ -179,7 +178,6 @@ impl Address {
     /// let expected = address!("0xd8da6bf26964af9d7eed9e03e53415d37aa96045");
     /// assert_eq!(address, expected);
     /// ```
-    #[cfg(feature = "alloc")]
     pub fn parse_checksummed<S: AsRef<str>>(
         s: S,
         chain_id: Option<u64>,
@@ -222,7 +220,6 @@ impl Address {
     /// let checksummed: String = address.to_checksum(Some(1));
     /// assert_eq!(checksummed, "0xD8Da6bf26964Af9d7EEd9e03e53415d37AA96045");
     /// ```
-    #[cfg(feature = "alloc")]
     #[inline]
     #[must_use]
     pub fn to_checksum(&self, chain_id: Option<u64>) -> String {
@@ -258,7 +255,6 @@ impl Address {
     /// let checksummed: &mut str = address.to_checksum_raw(&mut buf, Some(1));
     /// assert_eq!(checksummed, "0xD8Da6bf26964Af9d7EEd9e03e53415d37AA96045");
     /// ```
-    #[cfg(feature = "alloc")]
     #[inline]
     #[must_use]
     pub fn to_checksum_raw<'a>(&self, buf: &'a mut [u8], chain_id: Option<u64>) -> &'a mut str {
@@ -401,7 +397,6 @@ impl Address {
     /// let expected = address!("0x533ae9d683B10C02EbDb05471642F85230071FC3");
     /// assert_eq!(address.create2_from_code(salt, init_code), expected);
     /// ```
-    #[cfg(feature = "alloc")]
     #[must_use]
     pub fn create2_from_code<S, C>(&self, salt: S, init_code: C) -> Self
     where
@@ -434,7 +429,6 @@ impl Address {
     /// let expected = address!("0x0d4a11d5EEaaC28EC3F61d100daF4d40471f1852");
     /// assert_eq!(address.create2(salt, init_code_hash), expected);
     /// ```
-    #[cfg(feature = "alloc")]
     #[must_use]
     pub fn create2<S, H>(&self, salt: S, init_code_hash: H) -> Self
     where
@@ -479,7 +473,6 @@ impl Address {
     /// // Create an address using CREATE_EOF
     /// let eof_address = address.create_eof(salt);
     /// ```
-    #[cfg(feature = "alloc")]
     #[must_use]
     #[doc(alias = "eof_create")]
     pub fn create_eof<S>(&self, salt: S) -> Self

--- a/crates/primitives/src/bits/address.rs
+++ b/crates/primitives/src/bits/address.rs
@@ -1,4 +1,5 @@
 use crate::{FixedBytes, aliases::U160, utils::keccak256};
+#[cfg(feature = "alloc")]
 use alloc::{
     borrow::Borrow,
     string::{String, ToString},
@@ -102,6 +103,7 @@ impl From<Address> for U160 {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::Display for Address {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let checksum = self.to_checksum_buffer(None);
@@ -177,6 +179,7 @@ impl Address {
     /// let expected = address!("0xd8da6bf26964af9d7eed9e03e53415d37aa96045");
     /// assert_eq!(address, expected);
     /// ```
+    #[cfg(feature = "alloc")]
     pub fn parse_checksummed<S: AsRef<str>>(
         s: S,
         chain_id: Option<u64>,
@@ -219,6 +222,7 @@ impl Address {
     /// let checksummed: String = address.to_checksum(Some(1));
     /// assert_eq!(checksummed, "0xD8Da6bf26964Af9d7EEd9e03e53415d37AA96045");
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline]
     #[must_use]
     pub fn to_checksum(&self, chain_id: Option<u64>) -> String {
@@ -254,6 +258,7 @@ impl Address {
     /// let checksummed: &mut str = address.to_checksum_raw(&mut buf, Some(1));
     /// assert_eq!(checksummed, "0xD8Da6bf26964Af9d7EEd9e03e53415d37AA96045");
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline]
     #[must_use]
     pub fn to_checksum_raw<'a>(&self, buf: &'a mut [u8], chain_id: Option<u64>) -> &'a mut str {
@@ -284,6 +289,7 @@ impl Address {
     /// let checksummed: &str = buffer.format(&address, Some(1));
     /// assert_eq!(checksummed, "0xD8Da6bf26964Af9d7EEd9e03e53415d37AA96045");
     /// ```
+    #[cfg(feature = "alloc")]
     #[inline]
     pub fn to_checksum_buffer(&self, chain_id: Option<u64>) -> AddressChecksumBuffer {
         // SAFETY: The buffer is initialized by `format`.
@@ -301,6 +307,7 @@ impl Address {
     // > [...] If the chain id passed to the function belongs to a network that opted for using this
     // > checksum variant, prefix the address with the chain id and the `0x` separator before
     // > calculating the hash. [...]
+    #[cfg(feature = "alloc")]
     #[allow(clippy::wrong_self_convention)]
     fn to_checksum_inner(&self, buf: &mut [u8; 42], chain_id: Option<u64>) {
         buf[0] = b'0';
@@ -396,6 +403,7 @@ impl Address {
     /// let expected = address!("0x533ae9d683B10C02EbDb05471642F85230071FC3");
     /// assert_eq!(address.create2_from_code(salt, init_code), expected);
     /// ```
+    #[cfg(feature = "alloc")]
     #[must_use]
     pub fn create2_from_code<S, C>(&self, salt: S, init_code: C) -> Self
     where
@@ -428,6 +436,7 @@ impl Address {
     /// let expected = address!("0x0d4a11d5EEaaC28EC3F61d100daF4d40471f1852");
     /// assert_eq!(address.create2(salt, init_code_hash), expected);
     /// ```
+    #[cfg(feature = "alloc")]
     #[must_use]
     pub fn create2<S, H>(&self, salt: S, init_code_hash: H) -> Self
     where
@@ -472,6 +481,7 @@ impl Address {
     /// // Create an address using CREATE_EOF
     /// let eof_address = address.create_eof(salt);
     /// ```
+    #[cfg(feature = "alloc")]
     #[must_use]
     #[doc(alias = "eof_create")]
     pub fn create_eof<S>(&self, salt: S) -> Self
@@ -560,6 +570,7 @@ impl AddressChecksumBuffer {
     /// Calculates the checksum of an address into the buffer.
     ///
     /// See [`Address::to_checksum_buffer`] for more information.
+    #[cfg(feature = "alloc")]
     #[inline]
     pub fn format(&mut self, address: &Address, chain_id: Option<u64>) -> &mut str {
         address.to_checksum_inner(unsafe { self.0.assume_init_mut() }, chain_id);
@@ -579,6 +590,7 @@ impl AddressChecksumBuffer {
     }
 
     /// Returns the checksum of a formatted address.
+    #[cfg(feature = "alloc")]
     #[inline]
     #[allow(clippy::inherent_to_string_shadow_display)]
     pub fn to_string(&self) -> String {

--- a/crates/primitives/src/bits/serde.rs
+++ b/crates/primitives/src/bits/serde.rs
@@ -38,7 +38,7 @@ impl<'de, const N: usize> Deserialize<'de> for FixedBytes<N> {
 
             fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
                 let len_error =
-                    |i| de::Error::invalid_length(i, &format!("exactly {N} bytes").as_str());
+                    |i| de::Error::invalid_length(i, &"exactly {N} bytes"); // TODO: actual formatting
                 let mut bytes = [0u8; N];
 
                 for (i, byte) in bytes.iter_mut().enumerate() {

--- a/crates/primitives/src/bytes/mod.rs
+++ b/crates/primitives/src/bytes/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "alloc")]
+
 use crate::FixedBytes;
 use alloc::{boxed::Box, vec::Vec};
 use core::{

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -8,6 +8,8 @@
 #![cfg_attr(feature = "nightly", feature(hasher_prefixfree_extras))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[cfg(feature = "alloc")]
+#[allow(unused_imports)]
 #[macro_use]
 extern crate alloc;
 
@@ -70,6 +72,7 @@ pub use signature::PrimitiveSignature;
 pub use signature::{Signature, SignatureError, normalize_v, to_eip155_v};
 
 pub mod utils;
+#[cfg(feature = "alloc")]
 pub use utils::{KECCAK256_EMPTY, Keccak256, eip191_hash_message, keccak256};
 
 #[doc(hidden)] // Use `hex` directly instead!
@@ -107,6 +110,7 @@ pub type B160 = FixedBytes<20>;
 // Not public API.
 #[doc(hidden)]
 pub mod private {
+    #[cfg(feature = "alloc")]
     pub use alloc::vec::Vec;
     pub use core::{
         self,

--- a/crates/primitives/src/log/mod.rs
+++ b/crates/primitives/src/log/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "alloc")] // logs are a wrapper over Vec basically, so there is no point in having them without alloc
+
 use crate::{Address, B256, Bloom, Bytes};
 use alloc::vec::Vec;
 

--- a/crates/primitives/src/signature/sig.rs
+++ b/crates/primitives/src/signature/sig.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::missing_const_for_fn)] // On purpose for forward compatibility.
 
 use crate::{B256, U256, hex, normalize_v, signature::SignatureError, uint};
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 use core::{fmt::Display, str::FromStr};
 
@@ -60,6 +61,7 @@ impl From<Signature> for [u8; 65] {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<&Signature> for Vec<u8> {
     #[inline]
     fn from(value: &Signature) -> Self {
@@ -67,6 +69,7 @@ impl From<&Signature> for Vec<u8> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<Signature> for Vec<u8> {
     #[inline]
     fn from(value: Signature) -> Self {

--- a/crates/primitives/src/signed/conversions.rs
+++ b/crates/primitives/src/signed/conversions.rs
@@ -1,4 +1,5 @@
 use super::{BigIntConversionError, ParseSignedError, Sign, Signed, utils::twos_complement};
+#[cfg(feature = "alloc")]
 use alloc::string::String;
 use core::str::FromStr;
 use ruint::{ToUintError, Uint, UintTryFrom};
@@ -95,6 +96,7 @@ impl<const BITS: usize, const LIMBS: usize> TryFrom<&str> for Signed<BITS, LIMBS
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<const BITS: usize, const LIMBS: usize> TryFrom<&String> for Signed<BITS, LIMBS> {
     type Error = ParseSignedError;
 
@@ -104,6 +106,7 @@ impl<const BITS: usize, const LIMBS: usize> TryFrom<&String> for Signed<BITS, LI
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<const BITS: usize, const LIMBS: usize> TryFrom<String> for Signed<BITS, LIMBS> {
     type Error = ParseSignedError;
 

--- a/crates/primitives/src/signed/int.rs
+++ b/crates/primitives/src/signed/int.rs
@@ -1,4 +1,5 @@
 use super::{ParseSignedError, Sign, utils::*};
+#[cfg(feature = "alloc")]
 use alloc::string::String;
 use core::fmt;
 use ruint::{BaseConvertError, Uint, UintTryFrom, UintTryTo};
@@ -367,6 +368,7 @@ impl<const BITS: usize, const LIMBS: usize> Signed<BITS, LIMBS> {
     }
 
     /// Convert to a decimal string.
+    #[cfg(feature = "alloc")]
     pub fn to_dec_string(&self) -> String {
         let sign = self.sign();
         let abs = self.unsigned_abs();
@@ -393,6 +395,7 @@ impl<const BITS: usize, const LIMBS: usize> Signed<BITS, LIMBS> {
     }
 
     /// Convert to a hex string.
+    #[cfg(feature = "alloc")]
     pub fn to_hex_string(&self) -> String {
         let sign = self.sign();
         let abs = self.unsigned_abs();

--- a/crates/primitives/src/signed/serde.rs
+++ b/crates/primitives/src/signed/serde.rs
@@ -1,4 +1,5 @@
 use super::Signed;
+#[cfg(feature = "alloc")]
 use alloc::string::String;
 use core::{fmt, str};
 use ruint::Uint;
@@ -55,6 +56,7 @@ fn deserialize<'de, const BITS: usize, const LIMBS: usize, D: Deserializer<'de>>
             v.parse().map_err(serde::de::Error::custom)
         }
 
+        #[cfg(feature = "alloc")]
         fn visit_string<E: de::Error>(self, v: String) -> Result<Self::Value, E> {
             self.visit_str(&v)
         }

--- a/crates/primitives/src/utils/units.rs
+++ b/crates/primitives/src/utils/units.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "alloc")]
+
 use crate::{I256, ParseSignedError, U256};
 use alloc::string::{String, ToString};
 use core::fmt;


### PR DESCRIPTION
Closes #999 

It just adds feature gate everywhere and showcases one example how some string usages can be replaced with `arrayvec`. It's a bit unfortunate in a sense that sequences with N > 10**17 elements will have a slightly worse error message, but otherwise it remove an allocation in here for free and works in no_std no alloc scenarios. 

The subsequent PRs can be used to remove `alloc` requirements for the code (e.g. `mod utils` doesn't seem to need that many allocs).