### PR TITLE
perf: add Token::decode_many_from for batch decoding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,13 @@ jobs:
         with:
           cache-on-failure: true
       # Only run tests on latest stable and above
+      - name: pin deps
+        if: ${{ matrix.rust == '1.85' }} # MSRV
+        run: cargo +nightly update -Z minimal-versions
       - name: build
         if: ${{ matrix.rust == '1.85' }} # MSRV
         run: cargo build --workspace ${{ matrix.flags }}
+
       - name: test
         if: ${{ matrix.rust != '1.85' }} # MSRV
         run: cargo test --workspace ${{ matrix.flags }}

--- a/crates/sol-types/src/abi/encoder.rs
+++ b/crates/sol-types/src/abi/encoder.rs
@@ -111,6 +111,12 @@ impl Encoder {
         self.buf.push(word);
     }
 
+    /// Append a slice of words to the encoder.
+    #[inline]
+    pub fn append_words(&mut self, words: &[Word]) {
+        self.buf.extend_from_slice(words);
+    }
+
     /// Append a pointer to the current suffix offset.
     ///
     /// # Panics

--- a/crates/sol-types/src/abi/encoder.rs
+++ b/crates/sol-types/src/abi/encoder.rs
@@ -111,12 +111,6 @@ impl Encoder {
         self.buf.push(word);
     }
 
-    /// Append a slice of words to the encoder.
-    #[inline]
-    pub fn append_words(&mut self, words: &[Word]) {
-        self.buf.extend_from_slice(words);
-    }
-
     /// Append a pointer to the current suffix offset.
     ///
     /// # Panics

--- a/crates/sol-types/src/abi/token.rs
+++ b/crates/sol-types/src/abi/token.rs
@@ -75,31 +75,7 @@ pub trait Token<'de>: Sealed + Sized {
         dec: &mut Decoder<'de>,
         out: &mut [MaybeUninit<Self>],
     ) -> Result<()> {
-        /// Drop guard that drops initialized elements on panic or early return.
-        struct Guard<'a, T> {
-            buf: &'a mut [MaybeUninit<T>],
-            initialized: usize,
-        }
-        impl<T> Drop for Guard<'_, T> {
-            fn drop(&mut self) {
-                // SAFETY: the first `self.initialized` elements are guaranteed initialized.
-                unsafe {
-                    let ptr = self.buf.as_mut_ptr().cast::<T>();
-                    core::ptr::drop_in_place(core::ptr::slice_from_raw_parts_mut(
-                        ptr,
-                        self.initialized,
-                    ));
-                }
-            }
-        }
-
-        let mut guard = Guard { buf: out, initialized: 0 };
-        for x in guard.buf {
-            x.write(Self::decode_from(dec)?);
-            guard.initialized += 1;
-        }
-        core::mem::forget(guard);
-        Ok(())
+        crate::impl_core::try_init_each(out, || Self::decode_from(dec))
     }
 
     /// Calculate the number of head words.

--- a/crates/sol-types/src/abi/token.rs
+++ b/crates/sol-types/src/abi/token.rs
@@ -60,7 +60,7 @@ pub trait Token<'de>: Sealed + Sized {
 
     /// Decode tokens from a decoder into the given uninitialized buffer.
     ///
-    /// On success, all elements in `out` are guaranteed to be initialized.
+    /// On success, returns the initialized slice.
     /// On error, no elements are initialized (partially initialized elements are dropped).
     ///
     /// The default implementation simply loops over [`decode_from`](Self::decode_from).
@@ -71,10 +71,10 @@ pub trait Token<'de>: Sealed + Sized {
     ///
     /// `out` must point to valid, writable memory for `out.len()` elements.
     #[inline]
-    unsafe fn decode_many_from(
+    unsafe fn decode_many_from<'a>(
         dec: &mut Decoder<'de>,
-        out: &mut [MaybeUninit<Self>],
-    ) -> Result<()> {
+        out: &'a mut [MaybeUninit<Self>],
+    ) -> Result<&'a mut [Self]> {
         crate::impl_core::try_init_each(out, || Self::decode_from(dec))
     }
 
@@ -212,16 +212,20 @@ impl<'a> Token<'a> for WordToken {
     }
 
     #[inline]
-    unsafe fn decode_many_from(dec: &mut Decoder<'a>, out: &mut [MaybeUninit<Self>]) -> Result<()> {
-        let byte_len = out.len() * Word::len_bytes();
+    unsafe fn decode_many_from<'b>(
+        dec: &mut Decoder<'a>,
+        out: &'b mut [MaybeUninit<Self>],
+    ) -> Result<&'b mut [Self]> {
+        let len = out.len();
+        let byte_len = len * Word::len_bytes();
         let slice = dec.take_slice(byte_len)?;
         // SAFETY: `MaybeUninit<WordToken>` has the same layout as `WordToken` which is
         // `#[repr(transparent)]` over `Word` (`[u8; 32]`), all with alignment 1.
-        // `slice` is exactly `out.len() * 32` bytes, matching the output layout.
+        // `slice` is exactly `len * 32` bytes, matching the output layout.
         unsafe {
             core::ptr::copy_nonoverlapping(slice.as_ptr(), out.as_mut_ptr().cast::<u8>(), byte_len);
+            Ok(core::slice::from_raw_parts_mut(out.as_mut_ptr().cast::<Self>(), len))
         }
-        Ok(())
     }
 
     #[inline]

--- a/crates/sol-types/src/abi/token.rs
+++ b/crates/sol-types/src/abi/token.rs
@@ -588,10 +588,9 @@ where
         }
     }
 
-    let len = out.len();
     let mut guard = Guard { buf: out, initialized: 0 };
-    for i in 0..len {
-        guard.buf[i].write(f()?);
+    for x in guard.buf.iter_mut() {
+        x.write(f()?);
         guard.initialized += 1;
     }
     let buf = guard.buf as *mut [MaybeUninit<T>] as *mut [T];

--- a/crates/sol-types/src/abi/token.rs
+++ b/crates/sol-types/src/abi/token.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use alloc::vec::Vec;
 use alloy_primitives::{Bytes, FixedBytes, I256, U256, hex, utils::vec_try_with_capacity};
-use core::{fmt, mem::MaybeUninit};
+use core::{fmt, mem, mem::MaybeUninit, ptr};
 
 #[allow(unknown_lints, unnameable_types)]
 mod sealed {
@@ -75,7 +75,7 @@ pub trait Token<'de>: Sealed + Sized {
         dec: &mut Decoder<'de>,
         out: &'a mut [MaybeUninit<Self>],
     ) -> Result<&'a mut [Self]> {
-        crate::impl_core::try_init_each(out, || Self::decode_from(dec))
+        try_init_each(out, || Self::decode_from(dec))
     }
 
     /// Calculate the number of head words.
@@ -563,6 +563,41 @@ impl PackedSeqToken<'_> {
     pub const fn as_slice(&self) -> &[u8] {
         self.0
     }
+}
+
+/// Initializes each element of `out` by calling `f` for each slot.
+///
+/// On success, all elements in `out` are initialized and returned as `&mut [T]`.
+/// On failure or panic, already-initialized elements are dropped.
+#[inline]
+fn try_init_each<T, E, F>(out: &mut [MaybeUninit<T>], mut f: F) -> core::result::Result<&mut [T], E>
+where
+    F: FnMut() -> core::result::Result<T, E>,
+{
+    struct Guard<'a, T> {
+        buf: &'a mut [MaybeUninit<T>],
+        initialized: usize,
+    }
+    impl<T> Drop for Guard<'_, T> {
+        fn drop(&mut self) {
+            // SAFETY: the first `self.initialized` elements are guaranteed initialized.
+            unsafe {
+                let ptr = self.buf.as_mut_ptr().cast::<T>();
+                ptr::drop_in_place(ptr::slice_from_raw_parts_mut(ptr, self.initialized));
+            }
+        }
+    }
+
+    let len = out.len();
+    let mut guard = Guard { buf: out, initialized: 0 };
+    for i in 0..len {
+        guard.buf[i].write(f()?);
+        guard.initialized += 1;
+    }
+    let buf = guard.buf as *mut [MaybeUninit<T>] as *mut [T];
+    mem::forget(guard);
+    // SAFETY: all `len` elements are initialized.
+    Ok(unsafe { &mut *buf })
 }
 
 macro_rules! tuple_impls {

--- a/crates/sol-types/src/abi/token.rs
+++ b/crates/sol-types/src/abi/token.rs
@@ -66,8 +66,12 @@ pub trait Token<'de>: Sealed + Sized {
     /// The default implementation simply loops over [`decode_from`](Self::decode_from).
     /// Implementations may override this to provide a more efficient batch decode,
     /// e.g. a single `memcpy` for [`WordToken`].
+    ///
+    /// # Safety
+    ///
+    /// `out` must point to valid, writable memory for `out.len()` elements.
     #[inline]
-    fn decode_many_from<'a>(
+    unsafe fn decode_many_from<'a>(
         dec: &mut Decoder<'de>,
         out: &'a mut [MaybeUninit<Self>],
     ) -> Result<&'a mut [Self]> {
@@ -208,7 +212,7 @@ impl<'a> Token<'a> for WordToken {
     }
 
     #[inline]
-    fn decode_many_from<'b>(
+    unsafe fn decode_many_from<'b>(
         dec: &mut Decoder<'a>,
         out: &'b mut [MaybeUninit<Self>],
     ) -> Result<&'b mut [Self]> {
@@ -354,9 +358,12 @@ impl<'de, T: Token<'de>, const N: usize> TokenSeq<'de> for FixedSeqToken<T, N> {
     #[inline]
     fn decode_sequence(dec: &mut Decoder<'de>) -> Result<Self> {
         let mut arr = crate::impl_core::uninit_array::<T, N>();
-        T::decode_many_from(dec, &mut arr)?;
-        // SAFETY: `decode_many_from` initialized all elements on success.
-        Ok(Self(unsafe { crate::impl_core::array_assume_init(arr) }))
+        // SAFETY: `arr` is valid writable memory for `N` elements.
+        // `decode_many_from` initializes all elements on success.
+        unsafe {
+            T::decode_many_from(dec, &mut arr)?;
+            Ok(Self(crate::impl_core::array_assume_init(arr)))
+        }
     }
 }
 
@@ -413,9 +420,12 @@ impl<'de, T: Token<'de>> Token<'de> for DynSeqToken<T> {
         // word AFTER the array size
         let mut child = child.raw_child()?;
         let mut tokens = vec_try_with_capacity(len)?;
-        T::decode_many_from(&mut child, &mut tokens.spare_capacity_mut()[..len])?;
-        // SAFETY: `decode_many_from` initialized all `len` elements on success.
-        unsafe { tokens.set_len(len) };
+        // SAFETY: `spare_capacity_mut` returns valid writable memory.
+        // `decode_many_from` initializes all `len` elements on success.
+        unsafe {
+            T::decode_many_from(&mut child, &mut tokens.spare_capacity_mut()[..len])?;
+            tokens.set_len(len);
+        }
         Ok(Self(tokens))
     }
 

--- a/crates/sol-types/src/abi/token.rs
+++ b/crates/sol-types/src/abi/token.rs
@@ -66,12 +66,8 @@ pub trait Token<'de>: Sealed + Sized {
     /// The default implementation simply loops over [`decode_from`](Self::decode_from).
     /// Implementations may override this to provide a more efficient batch decode,
     /// e.g. a single `memcpy` for [`WordToken`].
-    ///
-    /// # Safety
-    ///
-    /// `out` must point to valid, writable memory for `out.len()` elements.
     #[inline]
-    unsafe fn decode_many_from<'a>(
+    fn decode_many_from<'a>(
         dec: &mut Decoder<'de>,
         out: &'a mut [MaybeUninit<Self>],
     ) -> Result<&'a mut [Self]> {
@@ -212,7 +208,7 @@ impl<'a> Token<'a> for WordToken {
     }
 
     #[inline]
-    unsafe fn decode_many_from<'b>(
+    fn decode_many_from<'b>(
         dec: &mut Decoder<'a>,
         out: &'b mut [MaybeUninit<Self>],
     ) -> Result<&'b mut [Self]> {
@@ -358,12 +354,9 @@ impl<'de, T: Token<'de>, const N: usize> TokenSeq<'de> for FixedSeqToken<T, N> {
     #[inline]
     fn decode_sequence(dec: &mut Decoder<'de>) -> Result<Self> {
         let mut arr = crate::impl_core::uninit_array::<T, N>();
-        // SAFETY: `arr` is valid writable memory for `N` elements.
-        // `decode_many_from` initializes all elements on success.
-        unsafe {
-            T::decode_many_from(dec, &mut arr)?;
-            Ok(Self(crate::impl_core::array_assume_init(arr)))
-        }
+        T::decode_many_from(dec, &mut arr)?;
+        // SAFETY: `decode_many_from` initialized all elements on success.
+        Ok(Self(unsafe { crate::impl_core::array_assume_init(arr) }))
     }
 }
 
@@ -420,12 +413,9 @@ impl<'de, T: Token<'de>> Token<'de> for DynSeqToken<T> {
         // word AFTER the array size
         let mut child = child.raw_child()?;
         let mut tokens = vec_try_with_capacity(len)?;
-        // SAFETY: `spare_capacity_mut` returns valid writable memory.
-        // `decode_many_from` initializes all `len` elements on success.
-        unsafe {
-            T::decode_many_from(&mut child, &mut tokens.spare_capacity_mut()[..len])?;
-            tokens.set_len(len);
-        }
+        T::decode_many_from(&mut child, &mut tokens.spare_capacity_mut()[..len])?;
+        // SAFETY: `decode_many_from` initialized all `len` elements on success.
+        unsafe { tokens.set_len(len) };
         Ok(Self(tokens))
     }
 

--- a/crates/sol-types/src/abi/token.rs
+++ b/crates/sol-types/src/abi/token.rs
@@ -93,18 +93,6 @@ pub trait Token<'de>: Sealed + Sized {
     /// Append head words to the encoder.
     fn head_append(&self, enc: &mut Encoder);
 
-    /// Append head words for a slice of tokens to the encoder.
-    ///
-    /// The default implementation simply loops over [`head_append`](Self::head_append).
-    /// Implementations may override this to provide a more efficient batch encode,
-    /// e.g. a single `memcpy` for [`WordToken`].
-    #[inline]
-    fn head_append_many(tokens: &[Self], enc: &mut Encoder) {
-        for token in tokens {
-            token.head_append(enc);
-        }
-    }
-
     /// Append tail words to the encoder.
     fn tail_append(&self, enc: &mut Encoder);
 }
@@ -256,13 +244,6 @@ impl<'a> Token<'a> for WordToken {
     }
 
     #[inline]
-    fn head_append_many(tokens: &[Self], enc: &mut Encoder) {
-        // SAFETY: `WordToken` is `#[repr(transparent)]` over `Word`.
-        let words = unsafe { &*(tokens as *const [Self] as *const [Word]) };
-        enc.append_words(words);
-    }
-
-    #[inline]
     fn tail_append(&self, _enc: &mut Encoder) {}
 }
 
@@ -345,7 +326,9 @@ impl<'de, T: Token<'de>, const N: usize> Token<'de> for FixedSeqToken<T, N> {
         if Self::DYNAMIC {
             enc.append_indirection();
         } else {
-            T::head_append_many(&self.0, enc);
+            for inner in &self.0 {
+                inner.head_append(enc);
+            }
         }
     }
 
@@ -359,21 +342,17 @@ impl<'de, T: Token<'de>, const N: usize> Token<'de> for FixedSeqToken<T, N> {
 
 impl<'de, T: Token<'de>, const N: usize> TokenSeq<'de> for FixedSeqToken<T, N> {
     fn encode_sequence(&self, enc: &mut Encoder) {
-        if T::DYNAMIC {
-            enc.push_offset(self.0.iter().map(T::head_words).sum());
+        enc.push_offset(self.0.iter().map(T::head_words).sum());
 
-            for inner in &self.0 {
-                inner.head_append(enc);
-                enc.bump_offset(inner.tail_words());
-            }
-            for inner in &self.0 {
-                inner.tail_append(enc);
-            }
-
-            enc.pop_offset();
-        } else {
-            T::head_append_many(&self.0, enc);
+        for inner in &self.0 {
+            inner.head_append(enc);
+            enc.bump_offset(inner.tail_words());
         }
+        for inner in &self.0 {
+            inner.tail_append(enc);
+        }
+
+        enc.pop_offset();
     }
 
     #[inline]
@@ -476,21 +455,17 @@ impl<'de, T: Token<'de>> Token<'de> for DynSeqToken<T> {
 
 impl<'de, T: Token<'de>> TokenSeq<'de> for DynSeqToken<T> {
     fn encode_sequence(&self, enc: &mut Encoder) {
-        if T::DYNAMIC {
-            enc.push_offset(self.0.iter().map(T::head_words).sum());
+        enc.push_offset(self.0.iter().map(T::head_words).sum());
 
-            for inner in &self.0 {
-                inner.head_append(enc);
-                enc.bump_offset(inner.tail_words());
-            }
-            for inner in &self.0 {
-                inner.tail_append(enc);
-            }
-
-            enc.pop_offset();
-        } else {
-            T::head_append_many(&self.0, enc);
+        for inner in &self.0 {
+            inner.head_append(enc);
+            enc.bump_offset(inner.tail_words());
         }
+        for inner in &self.0 {
+            inner.tail_append(enc);
+        }
+
+        enc.pop_offset();
     }
 
     #[inline]

--- a/crates/sol-types/src/abi/token.rs
+++ b/crates/sol-types/src/abi/token.rs
@@ -93,6 +93,18 @@ pub trait Token<'de>: Sealed + Sized {
     /// Append head words to the encoder.
     fn head_append(&self, enc: &mut Encoder);
 
+    /// Append head words for a slice of tokens to the encoder.
+    ///
+    /// The default implementation simply loops over [`head_append`](Self::head_append).
+    /// Implementations may override this to provide a more efficient batch encode,
+    /// e.g. a single `memcpy` for [`WordToken`].
+    #[inline]
+    fn head_append_many(tokens: &[Self], enc: &mut Encoder) {
+        for token in tokens {
+            token.head_append(enc);
+        }
+    }
+
     /// Append tail words to the encoder.
     fn tail_append(&self, enc: &mut Encoder);
 }
@@ -244,6 +256,13 @@ impl<'a> Token<'a> for WordToken {
     }
 
     #[inline]
+    fn head_append_many(tokens: &[Self], enc: &mut Encoder) {
+        // SAFETY: `WordToken` is `#[repr(transparent)]` over `Word`.
+        let words = unsafe { &*(tokens as *const [Self] as *const [Word]) };
+        enc.append_words(words);
+    }
+
+    #[inline]
     fn tail_append(&self, _enc: &mut Encoder) {}
 }
 
@@ -326,9 +345,7 @@ impl<'de, T: Token<'de>, const N: usize> Token<'de> for FixedSeqToken<T, N> {
         if Self::DYNAMIC {
             enc.append_indirection();
         } else {
-            for inner in &self.0 {
-                inner.head_append(enc);
-            }
+            T::head_append_many(&self.0, enc);
         }
     }
 
@@ -342,17 +359,21 @@ impl<'de, T: Token<'de>, const N: usize> Token<'de> for FixedSeqToken<T, N> {
 
 impl<'de, T: Token<'de>, const N: usize> TokenSeq<'de> for FixedSeqToken<T, N> {
     fn encode_sequence(&self, enc: &mut Encoder) {
-        enc.push_offset(self.0.iter().map(T::head_words).sum());
+        if T::DYNAMIC {
+            enc.push_offset(self.0.iter().map(T::head_words).sum());
 
-        for inner in &self.0 {
-            inner.head_append(enc);
-            enc.bump_offset(inner.tail_words());
-        }
-        for inner in &self.0 {
-            inner.tail_append(enc);
-        }
+            for inner in &self.0 {
+                inner.head_append(enc);
+                enc.bump_offset(inner.tail_words());
+            }
+            for inner in &self.0 {
+                inner.tail_append(enc);
+            }
 
-        enc.pop_offset();
+            enc.pop_offset();
+        } else {
+            T::head_append_many(&self.0, enc);
+        }
     }
 
     #[inline]
@@ -455,17 +476,21 @@ impl<'de, T: Token<'de>> Token<'de> for DynSeqToken<T> {
 
 impl<'de, T: Token<'de>> TokenSeq<'de> for DynSeqToken<T> {
     fn encode_sequence(&self, enc: &mut Encoder) {
-        enc.push_offset(self.0.iter().map(T::head_words).sum());
+        if T::DYNAMIC {
+            enc.push_offset(self.0.iter().map(T::head_words).sum());
 
-        for inner in &self.0 {
-            inner.head_append(enc);
-            enc.bump_offset(inner.tail_words());
-        }
-        for inner in &self.0 {
-            inner.tail_append(enc);
-        }
+            for inner in &self.0 {
+                inner.head_append(enc);
+                enc.bump_offset(inner.tail_words());
+            }
+            for inner in &self.0 {
+                inner.tail_append(enc);
+            }
 
-        enc.pop_offset();
+            enc.pop_offset();
+        } else {
+            T::head_append_many(&self.0, enc);
+        }
     }
 
     #[inline]

--- a/crates/sol-types/src/abi/token.rs
+++ b/crates/sol-types/src/abi/token.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use alloc::vec::Vec;
 use alloy_primitives::{Bytes, FixedBytes, I256, U256, hex, utils::vec_try_with_capacity};
-use core::fmt;
+use core::{fmt, mem::MaybeUninit};
 
 #[allow(unknown_lints, unnameable_types)]
 mod sealed {
@@ -58,6 +58,50 @@ pub trait Token<'de>: Sealed + Sized {
     /// Decode a token from a decoder.
     fn decode_from(dec: &mut Decoder<'de>) -> Result<Self>;
 
+    /// Decode tokens from a decoder into the given uninitialized buffer.
+    ///
+    /// On success, all elements in `out` are guaranteed to be initialized.
+    /// On error, no elements are initialized (partially initialized elements are dropped).
+    ///
+    /// The default implementation simply loops over [`decode_from`](Self::decode_from).
+    /// Implementations may override this to provide a more efficient batch decode,
+    /// e.g. a single `memcpy` for [`WordToken`].
+    ///
+    /// # Safety
+    ///
+    /// `out` must point to valid, writable memory for `out.len()` elements.
+    #[inline]
+    unsafe fn decode_many_from(
+        dec: &mut Decoder<'de>,
+        out: &mut [MaybeUninit<Self>],
+    ) -> Result<()> {
+        /// Drop guard that drops initialized elements on panic or early return.
+        struct Guard<'a, T> {
+            buf: &'a mut [MaybeUninit<T>],
+            initialized: usize,
+        }
+        impl<T> Drop for Guard<'_, T> {
+            fn drop(&mut self) {
+                // SAFETY: the first `self.initialized` elements are guaranteed initialized.
+                unsafe {
+                    let ptr = self.buf.as_mut_ptr().cast::<T>();
+                    core::ptr::drop_in_place(core::ptr::slice_from_raw_parts_mut(
+                        ptr,
+                        self.initialized,
+                    ));
+                }
+            }
+        }
+
+        let mut guard = Guard { buf: out, initialized: 0 };
+        for x in guard.buf {
+            x.write(Self::decode_from(dec)?);
+            guard.initialized += 1;
+        }
+        core::mem::forget(guard);
+        Ok(())
+    }
+
     /// Calculate the number of head words.
     fn head_words(&self) -> usize;
 
@@ -95,6 +139,7 @@ pub trait TokenSeq<'a>: Token<'a> {
 
 /// A single EVM word - T for any value type.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(transparent)]
 pub struct WordToken(pub Word);
 
 impl<T> From<&T> for WordToken
@@ -188,6 +233,19 @@ impl<'a> Token<'a> for WordToken {
     #[inline]
     fn decode_from(dec: &mut Decoder<'a>) -> Result<Self> {
         dec.take_word().copied().map(Self)
+    }
+
+    #[inline]
+    unsafe fn decode_many_from(dec: &mut Decoder<'a>, out: &mut [MaybeUninit<Self>]) -> Result<()> {
+        let byte_len = out.len() * Word::len_bytes();
+        let slice = dec.take_slice(byte_len)?;
+        // SAFETY: `MaybeUninit<WordToken>` has the same layout as `WordToken` which is
+        // `#[repr(transparent)]` over `Word` (`[u8; 32]`), all with alignment 1.
+        // `slice` is exactly `out.len() * 32` bytes, matching the output layout.
+        unsafe {
+            core::ptr::copy_nonoverlapping(slice.as_ptr(), out.as_mut_ptr().cast::<u8>(), byte_len);
+        }
+        Ok(())
     }
 
     #[inline]
@@ -319,7 +377,13 @@ impl<'de, T: Token<'de>, const N: usize> TokenSeq<'de> for FixedSeqToken<T, N> {
 
     #[inline]
     fn decode_sequence(dec: &mut Decoder<'de>) -> Result<Self> {
-        crate::impl_core::try_from_fn(|_| T::decode_from(dec)).map(Self)
+        let mut arr = crate::impl_core::uninit_array::<T, N>();
+        // SAFETY: `arr` is valid writable memory for `N` elements.
+        // `decode_many_from` initializes all elements on success.
+        unsafe {
+            T::decode_many_from(dec, &mut arr)?;
+            Ok(Self(crate::impl_core::array_assume_init(arr)))
+        }
     }
 }
 
@@ -376,8 +440,11 @@ impl<'de, T: Token<'de>> Token<'de> for DynSeqToken<T> {
         // word AFTER the array size
         let mut child = child.raw_child()?;
         let mut tokens = vec_try_with_capacity(len)?;
-        for _ in 0..len {
-            tokens.push(T::decode_from(&mut child)?);
+        // SAFETY: `spare_capacity_mut` returns valid writable memory.
+        // `decode_many_from` initializes all `len` elements on success.
+        unsafe {
+            T::decode_many_from(&mut child, &mut tokens.spare_capacity_mut()[..len])?;
+            tokens.set_len(len);
         }
         Ok(Self(tokens))
     }

--- a/crates/sol-types/src/impl_core.rs
+++ b/crates/sol-types/src/impl_core.rs
@@ -7,10 +7,10 @@ use core::{
 
 /// Initializes each element of `out` by calling `f` for each slot.
 ///
-/// On success, all elements in `out` are initialized.
+/// On success, all elements in `out` are initialized and returned as `&mut [T]`.
 /// On failure or panic, already-initialized elements are dropped.
 #[inline]
-pub(crate) fn try_init_each<T, E, F>(out: &mut [MaybeUninit<T>], mut f: F) -> Result<(), E>
+pub(crate) fn try_init_each<T, E, F>(out: &mut [MaybeUninit<T>], mut f: F) -> Result<&mut [T], E>
 where
     F: FnMut() -> Result<T, E>,
 {
@@ -28,13 +28,16 @@ where
         }
     }
 
+    let len = out.len();
     let mut guard = Guard { buf: out, initialized: 0 };
-    for i in 0..guard.buf.len() {
+    for i in 0..len {
         guard.buf[i].write(f()?);
         guard.initialized += 1;
     }
+    let buf = guard.buf as *mut [MaybeUninit<T>] as *mut [T];
     mem::forget(guard);
-    Ok(())
+    // SAFETY: all `len` elements are initialized.
+    Ok(unsafe { &mut *buf })
 }
 
 /// `MaybeUninit::uninit_array`

--- a/crates/sol-types/src/impl_core.rs
+++ b/crates/sol-types/src/impl_core.rs
@@ -2,60 +2,6 @@
 
 use core::mem::{self, MaybeUninit};
 
-/// [`core::array::try_from_fn`]
-#[inline]
-pub(crate) fn try_from_fn<F, T, E, const N: usize>(mut cb: F) -> Result<[T; N], E>
-where
-    F: FnMut(usize) -> Result<T, E>,
-{
-    if N == 0 {
-        // SAFETY: An empty array is always inhabited and has no validity invariants.
-        return unsafe { Ok(mem::zeroed()) };
-    }
-
-    struct Guard<'a, T, const N: usize> {
-        array_mut: &'a mut [MaybeUninit<T>; N],
-        initialized: usize,
-    }
-
-    impl<T, const N: usize> Drop for Guard<'_, T, N> {
-        fn drop(&mut self) {
-            debug_assert!(self.initialized <= N);
-
-            // SAFETY: this slice will contain only initialized objects.
-            unsafe {
-                core::ptr::drop_in_place(slice_assume_init_mut(
-                    self.array_mut.get_unchecked_mut(..self.initialized),
-                ));
-            }
-        }
-    }
-
-    let mut array = uninit_array::<T, N>();
-    let mut guard = Guard { array_mut: &mut array, initialized: 0 };
-
-    for _ in 0..N {
-        // SAFETY: `guard.initialized` starts at 0, is increased by one in the
-        // loop and the loop is aborted once it reaches N (which is `array.len()`).
-        unsafe {
-            guard.array_mut.get_unchecked_mut(guard.initialized).write(cb(guard.initialized)?);
-        }
-        guard.initialized += 1;
-    }
-
-    mem::forget(guard);
-    // SAFETY: all elements are initialized.
-    Ok(unsafe { array_assume_init(array) })
-}
-
-/// `MaybeUninit::slice_assume_init_mut`
-#[inline(always)]
-unsafe fn slice_assume_init_mut<T>(slice: &mut [MaybeUninit<T>]) -> &mut [T] {
-    // SAFETY: similar to safety notes for `slice_get_ref`, but we have a
-    // mutable reference which is also guaranteed to be valid for writes.
-    unsafe { &mut *(slice as *mut [MaybeUninit<T>] as *mut [T]) }
-}
-
 /// `MaybeUninit::uninit_array`
 #[inline]
 pub(crate) fn uninit_array<T, const N: usize>() -> [MaybeUninit<T>; N] {

--- a/crates/sol-types/src/impl_core.rs
+++ b/crates/sol-types/src/impl_core.rs
@@ -1,44 +1,6 @@
 //! Modified implementations of unstable libcore functions.
 
-use core::{
-    mem::{self, MaybeUninit},
-    ptr,
-};
-
-/// Initializes each element of `out` by calling `f` for each slot.
-///
-/// On success, all elements in `out` are initialized and returned as `&mut [T]`.
-/// On failure or panic, already-initialized elements are dropped.
-#[inline]
-pub(crate) fn try_init_each<T, E, F>(out: &mut [MaybeUninit<T>], mut f: F) -> Result<&mut [T], E>
-where
-    F: FnMut() -> Result<T, E>,
-{
-    struct Guard<'a, T> {
-        buf: &'a mut [MaybeUninit<T>],
-        initialized: usize,
-    }
-    impl<T> Drop for Guard<'_, T> {
-        fn drop(&mut self) {
-            // SAFETY: the first `self.initialized` elements are guaranteed initialized.
-            unsafe {
-                let ptr = self.buf.as_mut_ptr().cast::<T>();
-                ptr::drop_in_place(ptr::slice_from_raw_parts_mut(ptr, self.initialized));
-            }
-        }
-    }
-
-    let len = out.len();
-    let mut guard = Guard { buf: out, initialized: 0 };
-    for i in 0..len {
-        guard.buf[i].write(f()?);
-        guard.initialized += 1;
-    }
-    let buf = guard.buf as *mut [MaybeUninit<T>] as *mut [T];
-    mem::forget(guard);
-    // SAFETY: all `len` elements are initialized.
-    Ok(unsafe { &mut *buf })
-}
+use core::mem::{self, MaybeUninit};
 
 /// `MaybeUninit::uninit_array`
 #[inline]

--- a/crates/sol-types/src/impl_core.rs
+++ b/crates/sol-types/src/impl_core.rs
@@ -1,6 +1,41 @@
 //! Modified implementations of unstable libcore functions.
 
-use core::mem::{self, MaybeUninit};
+use core::{
+    mem::{self, MaybeUninit},
+    ptr,
+};
+
+/// Initializes each element of `out` by calling `f` for each slot.
+///
+/// On success, all elements in `out` are initialized.
+/// On failure or panic, already-initialized elements are dropped.
+#[inline]
+pub(crate) fn try_init_each<T, E, F>(out: &mut [MaybeUninit<T>], mut f: F) -> Result<(), E>
+where
+    F: FnMut() -> Result<T, E>,
+{
+    struct Guard<'a, T> {
+        buf: &'a mut [MaybeUninit<T>],
+        initialized: usize,
+    }
+    impl<T> Drop for Guard<'_, T> {
+        fn drop(&mut self) {
+            // SAFETY: the first `self.initialized` elements are guaranteed initialized.
+            unsafe {
+                let ptr = self.buf.as_mut_ptr().cast::<T>();
+                ptr::drop_in_place(ptr::slice_from_raw_parts_mut(ptr, self.initialized));
+            }
+        }
+    }
+
+    let mut guard = Guard { buf: out, initialized: 0 };
+    for i in 0..guard.buf.len() {
+        guard.buf[i].write(f()?);
+        guard.initialized += 1;
+    }
+    mem::forget(guard);
+    Ok(())
+}
 
 /// `MaybeUninit::uninit_array`
 #[inline]


### PR DESCRIPTION
Adds an `unsafe decode_many_from` method to the `Token` trait that writes decoded tokens directly into an uninitialized buffer (`&mut [MaybeUninit<Self>]`). The default implementation loops over `decode_from` with a drop guard for panic safety.

`WordToken` overrides this to perform a single `copy_nonoverlapping` instead of N individual `take_word` + copy calls, reducing the operation from O(N) `decode_from` calls (each with a bounds check and 32-byte copy) to one bounds check + one memcpy.

Both `DynSeqToken` and `FixedSeqToken` now use `decode_many_from` for their sequence decoding.

## Benchmarks

Decoding an `authorizeKey` calldata payload with offset aliasing (N shared `CallScope` entries, each containing N `bytes4` selectors):

| N | Before | After | Speedup |
|---|--------|-------|---------|
| 100 | 146µs | 132µs | 1.1x |
| 200 | 509µs | 300µs | 1.7x |
| 500 | 3.4ms | 2.3ms | 1.5x |
| 1000 | 14.5ms | 10.4ms | 1.4x |
| 2000 | 54.2ms | 39.1ms | 1.4x |
| 5000 | 332ms | 225ms | 1.5x |

End-to-end (hyperfine, all sizes combined): **1.30x faster**.