### PR TITLE
feat: move alloy-serde to primitives

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -177,7 +177,6 @@ rkyv = ["dep:rkyv", "ruint/rkyv"]
 rlp = ["dep:alloy-rlp", "ruint/alloy-rlp"]
 serde = [
     "dep:serde",
-    "dep:serde_json",
     "bytes/serde",
     "hex/serde",
     "ruint/serde",
@@ -185,6 +184,7 @@ serde = [
     "indexmap?/serde",
     "rand?/serde",
 ]
+serde-json = ["serde", "dep:serde_json"]
 schemars = ["dep:schemars"]
 borsh = ["dep:borsh", "ruint/borsh"]
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -65,6 +65,7 @@ alloy-rlp = { workspace = true, optional = true }
 
 # serde
 serde = { workspace = true, optional = true, features = ["derive"] }
+serde_json = { workspace = true, optional = true }
 
 # schemars
 schemars = { workspace = true, optional = true, default-features = false }
@@ -134,6 +135,7 @@ std = [
     "rand?/thread_rng",
     "rustc-hash/std",
     "serde?/std",
+    "serde_json?/std",
     "sha3/std",
 ]
 nightly = [
@@ -175,6 +177,7 @@ rkyv = ["dep:rkyv", "ruint/rkyv"]
 rlp = ["dep:alloy-rlp", "ruint/alloy-rlp"]
 serde = [
     "dep:serde",
+    "dep:serde_json",
     "bytes/serde",
     "hex/serde",
     "ruint/serde",

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -90,6 +90,8 @@ pub use {
 #[cfg(feature = "serde")]
 #[doc(no_inline)]
 pub use ::hex::serde as serde_hex;
+#[cfg(feature = "serde")]
+pub mod serde;
 
 // Not public API.
 #[doc(hidden)]

--- a/crates/primitives/src/serde/checksum.rs
+++ b/crates/primitives/src/serde/checksum.rs
@@ -1,0 +1,46 @@
+//! Serde functions for (de)serializing EIP-55 checksummed addresses.
+//!
+//! Can also be used for rejecting non checksummend addresses during deserialization.
+//!
+//! # Example
+//! ```
+//! use alloy_primitives::{Address, address};
+//! use serde::{Deserialize, Serialize};
+//!
+//! #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+//! pub struct Container {
+//!     #[serde(with = "alloy_primitives::serde::checksum")]
+//!     value: Address,
+//! }
+//!
+//! let val = Container { value: address!("0xdadB0d80178819F2319190D340ce9A924f783711") };
+//! let s = serde_json::to_string(&val).unwrap();
+//! assert_eq!(s, "{\"value\":\"0xdadB0d80178819F2319190D340ce9A924f783711\"}");
+//!
+//! let deserialized: Container = serde_json::from_str(&s).unwrap();
+//! assert_eq!(val, deserialized);
+//!
+//! let invalid = "{\"value\":\"0xdadb0d80178819F2319190D340ce9A924f783711\"}";
+//! serde_json::from_str::<Container>(&invalid).unwrap_err();
+//! ```
+
+use crate::Address;
+use alloc::string::String;
+use serde::{Deserialize, Deserializer, Serializer};
+
+/// Serialize an [Address] with EIP-55 checksum.
+pub fn serialize<S>(value: &Address, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.collect_str(&value.to_checksum(None))
+}
+
+/// Deserialize an [Address] only if it has EIP-55 checksum.
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Address, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let str = String::deserialize(deserializer)?;
+    Address::parse_checksummed(str, None).map_err(serde::de::Error::custom)
+}

--- a/crates/primitives/src/serde/displayfromstr.rs
+++ b/crates/primitives/src/serde/displayfromstr.rs
@@ -1,0 +1,45 @@
+//! Serde functions for (de)serializing using FromStr and Display
+//!
+//! Useful for example in encoding SSZ `uintN` primitives using the "canonical JSON mapping"
+//! described in the consensus-specs here: <https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md#json-mapping>
+//!
+//! # Example
+//! ```
+//! use serde::{Deserialize, Serialize};
+//!
+//! #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+//! pub struct Container {
+//!     #[serde(with = "alloy_primitives::serde::displayfromstr")]
+//!     value: u64,
+//! }
+//!
+//! let val = Container { value: 18112749083033600 };
+//! let s = serde_json::to_string(&val).unwrap();
+//! assert_eq!(s, "{\"value\":\"18112749083033600\"}");
+//!
+//! let deserialized: Container = serde_json::from_str(&s).unwrap();
+//! assert_eq!(val, deserialized);
+//! ```
+
+use alloc::string::String;
+use core::{fmt, str::FromStr};
+use serde::{Deserialize, Deserializer, Serializer};
+
+/// Serialize a type `T` that implements [fmt::Display] as a quoted string.
+pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    T: fmt::Display,
+    S: Serializer,
+{
+    serializer.collect_str(value)
+}
+
+/// Deserialize a quoted string to a type `T` using [FromStr].
+pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: FromStr,
+    T::Err: fmt::Display,
+{
+    String::deserialize(deserializer)?.parse().map_err(serde::de::Error::custom)
+}

--- a/crates/primitives/src/serde/mod.rs
+++ b/crates/primitives/src/serde/mod.rs
@@ -1,0 +1,42 @@
+//! Serde-related utilities for Alloy.
+
+use crate::{B256, hex};
+use serde::Serializer;
+
+pub mod displayfromstr;
+
+pub mod checksum;
+
+mod optional;
+pub use self::optional::*;
+
+pub mod quantity;
+
+/// Storage related helpers.
+pub mod storage;
+pub use storage::JsonStorageKey;
+
+pub mod ttd;
+pub use ttd::*;
+
+mod other;
+pub use other::{OtherFields, WithOtherFields};
+
+/// Serialize a byte vec as a hex string _without_ the "0x" prefix.
+///
+/// This behaves the same as [`hex::encode`].
+pub fn serialize_hex_string_no_prefix<S, T>(x: T, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: AsRef<[u8]>,
+{
+    s.serialize_str(&hex::encode(x.as_ref()))
+}
+
+/// Serialize a [B256] as a hex string _without_ the "0x" prefix.
+pub fn serialize_b256_hex_string_no_prefix<S>(x: &B256, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    s.collect_str(&format_args!("{x:x}"))
+}

--- a/crates/primitives/src/serde/mod.rs
+++ b/crates/primitives/src/serde/mod.rs
@@ -16,10 +16,14 @@ pub mod quantity;
 pub mod storage;
 pub use storage::JsonStorageKey;
 
+#[cfg(feature = "serde-json")]
 pub mod ttd;
+#[cfg(feature = "serde-json")]
 pub use ttd::*;
 
+#[cfg(feature = "serde-json")]
 mod other;
+#[cfg(feature = "serde-json")]
 pub use other::{OtherFields, WithOtherFields};
 
 /// Serialize a byte vec as a hex string _without_ the "0x" prefix.

--- a/crates/primitives/src/serde/optional.rs
+++ b/crates/primitives/src/serde/optional.rs
@@ -1,0 +1,78 @@
+//! Serde functions for encoding optional values.
+
+use serde::{Deserialize, Deserializer};
+
+/// For use with serde's `deserialize_with` on a sequence that must be
+/// deserialized as a single but optional (i.e. possibly `null`) value.
+pub fn null_as_default<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Deserialize<'de> + Default,
+    D: Deserializer<'de>,
+{
+    Option::<T>::deserialize(deserializer).map(Option::unwrap_or_default)
+}
+
+/// For use with serde's `deserialize_with` on a field that must be missing.
+pub fn reject_if_some<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    let value = Option::<T>::deserialize(deserializer)?;
+
+    if value.is_some() {
+        return Err(serde::de::Error::custom("unexpected value"));
+    }
+
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct TestStruct {
+        #[serde(default, deserialize_with = "null_as_default")]
+        value: Vec<i32>,
+
+        #[serde(default, deserialize_with = "reject_if_some")]
+        should_be_none: Option<String>,
+    }
+
+    #[test]
+    fn test_null_as_default_with_null() {
+        let json_data = json!({ "value": null });
+        let result: TestStruct = serde_json::from_value(json_data).unwrap();
+        assert_eq!(result.value, Vec::<i32>::new());
+    }
+
+    #[test]
+    fn test_null_as_default_with_value() {
+        let json_data = json!({ "value": [1, 2, 3] });
+        let result: TestStruct = serde_json::from_value(json_data).unwrap();
+        assert_eq!(result.value, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_null_as_default_with_missing_field() {
+        let json_data = json!({});
+        let result: TestStruct = serde_json::from_value(json_data).unwrap();
+        assert_eq!(result.value, Vec::<i32>::new());
+    }
+
+    #[test]
+    fn test_reject_if_some_with_none() {
+        let json_data = json!({});
+        let result: TestStruct = serde_json::from_value(json_data).unwrap();
+        assert_eq!(result.should_be_none, None);
+    }
+
+    #[test]
+    fn test_reject_if_some_with_some() {
+        let json_data = json!({ "should_be_none": "unexpected value" });
+        let result: Result<TestStruct, _> = serde_json::from_value(json_data);
+        assert!(result.is_err());
+    }
+}

--- a/crates/primitives/src/serde/optional.rs
+++ b/crates/primitives/src/serde/optional.rs
@@ -30,6 +30,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::{string::String, vec, vec::Vec};
     use serde_json::json;
 
     #[derive(Debug, Deserialize, PartialEq)]

--- a/crates/primitives/src/serde/other/arbitrary_.rs
+++ b/crates/primitives/src/serde/other/arbitrary_.rs
@@ -1,0 +1,40 @@
+use super::OtherFields;
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
+
+impl arbitrary::Arbitrary<'_> for OtherFields {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        let mut inner = BTreeMap::new();
+        for _ in 0usize..u.int_in_range(0usize..=15)? {
+            inner.insert(u.arbitrary()?, u.arbitrary::<ArbitraryValue>()?.into_json_value());
+        }
+        Ok(Self { inner })
+    }
+}
+
+/// Redefinition of `serde_json::Value` for the purpose of implementing `Arbitrary`.
+#[derive(Clone, Debug, arbitrary::Arbitrary)]
+enum ArbitraryValue {
+    Null,
+    Bool(bool),
+    Number(u64),
+    String(String),
+    Array(Vec<Self>),
+    Object(BTreeMap<String, Self>),
+}
+
+impl ArbitraryValue {
+    fn into_json_value(self) -> serde_json::Value {
+        match self {
+            Self::Null => serde_json::Value::Null,
+            Self::Bool(b) => serde_json::Value::Bool(b),
+            Self::Number(n) => serde_json::Value::Number(n.into()),
+            Self::String(s) => serde_json::Value::String(s),
+            Self::Array(a) => {
+                serde_json::Value::Array(a.into_iter().map(Self::into_json_value).collect())
+            }
+            Self::Object(o) => serde_json::Value::Object(
+                o.into_iter().map(|(k, v)| (k, v.into_json_value())).collect(),
+            ),
+        }
+    }
+}

--- a/crates/primitives/src/serde/other/mod.rs
+++ b/crates/primitives/src/serde/other/mod.rs
@@ -1,0 +1,435 @@
+//! Support for capturing other fields.
+
+use alloc::{collections::BTreeMap, format, string::String};
+use core::{
+    fmt,
+    ops::{Deref, DerefMut},
+};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde_json::Value;
+
+#[cfg(feature = "arbitrary")]
+mod arbitrary_;
+
+/// Generic type for capturing additional fields when deserializing structs.
+///
+/// For example, the [optimism `eth_getTransactionByHash` request][optimism] returns additional
+/// fields that this type will capture instead.
+///
+/// Use `deserialize_as` or `deserialize_into` with a struct that captures the unknown fields, or
+/// deserialize the individual fields manually with `get_deserialized`.
+///
+/// This type must be used with [`#[serde(flatten)]`][flatten].
+///
+/// [optimism]: https://docs.alchemy.com/alchemy/apis/optimism/eth-gettransactionbyhash
+/// [flatten]: https://serde.rs/field-attrs.html#flatten
+#[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct OtherFields {
+    inner: BTreeMap<String, serde_json::Value>,
+}
+
+impl OtherFields {
+    /// Creates a new [`OtherFields`] instance.
+    pub const fn new(inner: BTreeMap<String, serde_json::Value>) -> Self {
+        Self { inner }
+    }
+
+    /// Inserts a given value as serialized [`serde_json::Value`] into the map.
+    pub fn insert_value(&mut self, key: String, value: impl Serialize) -> serde_json::Result<()> {
+        self.inner.insert(key, serde_json::to_value(value)?);
+        Ok(())
+    }
+
+    /// Inserts a given value as serialized [`serde_json::Value`] into the map and returns the
+    /// updated instance.
+    pub fn with_value(mut self, key: String, value: impl Serialize) -> serde_json::Result<Self> {
+        self.insert_value(key, value)?;
+        Ok(self)
+    }
+
+    /// Deserialized this type into another container type.
+    pub fn deserialize_as<T: DeserializeOwned>(&self) -> serde_json::Result<T> {
+        serde_json::to_value(&self.inner).and_then(serde_json::from_value)
+    }
+
+    /// Deserialized this type into another container type.
+    pub fn deserialize_into<T: DeserializeOwned>(self) -> serde_json::Result<T> {
+        serde_json::from_value(serde_json::Value::Object(self.inner.into_iter().collect()))
+    }
+
+    /// Returns the deserialized value of the field, if it exists.
+    /// Deserializes the value with the given closure
+    pub fn get_with<F, V>(&self, key: impl AsRef<str>, with: F) -> Option<V>
+    where
+        F: FnOnce(serde_json::Value) -> V,
+    {
+        self.inner.get(key.as_ref()).cloned().map(with)
+    }
+
+    /// Returns the deserialized value of the field, if it exists
+    pub fn get_deserialized<V: DeserializeOwned>(
+        &self,
+        key: impl AsRef<str>,
+    ) -> Option<serde_json::Result<V>> {
+        self.get_with(key, serde_json::from_value)
+    }
+
+    /// Returns the deserialized value of the field.
+    ///
+    /// Returns an error if the field is missing
+    pub fn try_get_deserialized<V: DeserializeOwned>(
+        &self,
+        key: impl AsRef<str>,
+    ) -> serde_json::Result<V> {
+        let key = key.as_ref();
+        self.get_deserialized(key)
+            .ok_or_else(|| serde::de::Error::custom(format!("Missing field `{key}`")))?
+    }
+
+    /// Removes the deserialized value of the field, if it exists
+    ///
+    /// **Note:** this will also remove the value if deserializing it resulted in an error
+    pub fn remove_deserialized<V: DeserializeOwned>(
+        &mut self,
+        key: impl AsRef<str>,
+    ) -> Option<serde_json::Result<V>> {
+        self.inner.remove(key.as_ref()).map(serde_json::from_value)
+    }
+
+    /// Removes the deserialized value of the field, if it exists.
+    /// Deserializes the value with the given closure
+    ///
+    /// **Note:** this will also remove the value if deserializing it resulted in an error
+    pub fn remove_with<F, V>(&mut self, key: impl AsRef<str>, with: F) -> Option<V>
+    where
+        F: FnOnce(serde_json::Value) -> V,
+    {
+        self.inner.remove(key.as_ref()).map(with)
+    }
+
+    /// Removes the deserialized value of the field, if it exists and also returns the key
+    ///
+    /// **Note:** this will also remove the value if deserializing it resulted in an error
+    pub fn remove_entry_deserialized<V: DeserializeOwned>(
+        &mut self,
+        key: impl AsRef<str>,
+    ) -> Option<(String, serde_json::Result<V>)> {
+        self.inner
+            .remove_entry(key.as_ref())
+            .map(|(key, value)| (key, serde_json::from_value(value)))
+    }
+}
+
+impl fmt::Debug for OtherFields {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("OtherFields ")?;
+        self.inner.fmt(f)
+    }
+}
+
+impl TryFrom<serde_json::Value> for OtherFields {
+    type Error = serde_json::Error;
+
+    fn try_from(value: serde_json::Value) -> Result<Self, Self::Error> {
+        serde_json::from_value(value).map(Self::new)
+    }
+}
+
+impl<K> FromIterator<(K, serde_json::Value)> for OtherFields
+where
+    K: Into<String>,
+{
+    fn from_iter<T: IntoIterator<Item = (K, serde_json::Value)>>(iter: T) -> Self {
+        Self { inner: iter.into_iter().map(|(key, value)| (key.into(), value)).collect() }
+    }
+}
+
+impl Deref for OtherFields {
+    type Target = BTreeMap<String, serde_json::Value>;
+
+    #[inline]
+    fn deref(&self) -> &BTreeMap<String, serde_json::Value> {
+        self.as_ref()
+    }
+}
+
+impl DerefMut for OtherFields {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl AsRef<BTreeMap<String, serde_json::Value>> for OtherFields {
+    fn as_ref(&self) -> &BTreeMap<String, serde_json::Value> {
+        &self.inner
+    }
+}
+
+impl IntoIterator for OtherFields {
+    type Item = (String, serde_json::Value);
+    type IntoIter = alloc::collections::btree_map::IntoIter<String, serde_json::Value>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a OtherFields {
+    type Item = (&'a String, &'a serde_json::Value);
+    type IntoIter = alloc::collections::btree_map::Iter<'a, String, serde_json::Value>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.as_ref().iter()
+    }
+}
+
+/// An extension to a struct that allows to capture additional fields when deserializing.
+///
+/// See [`OtherFields`] for more information.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct WithOtherFields<T> {
+    /// The inner struct.
+    #[serde(flatten)]
+    pub inner: T,
+    /// All fields not present in the inner struct.
+    #[serde(flatten)]
+    pub other: OtherFields,
+}
+
+impl<T, U> AsRef<U> for WithOtherFields<T>
+where
+    T: AsRef<U>,
+{
+    fn as_ref(&self) -> &U {
+        self.inner.as_ref()
+    }
+}
+
+impl<T> WithOtherFields<T> {
+    /// Creates a new [`WithOtherFields`] instance.
+    pub fn new(inner: T) -> Self {
+        Self { inner, other: Default::default() }
+    }
+
+    /// Consumes the type and returns the wrapped value.
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+
+    /// Returns the wrapped value.
+    pub const fn inner(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T> Deref for WithOtherFields<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T> DerefMut for WithOtherFields<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<'de, T> Deserialize<'de> for WithOtherFields<T>
+where
+    T: Deserialize<'de> + Serialize,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct WithOtherFieldsHelper<T> {
+            #[serde(flatten)]
+            inner: T,
+            #[serde(flatten)]
+            other: OtherFields,
+        }
+
+        let mut helper = WithOtherFieldsHelper::deserialize(deserializer)?;
+        // remove all fields present in the inner struct from the other fields, this is to avoid
+        // duplicate fields in the catch all other fields because serde flatten does not exclude
+        // already deserialized fields when deserializing the other fields.
+        if let Value::Object(map) =
+            serde_json::to_value(&helper.inner).map_err(serde::de::Error::custom)?
+        {
+            for key in map.keys() {
+                helper.other.remove(key);
+            }
+        }
+
+        Ok(Self { inner: helper.inner, other: helper.other })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+    use serde_json::json;
+
+    #[test]
+    #[cfg(all(feature = "arbitrary", feature = "rand"))]
+    fn other_fields_arbitrary() {
+        use rand::Rng;
+        let mut bytes = [0u8; 1024];
+        rand::rng().fill(bytes.as_mut_slice());
+
+        let _ = arbitrary::Unstructured::new(&bytes).arbitrary::<OtherFields>().unwrap();
+    }
+
+    #[test]
+    fn test_correct_other() {
+        #[derive(Serialize, Deserialize)]
+        struct Inner {
+            a: u64,
+        }
+
+        #[derive(Serialize, Deserialize)]
+        struct InnerWrapper {
+            #[serde(flatten)]
+            inner: Inner,
+        }
+
+        let with_other: WithOtherFields<InnerWrapper> =
+            serde_json::from_str("{\"a\": 1, \"b\": 2}").unwrap();
+        assert_eq!(with_other.inner.inner.a, 1);
+        assert_eq!(
+            with_other.other,
+            OtherFields::new(BTreeMap::from_iter([("b".to_string(), serde_json::json!(2))]))
+        );
+    }
+
+    #[test]
+    fn test_with_other_fields_serialization() {
+        #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        struct Inner {
+            a: u64,
+            b: String,
+        }
+
+        let inner = Inner { a: 42, b: "Hello".to_string() };
+        let mut other = BTreeMap::new();
+        other.insert("extra".to_string(), json!(99));
+
+        let with_other = WithOtherFields { inner, other: OtherFields::new(other.clone()) };
+        let serialized = serde_json::to_string(&with_other).unwrap();
+
+        let expected = r#"{"a":42,"b":"Hello","extra":99}"#;
+        assert_eq!(serialized, expected);
+    }
+
+    #[test]
+    fn test_remove_and_access_other_fields() {
+        #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        struct Inner {
+            a: u64,
+            b: String,
+        }
+
+        let json_data = r#"{"a":42,"b":"Hello","extra":99, "another": "test"}"#;
+        let mut with_other: WithOtherFields<Inner> = serde_json::from_str(json_data).unwrap();
+
+        assert_eq!(with_other.other.inner.get("extra"), Some(&json!(99)));
+        assert_eq!(with_other.other.inner.get("another"), Some(&json!("test")));
+
+        with_other.other.remove("extra");
+        assert!(!with_other.other.inner.contains_key("extra"));
+    }
+
+    #[test]
+    fn test_deserialize_as() {
+        let mut map = BTreeMap::new();
+        map.insert("a".to_string(), json!(1));
+        let other_fields = OtherFields::new(map);
+        let deserialized: Result<BTreeMap<String, u64>, _> = other_fields.deserialize_as();
+        assert_eq!(deserialized.unwrap().get("a"), Some(&1));
+    }
+
+    #[test]
+    fn test_deserialize_into() {
+        let mut map = BTreeMap::new();
+        map.insert("a".to_string(), json!(1));
+        let other_fields = OtherFields::new(map);
+        let deserialized: Result<BTreeMap<String, u64>, _> = other_fields.deserialize_into();
+        assert_eq!(deserialized.unwrap().get("a"), Some(&1));
+    }
+
+    #[test]
+    fn test_get_with() {
+        let mut map = BTreeMap::new();
+        map.insert("key".to_string(), json!(42));
+        let other_fields = OtherFields::new(map);
+        let value: Option<u64> = other_fields.get_with("key", |v| v.as_u64().unwrap());
+        assert_eq!(value, Some(42));
+    }
+
+    #[test]
+    fn test_get_deserialized() {
+        let mut map = BTreeMap::new();
+        map.insert("key".to_string(), json!(42));
+        let other_fields = OtherFields::new(map);
+        let value: Option<serde_json::Result<u64>> = other_fields.get_deserialized("key");
+        assert_eq!(value.unwrap().unwrap(), 42);
+    }
+
+    #[test]
+    fn test_remove_deserialized() {
+        let mut map = BTreeMap::new();
+        map.insert("key".to_string(), json!(42));
+        let mut other_fields = OtherFields::new(map);
+        let value: Option<serde_json::Result<u64>> = other_fields.remove_deserialized("key");
+        assert_eq!(value.unwrap().unwrap(), 42);
+        assert!(!other_fields.inner.contains_key("key"));
+    }
+
+    #[test]
+    fn test_remove_with() {
+        let mut map = BTreeMap::new();
+        map.insert("key".to_string(), json!(42));
+        let mut other_fields = OtherFields::new(map);
+        let value: Option<u64> = other_fields.remove_with("key", |v| v.as_u64().unwrap());
+        assert_eq!(value, Some(42));
+        assert!(!other_fields.inner.contains_key("key"));
+    }
+
+    #[test]
+    fn test_remove_entry_deserialized() {
+        let mut map = BTreeMap::new();
+        map.insert("key".to_string(), json!(42));
+        let mut other_fields = OtherFields::new(map);
+        let entry: Option<(String, serde_json::Result<u64>)> =
+            other_fields.remove_entry_deserialized("key");
+        assert!(entry.is_some());
+        let (key, value) = entry.unwrap();
+        assert_eq!(key, "key");
+        assert_eq!(value.unwrap(), 42);
+        assert!(!other_fields.inner.contains_key("key"));
+    }
+
+    #[test]
+    fn test_try_from_value() {
+        let json_value = json!({ "key": "value" });
+        let other_fields = OtherFields::try_from(json_value).unwrap();
+        assert_eq!(other_fields.inner.get("key").unwrap(), &json!("value"));
+    }
+
+    #[test]
+    fn test_into_iter() {
+        let mut map = BTreeMap::new();
+        map.insert("key1".to_string(), json!("value1"));
+        map.insert("key2".to_string(), json!("value2"));
+        let other_fields = OtherFields::new(map.clone());
+
+        let iterated_map: BTreeMap<_, _> = other_fields.into_iter().collect();
+        assert_eq!(iterated_map, map);
+    }
+}

--- a/crates/primitives/src/serde/quantity.rs
+++ b/crates/primitives/src/serde/quantity.rs
@@ -1,0 +1,500 @@
+//! Serde functions for encoding primitive numbers using the Ethereum JSON-RPC "quantity" format.
+//!
+//! This is defined as a "hex encoded unsigned integer", with a special case of 0 being `0x0`.
+//!
+//! A regex for this format is: `^0x([1-9a-f]+[0-9a-f]*|0)$`.
+//!
+//! This is only valid for human-readable [`serde`] implementations.
+//! For non-human-readable implementations, the format is unspecified.
+//! Currently, it uses a fixed-width big-endian byte-array.
+
+use private::ConvertRuint;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Serializes a primitive number as a "quantity" hex string.
+pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    T: ConvertRuint,
+    S: Serializer,
+{
+    value.into_ruint().serialize(serializer)
+}
+
+/// Deserializes a primitive number from a "quantity" hex string.
+pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: ConvertRuint,
+    D: Deserializer<'de>,
+{
+    T::Ruint::deserialize(deserializer).map(T::from_ruint)
+}
+
+/// Serde functions for encoding optional primitive numbers using the Ethereum "quantity" format.
+///
+/// See [`quantity`](self) for more information.
+pub mod opt {
+    use super::private::ConvertRuint;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    /// Serializes an optional primitive number as a "quantity" hex string.
+    pub fn serialize<T, S>(value: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: ConvertRuint,
+        S: Serializer,
+    {
+        match value {
+            Some(value) => serializer.serialize_some(&value.into_ruint()),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    /// Deserializes an optional primitive number from a "quantity" hex string.
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+    where
+        T: ConvertRuint,
+        D: Deserializer<'de>,
+    {
+        Ok(Option::<T::Ruint>::deserialize(deserializer)?.map(T::from_ruint))
+    }
+}
+
+/// Serde functions for encoding a list of primitive numbers using the Ethereum "quantity" format.
+///
+/// See [`quantity`](self) for more information.
+pub mod vec {
+    use super::private::ConvertRuint;
+    use alloc::vec::Vec;
+    use core::{fmt, marker::PhantomData};
+    use serde::{
+        Deserializer, Serializer,
+        de::{SeqAccess, Visitor},
+        ser::SerializeSeq,
+    };
+
+    /// Serializes a vector of primitive numbers as a "quantity" hex string.
+    pub fn serialize<T, S>(value: &[T], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: ConvertRuint,
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(value.len()))?;
+        for val in value {
+            seq.serialize_element(&val.into_ruint())?;
+        }
+        seq.end()
+    }
+
+    /// Deserializes a vector of primitive numbers from a "quantity" hex string.
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<Vec<T>, D::Error>
+    where
+        T: ConvertRuint,
+        D: Deserializer<'de>,
+    {
+        struct VecVisitor<T> {
+            marker: PhantomData<T>,
+        }
+
+        impl<'de, T> Visitor<'de> for VecVisitor<T>
+        where
+            T: ConvertRuint,
+        {
+            type Value = Vec<T>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a sequence")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut values = Vec::<T>::with_capacity(seq.size_hint().unwrap_or(0));
+
+                while let Some(value) = seq.next_element::<T::Ruint>()? {
+                    values.push(T::from_ruint(value));
+                }
+                Ok(values)
+            }
+        }
+
+        let visitor = VecVisitor { marker: PhantomData };
+        deserializer.deserialize_seq(visitor)
+    }
+}
+
+/// serde functions for handling `Vec<Vec<u128>>` via [U128](crate::U128)
+pub mod u128_vec_vec_opt {
+    use crate::U128;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
+
+    /// Deserializes an `u128` accepting a hex quantity string with optional 0x prefix or
+    /// a number
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Vec<Vec<u128>>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Option::<Vec<Vec<U128>>>::deserialize(deserializer)?.map_or_else(
+            || Ok(None),
+            |vec| {
+                Ok(Some(
+                    vec.into_iter().map(|v| v.into_iter().map(|val| val.to()).collect()).collect(),
+                ))
+            },
+        )
+    }
+
+    /// Serializes u128 as hex string
+    pub fn serialize<S: Serializer>(
+        value: &Option<Vec<Vec<u128>>>,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        match value {
+            Some(vec) => {
+                let vec = vec
+                    .iter()
+                    .map(|v| v.iter().map(|val| U128::from(*val)).collect::<Vec<_>>())
+                    .collect::<Vec<_>>();
+                s.serialize_some(&vec)
+            }
+            None => s.serialize_none(),
+        }
+    }
+}
+
+/// Serde functions for encoding a `HashMap` of primitive numbers using the Ethereum "quantity"
+/// format.
+///
+/// See [`quantity`](self) for more information.
+#[cfg(feature = "map")]
+pub mod hashmap {
+    use super::private::ConvertRuint;
+    use crate::map::HashMap;
+    use core::{fmt, hash::BuildHasher, marker::PhantomData};
+    use serde::{
+        Deserialize, Deserializer, Serialize, Serializer, de::MapAccess, ser::SerializeMap,
+    };
+
+    /// Serializes a `HashMap` of primitive numbers as a "quantity" hex string.
+    pub fn serialize<K, V, S, H>(map: &HashMap<K, V, H>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        K: ConvertRuint,
+        V: Serialize,
+        S: Serializer,
+        H: BuildHasher,
+    {
+        let mut map_ser = serializer.serialize_map(Some(map.len()))?;
+        for (key, value) in map {
+            map_ser.serialize_entry(&key.into_ruint(), value)?;
+        }
+        map_ser.end()
+    }
+
+    /// Deserializes a `HashMap` of primitive numbers from a "quantity" hex string.
+    pub fn deserialize<'de, K, V, D, H>(deserializer: D) -> Result<HashMap<K, V, H>, D::Error>
+    where
+        K: ConvertRuint + Eq + core::hash::Hash,
+        V: Deserialize<'de>,
+        D: Deserializer<'de>,
+        H: BuildHasher + Default,
+    {
+        struct HashMapVisitor<K, V, H> {
+            marker: PhantomData<(K, V, H)>,
+        }
+
+        impl<'de, K, V, H> serde::de::Visitor<'de> for HashMapVisitor<K, V, H>
+        where
+            K: ConvertRuint + Eq + core::hash::Hash,
+            V: Deserialize<'de>,
+            H: BuildHasher + Default,
+        {
+            type Value = HashMap<K, V, H>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a map with quantity hex-encoded keys")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut values =
+                    HashMap::with_capacity_and_hasher(map.size_hint().unwrap_or(0), H::default());
+
+                while let Some((key, value)) = map.next_entry::<K::Ruint, V>()? {
+                    values.insert(K::from_ruint(key), value);
+                }
+                Ok(values)
+            }
+        }
+
+        let visitor = HashMapVisitor { marker: PhantomData };
+        deserializer.deserialize_map(visitor)
+    }
+}
+
+/// Serde functions for encoding a `BTreeMap` of primitive numbers using the Ethereum "quantity"
+/// format.
+pub mod btreemap {
+    use super::private::ConvertRuint;
+    use alloc::collections::BTreeMap;
+    use core::{fmt, marker::PhantomData};
+    use serde::{
+        Deserialize, Deserializer, Serialize, Serializer, de::MapAccess, ser::SerializeMap,
+    };
+
+    /// Serializes a `BTreeMap` of primitive numbers as a "quantity" hex string.
+    pub fn serialize<K, V, S>(value: &BTreeMap<K, V>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        K: ConvertRuint + Ord,
+        V: Serialize,
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(value.len()))?;
+        for (key, val) in value {
+            map.serialize_entry(&key.into_ruint(), val)?;
+        }
+        map.end()
+    }
+
+    /// Deserializes a `BTreeMap` of primitive numbers from a "quantity" hex string.
+    pub fn deserialize<'de, K, V, D>(deserializer: D) -> Result<BTreeMap<K, V>, D::Error>
+    where
+        K: ConvertRuint + Ord,
+        V: Deserialize<'de>,
+        D: Deserializer<'de>,
+    {
+        struct BTreeMapVisitor<K, V> {
+            key_marker: PhantomData<K>,
+            value_marker: PhantomData<V>,
+        }
+
+        impl<'de, K, V> serde::de::Visitor<'de> for BTreeMapVisitor<K, V>
+        where
+            K: ConvertRuint + Ord,
+            V: Deserialize<'de>,
+        {
+            type Value = BTreeMap<K, V>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a map with quantity hex-encoded keys")
+            }
+
+            fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                let mut values = BTreeMap::new();
+
+                while let Some((key, value)) = map.next_entry::<K::Ruint, V>()? {
+                    values.insert(K::from_ruint(key), value);
+                }
+                Ok(values)
+            }
+        }
+
+        let visitor = BTreeMapVisitor { key_marker: PhantomData, value_marker: PhantomData };
+        deserializer.deserialize_map(visitor)
+    }
+}
+
+/// Private implementation details of the [`quantity`](self) module.
+#[expect(unnameable_types)]
+mod private {
+    #[doc(hidden)]
+    pub trait ConvertRuint: Copy + Sized {
+        // We have to use `Try*` traits because `From` is not implemented by ruint types.
+        // They shouldn't ever error.
+        type Ruint: Copy
+            + serde::Serialize
+            + serde::de::DeserializeOwned
+            + TryFrom<Self>
+            + TryInto<Self>;
+
+        #[inline]
+        fn into_ruint(self) -> Self::Ruint {
+            self.try_into().ok().unwrap()
+        }
+
+        #[inline]
+        fn from_ruint(ruint: Self::Ruint) -> Self {
+            ruint.try_into().ok().unwrap()
+        }
+    }
+
+    macro_rules! impl_from_ruint {
+        ($($primitive:ty = $ruint:ty),* $(,)?) => {
+            $(
+                impl ConvertRuint for $primitive {
+                    type Ruint = $ruint;
+                }
+            )*
+        };
+    }
+
+    impl_from_ruint! {
+        bool = crate::ruint::aliases::U1,
+        u8   = crate::U8,
+        u16  = crate::U16,
+        u32  = crate::U32,
+        u64  = crate::U64,
+        u128 = crate::U128,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{string::ToString, vec, vec::Vec};
+    use serde::{Deserialize, Serialize};
+
+    #[test]
+    fn test_hex_u64() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Value {
+            #[serde(with = "super")]
+            inner: u64,
+        }
+
+        let val = Value { inner: 1000 };
+        let s = serde_json::to_string(&val).unwrap();
+        assert_eq!(s, "{\"inner\":\"0x3e8\"}");
+
+        let deserialized: Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(val, deserialized);
+    }
+
+    #[test]
+    fn test_u128_via_ruint() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Value {
+            #[serde(with = "super")]
+            inner: u128,
+        }
+
+        let val = Value { inner: 1000 };
+        let s = serde_json::to_string(&val).unwrap();
+        assert_eq!(s, "{\"inner\":\"0x3e8\"}");
+
+        let deserialized: Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(val, deserialized);
+
+        let s = "{\"inner\":\"1000\"}".to_string();
+        let deserialized: Value = serde_json::from_str(&s).unwrap();
+
+        assert_eq!(val, deserialized);
+    }
+
+    #[test]
+    fn test_u128_opt_via_ruint() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Value {
+            #[serde(with = "super::opt")]
+            inner: Option<u128>,
+        }
+
+        let val = Value { inner: Some(1000) };
+        let s = serde_json::to_string(&val).unwrap();
+        assert_eq!(s, "{\"inner\":\"0x3e8\"}");
+
+        let deserialized: Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(val, deserialized);
+
+        let s = "{\"inner\":\"1000\"}".to_string();
+        let deserialized: Value = serde_json::from_str(&s).unwrap();
+
+        assert_eq!(val, deserialized);
+
+        let val = Value { inner: None };
+        let s = serde_json::to_string(&val).unwrap();
+        assert_eq!(s, "{\"inner\":null}");
+
+        let deserialized: Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(val, deserialized);
+    }
+
+    #[test]
+    fn test_u128_vec_via_ruint() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Value {
+            #[serde(with = "super::vec")]
+            inner: Vec<u128>,
+        }
+
+        let val = Value { inner: vec![1000, 2000] };
+        let s = serde_json::to_string(&val).unwrap();
+        assert_eq!(s, "{\"inner\":[\"0x3e8\",\"0x7d0\"]}");
+
+        let deserialized: Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(val, deserialized);
+    }
+
+    #[test]
+    fn test_u128_vec_vec_opt_via_ruint() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Value {
+            #[serde(with = "super::u128_vec_vec_opt")]
+            inner: Option<Vec<Vec<u128>>>,
+        }
+
+        let val = Value { inner: Some(vec![vec![1000, 2000], vec![3000, 4000]]) };
+        let s = serde_json::to_string(&val).unwrap();
+        assert_eq!(s, "{\"inner\":[[\"0x3e8\",\"0x7d0\"],[\"0xbb8\",\"0xfa0\"]]}");
+
+        let deserialized: Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(val, deserialized);
+
+        let val = Value { inner: None };
+        let s = serde_json::to_string(&val).unwrap();
+        assert_eq!(s, "{\"inner\":null}");
+
+        let deserialized: Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(val, deserialized);
+    }
+
+    #[test]
+    #[cfg(feature = "map")]
+    fn test_u128_hashmap_via_ruint() {
+        use crate::map::HashMap;
+
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Value {
+            #[serde(with = "super::hashmap")]
+            inner: HashMap<u128, u128>,
+        }
+
+        let mut inner_map = HashMap::default();
+        inner_map.insert(1000, 2000);
+        inner_map.insert(3000, 4000);
+
+        let val = Value { inner: inner_map.clone() };
+        let s = serde_json::to_string(&val).unwrap();
+
+        // Deserialize and verify that the original `val` and deserialized version match
+        let deserialized: Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(val.inner, deserialized.inner);
+    }
+
+    #[test]
+    fn test_u128_btreemap_via_ruint() {
+        use alloc::collections::BTreeMap;
+
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Value {
+            #[serde(with = "super::btreemap")]
+            inner: BTreeMap<u128, u128>,
+        }
+
+        let mut inner_map = BTreeMap::new();
+        inner_map.insert(1000, 2000);
+        inner_map.insert(3000, 4000);
+
+        let val = Value { inner: inner_map };
+        let s = serde_json::to_string(&val).unwrap();
+        assert_eq!(s, "{\"inner\":{\"0x3e8\":2000,\"0xbb8\":4000}}");
+
+        let deserialized: Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(val, deserialized);
+    }
+}

--- a/crates/primitives/src/serde/storage.rs
+++ b/crates/primitives/src/serde/storage.rs
@@ -1,0 +1,347 @@
+use crate::{
+    B256, Bytes, U256,
+    ruint::{BaseConvertError, ParseError},
+};
+use alloc::collections::BTreeMap;
+use core::{fmt, str::FromStr};
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// A storage key type that can be serialized to and from a hex string up to 32 bytes. Used for
+/// `eth_getStorageAt` and `eth_getProof` RPCs.
+///
+/// This is a wrapper type meant to mirror geth's serialization and deserialization behavior for
+/// storage keys.
+///
+/// In `eth_getStorageAt`, this is used for deserialization of the `index` field. Internally, the
+/// index is a [B256], but in `eth_getStorageAt` requests, its serialization can be _up to_ 32
+/// bytes. To support this, the storage key is deserialized first as a U256, and converted to a
+/// B256 for use internally.
+///
+/// `eth_getProof` also takes storage keys up to 32 bytes as input, so the `keys` field is
+/// similarly deserialized. However, geth populates the storage proof `key` fields in the response
+/// by mirroring the `key` field used in the input.
+///
+/// See how `storageKey`s (the input) are populated in the `StorageResult` (the output):
+/// <https://github.com/ethereum/go-ethereum/blob/00a73fbcce3250b87fc4160f3deddc44390848f4/internal/ethapi/api.go#L658-L690>
+///
+/// The contained [B256] and From implementation for String are used to preserve the input and
+/// implement this behavior from geth.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum JsonStorageKey {
+    /// A full 32-byte key (tried first during deserialization)
+    Hash(B256),
+    /// A number (fallback if B256 deserialization fails)
+    Number(U256),
+}
+
+impl JsonStorageKey {
+    /// Returns the key as a [`B256`] value.
+    pub fn as_b256(&self) -> B256 {
+        match self {
+            Self::Hash(hash) => *hash,
+            Self::Number(num) => B256::from(*num),
+        }
+    }
+}
+
+impl Default for JsonStorageKey {
+    fn default() -> Self {
+        Self::Hash(Default::default())
+    }
+}
+
+impl From<B256> for JsonStorageKey {
+    fn from(value: B256) -> Self {
+        Self::Hash(value)
+    }
+}
+
+impl From<[u8; 32]> for JsonStorageKey {
+    fn from(value: [u8; 32]) -> Self {
+        B256::from(value).into()
+    }
+}
+
+impl From<U256> for JsonStorageKey {
+    fn from(value: U256) -> Self {
+        Self::Number(value)
+    }
+}
+
+impl FromStr for JsonStorageKey {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() > 64 && !(s.len() == 66 && s.starts_with("0x")) {
+            return Err(ParseError::BaseConvertError(BaseConvertError::Overflow));
+        }
+
+        if let Ok(hash) = B256::from_str(s) {
+            return Ok(Self::Hash(hash));
+        }
+        s.parse().map(Self::Number)
+    }
+}
+
+impl fmt::Display for JsonStorageKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Hash(hash) => hash.fmt(f),
+            Self::Number(num) => alloc::format!("{num:#x}").fmt(f),
+        }
+    }
+}
+
+/// Converts a Bytes value into a B256, accepting inputs that are less than 32 bytes long. These
+/// inputs will be left padded with zeros.
+pub fn from_bytes_to_b256<'de, D>(bytes: Bytes) -> Result<B256, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    if bytes.0.len() > 32 {
+        return Err(serde::de::Error::custom("input too long to be a B256"));
+    }
+
+    // left pad with zeros to 32 bytes
+    let mut padded = [0u8; 32];
+    padded[32 - bytes.0.len()..].copy_from_slice(&bytes.0);
+
+    // then convert to B256 without a panic
+    Ok(B256::from_slice(&padded))
+}
+
+/// Deserializes the input into a storage map, using [from_bytes_to_b256] which allows cropped
+/// values:
+///
+/// ```json
+/// {
+///     "0x0000000000000000000000000000000000000000000000000000000000000001": "0x22"
+/// }
+/// ```
+pub fn deserialize_storage_map<'de, D>(
+    deserializer: D,
+) -> Result<Option<BTreeMap<B256, B256>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    if deserializer.is_human_readable() {
+        let map = Option::<BTreeMap<Bytes, Bytes>>::deserialize(deserializer)?;
+        match map {
+            Some(map) => {
+                let mut res_map = BTreeMap::new();
+                for (k, v) in map {
+                    let k_deserialized = from_bytes_to_b256::<'de, D>(k)?;
+                    let v_deserialized = from_bytes_to_b256::<'de, D>(v)?;
+                    res_map.insert(k_deserialized, v_deserialized);
+                }
+                Ok(Some(res_map))
+            }
+            None => Ok(None),
+        }
+    } else {
+        Option::<BTreeMap<B256, B256>>::deserialize(deserializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::{String, ToString};
+    use serde_json::json;
+
+    #[test]
+    fn default_number_storage_key() {
+        let key = JsonStorageKey::Number(Default::default());
+        assert_eq!(key.to_string(), String::from("0x0"));
+    }
+
+    #[test]
+    fn default_hash_storage_key() {
+        let key = JsonStorageKey::default();
+        assert_eq!(
+            key.to_string(),
+            String::from("0x0000000000000000000000000000000000000000000000000000000000000000")
+        );
+    }
+
+    #[test]
+    fn test_storage_key() {
+        let cases = [
+            "0x0000000000000000000000000000000000000000000000000000000000000001", // Hash
+            "0000000000000000000000000000000000000000000000000000000000000001",   // Hash
+        ];
+
+        let key: JsonStorageKey = serde_json::from_str(&json!(cases[0]).to_string()).unwrap();
+        let key2: JsonStorageKey = serde_json::from_str(&json!(cases[1]).to_string()).unwrap();
+
+        assert_eq!(key.as_b256(), key2.as_b256());
+    }
+
+    #[test]
+    fn test_storage_key_serde_roundtrips() {
+        let test_cases = [
+            "0x0000000000000000000000000000000000000000000000000000000000000001", // Hash
+            "0x0000000000000000000000000000000000000000000000000000000000000abc", // Hash
+            "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",   // Number
+            "0xabc",                                                              // Number
+            "0xabcd",                                                             // Number
+        ];
+
+        for input in test_cases {
+            let key: JsonStorageKey = serde_json::from_str(&json!(input).to_string()).unwrap();
+            let output = key.to_string();
+
+            assert_eq!(
+                input, output,
+                "Storage key roundtrip failed to preserve the exact hex representation for {input}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_as_b256() {
+        let cases = [
+            "0x0abc",                                                             // Number
+            "0x0000000000000000000000000000000000000000000000000000000000000abc", // Hash
+        ];
+
+        let num_key: JsonStorageKey = serde_json::from_str(&json!(cases[0]).to_string()).unwrap();
+        let hash_key: JsonStorageKey = serde_json::from_str(&json!(cases[1]).to_string()).unwrap();
+
+        assert_eq!(num_key, JsonStorageKey::Number(U256::from_str(cases[0]).unwrap()));
+        assert_eq!(hash_key, JsonStorageKey::Hash(B256::from_str(cases[1]).unwrap()));
+
+        assert_eq!(num_key.as_b256(), hash_key.as_b256());
+    }
+
+    #[test]
+    fn test_json_storage_key_from_b256() {
+        let b256_value = B256::from([1u8; 32]);
+        let key = JsonStorageKey::from(b256_value);
+        assert_eq!(key, JsonStorageKey::Hash(b256_value));
+        assert_eq!(
+            key.to_string(),
+            "0x0101010101010101010101010101010101010101010101010101010101010101"
+        );
+    }
+
+    #[test]
+    fn test_json_storage_key_from_u256() {
+        let u256_value = U256::from(42);
+        let key = JsonStorageKey::from(u256_value);
+        assert_eq!(key, JsonStorageKey::Number(u256_value));
+        assert_eq!(key.to_string(), "0x2a");
+    }
+
+    #[test]
+    fn test_json_storage_key_from_u8_array() {
+        let bytes = [0u8; 32];
+        let key = JsonStorageKey::from(bytes);
+        assert_eq!(key, JsonStorageKey::Hash(B256::from(bytes)));
+    }
+
+    #[test]
+    fn test_from_str_parsing() {
+        let hex_str = "0x0101010101010101010101010101010101010101010101010101010101010101";
+        let key = JsonStorageKey::from_str(hex_str).unwrap();
+        assert_eq!(key, JsonStorageKey::Hash(B256::from_str(hex_str).unwrap()));
+    }
+
+    #[test]
+    fn test_from_str_with_too_long_hex_string() {
+        let long_hex_str = "0x".to_string() + &"1".repeat(65);
+        let result = JsonStorageKey::from_str(&long_hex_str);
+
+        assert!(matches!(result, Err(ParseError::BaseConvertError(BaseConvertError::Overflow))));
+    }
+
+    #[test]
+    fn test_deserialize_storage_map_with_valid_data() {
+        let json_data = json!({
+            "0x0000000000000000000000000000000000000000000000000000000000000001": "0x22",
+            "0x0000000000000000000000000000000000000000000000000000000000000002": "0x33"
+        });
+
+        // Specify the deserialization type explicitly
+        let deserialized: Option<BTreeMap<B256, B256>> = deserialize_storage_map(
+            &serde_json::from_value::<serde_json::Value>(json_data).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            deserialized.unwrap(),
+            BTreeMap::from([
+                (B256::from(U256::from(1u128)), B256::from(U256::from(0x22u128))),
+                (B256::from(U256::from(2u128)), B256::from(U256::from(0x33u128)))
+            ])
+        );
+    }
+
+    #[test]
+    fn test_deserialize_storage_map_with_empty_data() {
+        let json_data = json!({});
+        let deserialized: Option<BTreeMap<B256, B256>> = deserialize_storage_map(
+            &serde_json::from_value::<serde_json::Value>(json_data).unwrap(),
+        )
+        .unwrap();
+        assert!(deserialized.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_deserialize_storage_map_with_none() {
+        let json_data = json!(null);
+        let deserialized: Option<BTreeMap<B256, B256>> = deserialize_storage_map(
+            &serde_json::from_value::<serde_json::Value>(json_data).unwrap(),
+        )
+        .unwrap();
+        assert!(deserialized.is_none());
+    }
+
+    #[test]
+    fn test_from_bytes_to_b256_with_valid_input() {
+        // Test case with input less than 32 bytes, should be left-padded with zeros
+        let bytes = Bytes::from(vec![0x1, 0x2, 0x3, 0x4]);
+        let result = from_bytes_to_b256::<serde_json::Value>(bytes).unwrap();
+        let expected = B256::from_slice(&[
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+            2, 3, 4,
+        ]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_from_bytes_to_b256_with_exact_32_bytes() {
+        // Test case with input exactly 32 bytes long
+        let bytes = Bytes::from(vec![
+            0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF, 0x10, 0x11,
+            0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
+            0x20,
+        ]);
+        let result = from_bytes_to_b256::<serde_json::Value>(bytes).unwrap();
+        let expected = B256::from_slice(&[
+            0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF, 0x10, 0x11,
+            0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
+            0x20,
+        ]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_from_bytes_to_b256_with_input_too_long() {
+        // Test case with input longer than 32 bytes, should return an error
+        let bytes = Bytes::from(vec![0x1; 33]); // 33 bytes long
+        let result = from_bytes_to_b256::<serde_json::Value>(bytes);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "input too long to be a B256");
+    }
+
+    #[test]
+    fn test_from_bytes_to_b256_with_empty_input() {
+        // Test case with empty input, should be all zeros
+        let bytes = Bytes::from(vec![]);
+        let result = from_bytes_to_b256::<serde_json::Value>(bytes).unwrap();
+        let expected = B256::from_slice(&[0; 32]); // All zeros
+        assert_eq!(result, expected);
+    }
+}

--- a/crates/primitives/src/serde/ttd.rs
+++ b/crates/primitives/src/serde/ttd.rs
@@ -1,0 +1,255 @@
+//! Serde functions for encoding the TTD using a Geth compatible format.
+//!
+//! In Go `big.Int` is marshalled as a JSON number without quotes. Numbers are arbitrary
+//! precision in JSON, so this is valid JSON.
+//!
+//! These functions serialize the TTD as a JSON number, if the value fits within `u128`.
+//!
+//! The TTD is parsed from:
+//!   - JSON numbers: direct `u64` values, or the specific Ethereum mainnet TTD (e.g., `5.875e22` if
+//!     represented as a float). Other floats or negative numbers will error.
+//!   - JSON strings: these are parsed as `U256` (allowing hex or decimal strings).
+//!
+//! For non-human-readable formats, the default `serde` behavior for `Option<U256>` is used.
+
+use crate::U256;
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+use serde_json::Value;
+
+/// Serializes an optional TTD as a JSON number.
+///
+/// It returns an error, if the TTD value is larger than 128-bit.
+pub fn serialize<S>(value: &Option<U256>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    if serializer.is_human_readable() {
+        match value {
+            Some(value) => {
+                // serialize as an u128 when possible, otherwise as a hex string
+                match value.try_into() {
+                    Ok(value) => serializer.serialize_u128(value),
+                    Err(_) => value.serialize(serializer),
+                }
+            }
+            None => serializer.serialize_none(),
+        }
+    } else {
+        value.serialize(serializer)
+    }
+}
+
+/// Deserializes an optional TTD value from JSON number or string.
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<U256>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    if deserializer.is_human_readable() {
+        Option::<Value>::deserialize(deserializer)?
+            .map_or_else(|| Ok(None), |value| ttd_from_value::<D>(value).map(Some))
+    } else {
+        Option::<U256>::deserialize(deserializer)
+    }
+}
+
+/// Supports parsing the TTD as an `Option<u64>`, or `Option<f64>` specifically for the mainnet TTD
+/// (5.875e22).
+pub fn deserialize_json_ttd_opt<'de, D>(deserializer: D) -> Result<Option<U256>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize(deserializer)
+}
+
+/// Converts the given [serde_json::Value] into a `U256` value for TTD deserialization.
+fn ttd_from_value<'de, D>(val: Value) -> Result<U256, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let val = match val {
+        Value::Number(num) => num,
+        Value::String(raw) => return raw.parse().map_err(<D::Error as de::Error>::custom),
+        _ => return Err(de::Error::custom("TTD must be a number or string")),
+    };
+
+    let num = if let Some(val) = val.as_u64() {
+        U256::from(val)
+    } else if let Some(value) = val.as_f64() {
+        // The ethereum mainnet TTD is 58750000000000000000000, and geth serializes this
+        // without quotes, because that is how golang `big.Int`s marshal in JSON. Numbers
+        // are arbitrary precision in JSON, so this is valid JSON. This number is also
+        // greater than a `u64`.
+        //
+        // Unfortunately, serde_json only supports parsing up to `u64`, resorting to `f64`
+        // once `u64` overflows:
+        // <https://github.com/serde-rs/json/blob/4bc1eaa03a6160593575bc9bc60c94dba4cab1e3/src/de.rs#L1411-L1415>
+        // <https://github.com/serde-rs/json/blob/4bc1eaa03a6160593575bc9bc60c94dba4cab1e3/src/de.rs#L479-L484>
+        // <https://github.com/serde-rs/json/blob/4bc1eaa03a6160593575bc9bc60c94dba4cab1e3/src/de.rs#L102-L108>
+        //
+        // serde_json does have an arbitrary precision feature, but this breaks untagged
+        // enums in serde:
+        // <https://github.com/serde-rs/serde/issues/2230>
+        // <https://github.com/serde-rs/serde/issues/1183>
+        //
+        // To solve this, we use the captured float and return the TTD as a U256 if it's equal.
+        if value == 5.875e22 {
+            U256::from(58750000000000000000000u128)
+        } else {
+            // We could try to convert to a u128 here but there would probably be loss of
+            // precision, so we just return an error.
+            return Err(de::Error::custom(
+                "Deserializing a large non-mainnet TTD is not supported",
+            ));
+        }
+    } else {
+        // must be i64 - negative numbers are not supported
+        return Err(de::Error::custom(
+            "Negative TTD values are invalid and will not be deserialized",
+        ));
+    };
+
+    Ok(num)
+}
+#[cfg(test)]
+mod tests {
+    use crate::U256;
+    #[cfg(not(feature = "std"))]
+    use alloc::{vec, vec::Vec};
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+
+    #[test]
+    fn jsonu256_deserialize() {
+        let deserialized: Vec<U256> =
+            serde_json::from_str(r#"["","0", "0x","10",10,"0x10"]"#).unwrap();
+        assert_eq!(
+            deserialized,
+            vec![
+                U256::ZERO,
+                U256::ZERO,
+                U256::ZERO,
+                U256::from(10),
+                U256::from(10),
+                U256::from(16),
+            ]
+        );
+    }
+
+    #[test]
+    fn jsonu256_serialize() {
+        let data = U256::from(16);
+        let serialized = serde_json::to_string(&data).unwrap();
+
+        assert_eq!(serialized, r#""0x10""#);
+    }
+
+    #[test]
+    fn deserialize_ttd() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Ttd(#[serde(with = "super")] Option<U256>);
+
+        let deserialized: Vec<Ttd> = serde_json::from_str(
+            r#"["",0,"0","0x0",18446744073709551615,58750000000000000000000,"58750000000000000000000","0xC70D808A128D7380000"]"#,
+        )
+        .unwrap();
+        assert_eq!(
+            deserialized,
+            vec![
+                Ttd(Some(U256::ZERO)),
+                Ttd(Some(U256::ZERO)),
+                Ttd(Some(U256::ZERO)),
+                Ttd(Some(U256::ZERO)),
+                Ttd(Some(U256::from(18446744073709551615u64))),
+                Ttd(Some(U256::from(58750000000000000000000u128))),
+                Ttd(Some(U256::from(58750000000000000000000u128))),
+                Ttd(Some(U256::from(58750000000000000000000u128))),
+            ]
+        );
+    }
+
+    #[test]
+    fn serialize_ttd() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Ttd(#[serde(with = "super")] Option<U256>);
+
+        let tests = vec![
+            Ttd(Some(U256::ZERO)),
+            Ttd(Some(U256::from(17000000000000000u64))),
+            Ttd(Some(U256::from(58750000000000000000000u128))),
+            Ttd(Some(U256::from(u128::MAX))),
+        ];
+
+        for test in tests {
+            let str = serde_json::to_string(&test).unwrap();
+            // should be serialized as a decimal number and not a quoted string
+            let num = str.parse::<u128>().unwrap();
+            assert!(matches!(test, Ttd(Some(ttd)) if ttd == U256::from(num)));
+        }
+    }
+
+    #[test]
+    fn deserialize_ttd_untagged_enum() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        #[serde(untagged)]
+        enum Ttd {
+            Ttd(#[serde(with = "super")] Option<U256>),
+        }
+        let test = Ttd::Ttd(Some(U256::from(58750000000000000000000u128)));
+        let str = serde_json::to_string(&test).unwrap();
+        // should be serialized as an integer, not a float or a quoted string
+        assert_eq!(str, r#"58750000000000000000000"#);
+
+        let deserialized: Ttd = serde_json::from_str(&str).unwrap();
+        assert_eq!(deserialized, test);
+    }
+
+    #[test]
+    fn deserialize_ttd_none() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Ttd(#[serde(with = "super")] Option<U256>);
+
+        // Deserialize null as None
+        let deserialized: Ttd = serde_json::from_value(json!(null)).unwrap();
+        assert_eq!(deserialized, Ttd(None));
+    }
+
+    #[test]
+    fn deserialize_ttd_invalid_string() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Ttd(#[serde(with = "super")] Option<U256>);
+
+        // Invalid string that cannot be parsed into U256
+        let result: Result<Ttd, _> = serde_json::from_value(json!("invalid_string"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn deserialize_ttd_large_non_mainnet() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Ttd(#[serde(with = "super")] Option<U256>);
+
+        // Test for a large number not equal to 5.875e22, which should result in an error
+        let result: Result<Ttd, _> = serde_json::from_value(json!(6.0e22));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn deserialize_ttd_negative_number() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Ttd(#[serde(with = "super")] Option<U256>);
+
+        // Test for a negative number which should not be allowed
+        let result: Result<Ttd, _> = serde_json::from_value(json!(-1));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn deserialize_ttd_as_string() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Ttd(#[serde(with = "super")] Option<U256>);
+
+        // Test for valid TTD as a string
+        let deserialized: Ttd = serde_json::from_value(json!("0x12345")).unwrap();
+        assert_eq!(deserialized, Ttd(Some(U256::from(0x12345))));
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
moving `alloy-serde` to `alloy-primitives`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Moved `alloy-serde` into `alloy-primitives` as a `pub mod serde` behind the existing serde feature flag. Source files are unchanged aside from import path adjustments (alloy_primitives:: → crate::) and feature gate fixes needed because `arbitrary` and `map` are optional in primitives. Added `serde_json` as an optional dependency gated behind the `serde` feature.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
