### PR TITLE
fix(workspace): disable proptest default features to avoid rusty-fork (#1034)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ hex = { package = "const-hex", version = "1.14", default-features = false, featu
 itoa = "1"
 postgres-types = "0.2.6"
 pretty_assertions = "1.4"
-proptest = "1"
+proptest = { version = "1", default-features = false, features = ["std", "bit-set"] }
 proptest-derive = "0.8"
 rand = { version = "0.9", default-features = false, features = ["os_rng"] }
 rayon = { version = "1.2", default-features = false }


### PR DESCRIPTION
## Summary

The workspace activates `proptest` with its default features, which include `fork` and `timeout`. Those features pull in `rusty-fork` and transitively `wait-timeout`, which fail to compile on non-unix, non-windows targets such as ZkVM guest environments (Risc0, SP1).

Per maintainer guidance in #1034, this PR disables proptest's default features at the workspace level and re-enables only the ones we actually use:

```diff
-proptest = "1"
+proptest = { version = "1", default-features = false, features = ["std", "bit-set"] }
```

## Why these features

- `std` — needed by the in-process `TestRunner` and required transitively by `alloy-primitives`'s `std` feature (which already toggles `proptest?/std`). Keeping it on by default is harmless because the only consumer of `dep:proptest` is the `arbitrary` feature, and `arbitrary = ["std", ...]` already requires std.
- `bit-set` — kept to match the upstream non-fork defaults so `Index` / `Subsequence` strategies remain available to downstream crates that pick up alloy's workspace dep.

`fork` and `timeout` are intentionally dropped: alloy's property tests all run on the default in-process `TestRunner` (no `Config::with_fork(true)`), so they were never exercised.

## Verification

`cargo tree -p proptest` after the change:

```
proptest v1.11.0
├── bit-set
├── bit-vec
├── bitflags
├── num-traits
├── rand
├── rand_chacha
├── rand_xorshift
├── regex-syntax
└── unarray
```

No more `rusty-fork`, `wait-timeout`, or `tempfile` — exactly the dependencies #1034 wanted gone.

Test suites that exercise proptest still pass:

- `cargo test -p alloy-primitives --features arbitrary --lib` — 117 passed (1 pre-existing failure on `signed::int::tests::from_dec_str` that also reproduces on `main` and is unrelated to this change; it looks like a ruint error-shape drift)
- `cargo test -p alloy-sol-types --lib` — 111 passed
- `cargo test -p alloy-dyn-abi --features arbitrary --lib` — 155 passed (including `arbitrary::tests::proptest_*`)

Fixes #1034