### PR TITLE
fix(sol-macro): apply extra_derives to functions/calls enum container

### DIFF
--- a/crates/sol-macro-expander/src/expand/contract.rs
+++ b/crates/sol-macro-expander/src/expand/contract.rs
@@ -181,9 +181,6 @@ pub(super) fn expand(cx: &mut ExpCtxt<'_>, contract: &ItemContract) -> Result<To
         enum_expander.expand(ToExpand::Events(&events), attrs)
     });
 
-    // Do not propagate contract-level derives to the functions enum.
-    cx.attrs = prev_cx_attrs;
-
     let functions_enum = (!functions.is_empty()).then(|| {
         let mut attrs = enum_attrs;
         let doc_str = format!("Container for all the [`{name}`](self) function calls.");
@@ -192,6 +189,9 @@ pub(super) fn expand(cx: &mut ExpCtxt<'_>, contract: &ItemContract) -> Result<To
         let enum_expander = CallLikeExpander { cx, contract_name: name.clone(), extra_methods };
         enum_expander.expand(ToExpand::Functions(&functions), attrs)
     });
+
+    // Restore context attrs after all enum containers have been generated.
+    cx.attrs = prev_cx_attrs;
 
     let mod_descr_doc = (docs && docs_str(&mod_attrs).trim().is_empty())
         .then(|| mk_doc("Module containing a contract's types and functions."));

--- a/crates/sol-types/tests/derives.rs
+++ b/crates/sol-types/tests/derives.rs
@@ -69,9 +69,21 @@ fn test_extra_derives() {
     let errors_enum1 = ExtraDerivesContractErrors::InsufficientBalance(error1);
     let errors_enum2 = ExtraDerivesContractErrors::InsufficientBalance(error2);
 
-    // Test PartialEq and Debug
+    let call1 = transferCall { to: Address::ZERO, amount: U256::from(10) };
+    let call2 = transferCall { to: Address::ZERO, amount: U256::from(10) };
+    let calls_enum1 = ExtraDerivesContractCalls::transfer(call1);
+    let calls_enum2 = ExtraDerivesContractCalls::transfer(call2);
+
+    // Test PartialEq and Debug on all enum containers including calls (#3857)
     assert_eq!(errors_enum1, errors_enum2);
     assert_eq!(events_enum1, events_enum2);
+    assert_eq!(calls_enum1, calls_enum2);
+
+    // Test Hash and Eq derives on calls enum
+    let mut calls_set = HashSet::new();
+    calls_set.insert(calls_enum1);
+    calls_set.insert(calls_enum2);
+    assert_eq!(calls_set.len(), 1);
 
     // Test Hash and Eq derives
     let mut events_set = HashSet::new();


### PR DESCRIPTION
## Summary

Fixes #3857.

`#[sol(extra_derives(Debug, PartialEq, Eq, Hash))]` on a contract was correctly applied to the events and errors enum containers but silently ignored on the **calls/functions enum container**.

## Root Cause

In `contract.rs`, `cx.attrs` is restored to `prev_cx_attrs` (pre-contract state) to isolate contract-level attrs from outer context. This restore was placed **before** the functions enum was generated:

```rust
// Before fix
cx.attrs = prev_cx_attrs;  // resets extra_derives

let functions_enum = ...{
    enum_expander.expand(...)  // cx.type_derives() sees no extra_derives ✗
};
```

The errors and events enums are generated before the reset and correctly receive `extra_derives`. The calls enum is generated after the reset and does not.

## Fix

Move `cx.attrs = prev_cx_attrs` to after the functions enum is created, so all three enum containers see the same contract-level sol attrs:

```rust
// After fix
let functions_enum = ...{
    enum_expander.expand(...)  // cx.type_derives() sees extra_derives ✓
};

cx.attrs = prev_cx_attrs;  // restore after all enums generated
```

## Tests

Added test coverage for `extra_derives` on the calls enum container in `crates/sol-types/tests/derives.rs`, which was previously untested.

## Note on `all_derives`

`all_derives` on the calls enum has a separate, deeper issue: `can_derive_builtin_traits` returns `false` for generated call types (e.g. `transferCall`) because they are not registered in `all_items`. That is a follow-on issue and not addressed here.