### PR TITLE
fix(EIP-712): PropDef::parse supports extra whitespaces

### DIFF
--- a/crates/dyn-abi/src/eip712/parser.rs
+++ b/crates/dyn-abi/src/eip712/parser.rs
@@ -56,6 +56,7 @@ impl<'a> PropDef<'a> {
     /// assert_eq!(prop.name, "msg");
     /// ```
     pub fn parse(input: &'a str) -> Result<Self, Error> {
+        let input = input.trim();
         let (ty, name) =
             input.rsplit_once(' ').ok_or_else(|| Error::invalid_property_def(input))?;
         Ok(PropDef { ty: TypeSpecifier::parse_eip712(ty.trim())?, name: name.trim() })
@@ -221,6 +222,55 @@ mod tests {
             EncodeType::try_from("EIP712Domain()"),
             Ok(EncodeType { types: vec![empty_domain_type] })
         );
+    }
+
+    #[test]
+    fn prop_def_tolerates_surrounding_whitespace() {
+        let expected = PropDef::parse("uint256 x").unwrap();
+
+        let inputs = ["uint256 x ", " uint256 x", "  uint256 x  ", "\tuint256 x\t"];
+        for input in inputs {
+            let prop = PropDef::parse(input)
+                .unwrap_or_else(|e| panic!("PropDef::parse({input:?}) failed: {e}"));
+            assert_eq!(prop.ty.span(), expected.ty.span());
+            assert_eq!(prop.name, expected.name);
+        }
+    }
+
+    #[test]
+    fn component_type_tolerates_whitespace_inside_parens() {
+        let inputs = ["Foo(uint256 x)", "Foo(uint256 x )", "Foo( uint256 x)", "Foo( uint256 x )"];
+        for input in inputs {
+            let component = ComponentType::parse(input)
+                .unwrap_or_else(|e| panic!("ComponentType::parse({input:?}) failed: {e}"));
+            assert_eq!(component.type_name, "Foo");
+            assert_eq!(component.props.len(), 1);
+            assert_eq!(component.props[0].ty.span(), "uint256");
+            assert_eq!(component.props[0].name, "x");
+        }
+    }
+
+    #[test]
+    fn component_type_tolerates_whitespace_around_commas() {
+        let inputs = [
+            "Foo(uint256 x,uint8 y)",
+            "Foo(uint256 x, uint8 y)",
+            "Foo(uint256 x ,uint8 y)",
+            "Foo(uint256 x , uint8 y)",
+            "Foo( uint256 x , uint8 y )",
+        ];
+        for input in inputs {
+            let component = ComponentType::parse(input)
+                .unwrap_or_else(|e| panic!("ComponentType::parse({input:?}) failed: {e}"));
+            assert_eq!(component.type_name, "Foo");
+            assert_eq!(component.props.len(), 2);
+
+            assert_eq!(component.props[0].ty.span(), "uint256");
+            assert_eq!(component.props[0].name, "x");
+
+            assert_eq!(component.props[1].ty.span(), "uint8");
+            assert_eq!(component.props[1].name, "y");
+        }
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Current implementation fails to parse EIP-712 types containing certain whitespace: specifically, whitespace immediately before a `)` or `,`. Leading whitespace after `(` and after `,` are already tolerated. 

The root cause is `PropDef::parse` relying on `rsplit_once(' ')` without trimming its input first. As a result, in the cases mentioned above, the split leaves an internal space inside the type half that `TypeSpecifier::parse_eip712` then rejects.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Trim `PropDef::parse` `input` parameter before splitting and parsing it.


## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
