### PR TITLE
perf: add Token::head_append_many for batch encoding

### DIFF
--- a/crates/sol-types/src/abi/encoder.rs
+++ b/crates/sol-types/src/abi/encoder.rs
@@ -111,6 +111,12 @@ impl Encoder {
         self.buf.push(word);
     }
 
+    /// Append a slice of words to the encoder.
+    #[inline]
+    pub fn append_words(&mut self, words: &[Word]) {
+        self.buf.extend_from_slice(words);
+    }
+
     /// Append a pointer to the current suffix offset.
     ///
     /// # Panics

--- a/crates/sol-types/src/abi/token.rs
+++ b/crates/sol-types/src/abi/token.rs
@@ -359,21 +359,7 @@ impl<'de, T: Token<'de>, const N: usize> Token<'de> for FixedSeqToken<T, N> {
 
 impl<'de, T: Token<'de>, const N: usize> TokenSeq<'de> for FixedSeqToken<T, N> {
     fn encode_sequence(&self, enc: &mut Encoder) {
-        if T::DYNAMIC {
-            enc.push_offset(self.0.iter().map(T::head_words).sum());
-
-            for inner in &self.0 {
-                inner.head_append(enc);
-                enc.bump_offset(inner.tail_words());
-            }
-            for inner in &self.0 {
-                inner.tail_append(enc);
-            }
-
-            enc.pop_offset();
-        } else {
-            T::head_append_many(&self.0, enc);
-        }
+        encode_sequence_impl(&self.0, enc);
     }
 
     #[inline]
@@ -476,21 +462,7 @@ impl<'de, T: Token<'de>> Token<'de> for DynSeqToken<T> {
 
 impl<'de, T: Token<'de>> TokenSeq<'de> for DynSeqToken<T> {
     fn encode_sequence(&self, enc: &mut Encoder) {
-        if T::DYNAMIC {
-            enc.push_offset(self.0.iter().map(T::head_words).sum());
-
-            for inner in &self.0 {
-                inner.head_append(enc);
-                enc.bump_offset(inner.tail_words());
-            }
-            for inner in &self.0 {
-                inner.tail_append(enc);
-            }
-
-            enc.pop_offset();
-        } else {
-            T::head_append_many(&self.0, enc);
-        }
+        encode_sequence_impl(&self.0, enc);
     }
 
     #[inline]
@@ -590,6 +562,26 @@ impl PackedSeqToken<'_> {
     #[inline]
     pub const fn as_slice(&self) -> &[u8] {
         self.0
+    }
+}
+
+/// Shared implementation for [`TokenSeq::encode_sequence`] used by both
+/// [`FixedSeqToken`] and [`DynSeqToken`].
+fn encode_sequence_impl<'de, T: Token<'de>>(tokens: &[T], enc: &mut Encoder) {
+    if T::DYNAMIC {
+        enc.push_offset(tokens.iter().map(T::head_words).sum());
+
+        for inner in tokens {
+            inner.head_append(enc);
+            enc.bump_offset(inner.tail_words());
+        }
+        for inner in tokens {
+            inner.tail_append(enc);
+        }
+
+        enc.pop_offset();
+    } else {
+        T::head_append_many(tokens, enc);
     }
 }
 

--- a/crates/sol-types/src/abi/token.rs
+++ b/crates/sol-types/src/abi/token.rs
@@ -358,6 +358,7 @@ impl<'de, T: Token<'de>, const N: usize> Token<'de> for FixedSeqToken<T, N> {
 }
 
 impl<'de, T: Token<'de>, const N: usize> TokenSeq<'de> for FixedSeqToken<T, N> {
+    #[inline]
     fn encode_sequence(&self, enc: &mut Encoder) {
         encode_sequence_impl(&self.0, enc);
     }
@@ -461,6 +462,7 @@ impl<'de, T: Token<'de>> Token<'de> for DynSeqToken<T> {
 }
 
 impl<'de, T: Token<'de>> TokenSeq<'de> for DynSeqToken<T> {
+    #[inline]
     fn encode_sequence(&self, enc: &mut Encoder) {
         encode_sequence_impl(&self.0, enc);
     }

--- a/crates/sol-types/src/abi/token.rs
+++ b/crates/sol-types/src/abi/token.rs
@@ -587,40 +587,6 @@ fn encode_sequence_impl<'de, T: Token<'de>>(tokens: &[T], enc: &mut Encoder) {
     }
 }
 
-/// Initializes each element of `out` by calling `f` for each slot.
-///
-/// On success, all elements in `out` are initialized and returned as `&mut [T]`.
-/// On failure or panic, already-initialized elements are dropped.
-#[inline]
-fn try_init_each<T, E, F>(out: &mut [MaybeUninit<T>], mut f: F) -> core::result::Result<&mut [T], E>
-where
-    F: FnMut() -> core::result::Result<T, E>,
-{
-    struct Guard<'a, T> {
-        buf: &'a mut [MaybeUninit<T>],
-        initialized: usize,
-    }
-    impl<T> Drop for Guard<'_, T> {
-        fn drop(&mut self) {
-            // SAFETY: the first `self.initialized` elements are guaranteed initialized.
-            unsafe {
-                let ptr = self.buf.as_mut_ptr().cast::<T>();
-                ptr::drop_in_place(ptr::slice_from_raw_parts_mut(ptr, self.initialized));
-            }
-        }
-    }
-
-    let mut guard = Guard { buf: out, initialized: 0 };
-    for x in guard.buf.iter_mut() {
-        x.write(f()?);
-        guard.initialized += 1;
-    }
-    let buf = guard.buf as *mut [MaybeUninit<T>] as *mut [T];
-    mem::forget(guard);
-    // SAFETY: all `len` elements are initialized.
-    Ok(unsafe { &mut *buf })
-}
-
 macro_rules! tuple_impls {
     ($count:literal $($ty:ident),+) => {
         impl<'de, $($ty: Token<'de>,)+> Sealed for ($($ty,)+) {}
@@ -754,6 +720,40 @@ impl<'de> TokenSeq<'de> for () {
 }
 
 all_the_tuples!(tuple_impls);
+
+/// Initializes each element of `out` by calling `f` for each slot.
+///
+/// On success, all elements in `out` are initialized and returned as `&mut [T]`.
+/// On failure or panic, already-initialized elements are dropped.
+#[inline]
+fn try_init_each<T, E, F>(out: &mut [MaybeUninit<T>], mut f: F) -> core::result::Result<&mut [T], E>
+where
+    F: FnMut() -> core::result::Result<T, E>,
+{
+    struct Guard<'a, T> {
+        buf: &'a mut [MaybeUninit<T>],
+        initialized: usize,
+    }
+    impl<T> Drop for Guard<'_, T> {
+        fn drop(&mut self) {
+            // SAFETY: the first `self.initialized` elements are guaranteed initialized.
+            unsafe {
+                let ptr = self.buf.as_mut_ptr().cast::<T>();
+                ptr::drop_in_place(ptr::slice_from_raw_parts_mut(ptr, self.initialized));
+            }
+        }
+    }
+
+    let mut guard = Guard { buf: out, initialized: 0 };
+    for x in guard.buf.iter_mut() {
+        x.write(f()?);
+        guard.initialized += 1;
+    }
+    let buf = guard.buf as *mut [MaybeUninit<T>] as *mut [T];
+    mem::forget(guard);
+    // SAFETY: all `len` elements are initialized.
+    Ok(unsafe { &mut *buf })
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/sol-types/src/abi/token.rs
+++ b/crates/sol-types/src/abi/token.rs
@@ -518,18 +518,21 @@ impl fmt::Debug for PackedSeqToken<'_> {
 }
 
 impl<'a> From<&'a [u8]> for PackedSeqToken<'a> {
+    #[inline]
     fn from(value: &'a [u8]) -> Self {
         Self(value)
     }
 }
 
 impl<'a> From<&'a Vec<u8>> for PackedSeqToken<'a> {
+    #[inline]
     fn from(value: &'a Vec<u8>) -> Self {
         Self(value.as_slice())
     }
 }
 
 impl AsRef<[u8]> for PackedSeqToken<'_> {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         self.0
     }

--- a/crates/sol-types/src/abi/token.rs
+++ b/crates/sol-types/src/abi/token.rs
@@ -567,26 +567,6 @@ impl PackedSeqToken<'_> {
     }
 }
 
-/// Shared implementation for [`TokenSeq::encode_sequence`] used by both
-/// [`FixedSeqToken`] and [`DynSeqToken`].
-fn encode_sequence_impl<'de, T: Token<'de>>(tokens: &[T], enc: &mut Encoder) {
-    if T::DYNAMIC {
-        enc.push_offset(tokens.iter().map(T::head_words).sum());
-
-        for inner in tokens {
-            inner.head_append(enc);
-            enc.bump_offset(inner.tail_words());
-        }
-        for inner in tokens {
-            inner.tail_append(enc);
-        }
-
-        enc.pop_offset();
-    } else {
-        T::head_append_many(tokens, enc);
-    }
-}
-
 macro_rules! tuple_impls {
     ($count:literal $($ty:ident),+) => {
         impl<'de, $($ty: Token<'de>,)+> Sealed for ($($ty,)+) {}
@@ -720,6 +700,26 @@ impl<'de> TokenSeq<'de> for () {
 }
 
 all_the_tuples!(tuple_impls);
+
+/// Shared implementation for [`TokenSeq::encode_sequence`] used by both
+/// [`FixedSeqToken`] and [`DynSeqToken`].
+fn encode_sequence_impl<'de, T: Token<'de>>(tokens: &[T], enc: &mut Encoder) {
+    if T::DYNAMIC {
+        enc.push_offset(tokens.iter().map(T::head_words).sum());
+
+        for inner in tokens {
+            inner.head_append(enc);
+            enc.bump_offset(inner.tail_words());
+        }
+        for inner in tokens {
+            inner.tail_append(enc);
+        }
+
+        enc.pop_offset();
+    } else {
+        T::head_append_many(tokens, enc);
+    }
+}
 
 /// Initializes each element of `out` by calling `f` for each slot.
 ///

--- a/crates/sol-types/src/abi/token.rs
+++ b/crates/sol-types/src/abi/token.rs
@@ -73,6 +73,18 @@ pub trait Token<'de>: Sealed + Sized {
     /// Append head words to the encoder.
     fn head_append(&self, enc: &mut Encoder);
 
+    /// Append head words for a slice of tokens to the encoder.
+    ///
+    /// The default implementation simply loops over [`head_append`](Self::head_append).
+    /// Implementations may override this to provide a more efficient batch encode,
+    /// e.g. a single `memcpy` for [`WordToken`].
+    #[inline]
+    fn head_append_many(tokens: &[Self], enc: &mut Encoder) {
+        for token in tokens {
+            token.head_append(enc);
+        }
+    }
+
     /// Append tail words to the encoder.
     fn tail_append(&self, enc: &mut Encoder);
 }
@@ -206,6 +218,13 @@ impl<'a> Token<'a> for WordToken {
     }
 
     #[inline]
+    fn head_append_many(tokens: &[Self], enc: &mut Encoder) {
+        // SAFETY: `WordToken` is `#[repr(transparent)]` over `Word`.
+        let words = unsafe { &*(tokens as *const [Self] as *const [Word]) };
+        enc.append_words(words);
+    }
+
+    #[inline]
     fn tail_append(&self, _enc: &mut Encoder) {}
 }
 
@@ -288,9 +307,7 @@ impl<'de, T: Token<'de>, const N: usize> Token<'de> for FixedSeqToken<T, N> {
         if Self::DYNAMIC {
             enc.append_indirection();
         } else {
-            for inner in &self.0 {
-                inner.head_append(enc);
-            }
+            T::head_append_many(&self.0, enc);
         }
     }
 
@@ -304,17 +321,21 @@ impl<'de, T: Token<'de>, const N: usize> Token<'de> for FixedSeqToken<T, N> {
 
 impl<'de, T: Token<'de>, const N: usize> TokenSeq<'de> for FixedSeqToken<T, N> {
     fn encode_sequence(&self, enc: &mut Encoder) {
-        enc.push_offset(self.0.iter().map(T::head_words).sum());
+        if T::DYNAMIC {
+            enc.push_offset(self.0.iter().map(T::head_words).sum());
 
-        for inner in &self.0 {
-            inner.head_append(enc);
-            enc.bump_offset(inner.tail_words());
-        }
-        for inner in &self.0 {
-            inner.tail_append(enc);
-        }
+            for inner in &self.0 {
+                inner.head_append(enc);
+                enc.bump_offset(inner.tail_words());
+            }
+            for inner in &self.0 {
+                inner.tail_append(enc);
+            }
 
-        enc.pop_offset();
+            enc.pop_offset();
+        } else {
+            T::head_append_many(&self.0, enc);
+        }
     }
 
     #[inline]
@@ -408,17 +429,21 @@ impl<'de, T: Token<'de>> Token<'de> for DynSeqToken<T> {
 
 impl<'de, T: Token<'de>> TokenSeq<'de> for DynSeqToken<T> {
     fn encode_sequence(&self, enc: &mut Encoder) {
-        enc.push_offset(self.0.iter().map(T::head_words).sum());
+        if T::DYNAMIC {
+            enc.push_offset(self.0.iter().map(T::head_words).sum());
 
-        for inner in &self.0 {
-            inner.head_append(enc);
-            enc.bump_offset(inner.tail_words());
-        }
-        for inner in &self.0 {
-            inner.tail_append(enc);
-        }
+            for inner in &self.0 {
+                inner.head_append(enc);
+                enc.bump_offset(inner.tail_words());
+            }
+            for inner in &self.0 {
+                inner.tail_append(enc);
+            }
 
-        enc.pop_offset();
+            enc.pop_offset();
+        } else {
+            T::head_append_many(&self.0, enc);
+        }
     }
 
     #[inline]


### PR DESCRIPTION
Adds a `head_append_many` method to the `Token` trait for bulk encoding a slice of tokens. The default implementation loops over `head_append`.

`WordToken` overrides this to reinterpret `&[WordToken]` as `&[Word]` (both `#[repr(transparent)]`) and calls `Encoder::append_words` (`extend_from_slice`), replacing N individual `Vec::push` calls with a single memcpy.

`FixedSeqToken` and `DynSeqToken` use `head_append_many` in their `head_append` and `encode_sequence` for non-dynamic inner tokens, also skipping the unnecessary offset tracking in that case.