### PR TITLE
fix: disable proptest default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ hex = { package = "const-hex", version = "1.14", default-features = false, featu
 itoa = "1"
 postgres-types = "0.2.6"
 pretty_assertions = "1.4"
-proptest = "1"
+proptest = { version = "1", default-features = false }
 proptest-derive = "0.8"
 rand = { version = "0.9", default-features = false, features = ["os_rng"] }
 rayon = { version = "1.2", default-features = false }


### PR DESCRIPTION
## Summary
- disable default features for the workspace proptest dependency
- keep crates opting into proptest std via the existing proptest?/std feature edge
- avoids pulling proptest's fork/timeout defaults, which bring in rusty-fork and wait-timeout

Closes #1034

## Testing
- cargo check -p alloy-primitives --features arbitrary
- cargo tree -p alloy-primitives --features arbitrary -i rusty-fork (confirms rusty-fork is absent; command exits because the package is not in the graph)

Note: cargo fmt --check currently reports unrelated formatting drift in crates/sol-macro/src/lib.rs.