### PR TITLE
fix: reject extra event topics during decoding

### DIFF
--- a/crates/sol-types/src/types/event/mod.rs
+++ b/crates/sol-types/src/types/event/mod.rs
@@ -156,6 +156,8 @@ pub trait SolEvent: Sized {
     }
 
     /// Decode the topics of this event from the given data.
+    ///
+    /// This requires the input to contain exactly [`TopicList::COUNT`] topics.
     #[inline]
     fn decode_topics<I, D>(topics: I) -> Result<<Self::TopicList as SolType>::RustType>
     where

--- a/crates/sol-types/src/types/event/topic_list.rs
+++ b/crates/sol-types/src/types/event/topic_list.rs
@@ -48,9 +48,13 @@ macro_rules! impl_topic_list_tuples {
                 D: Into<WordToken>
             {
                 let mut iter = topics.into_iter();
-                Ok(($(
+                let topics = ($(
                     <$t>::detokenize(iter.next().ok_or_else(length_mismatch)?.into()),
-                )*))
+                )*);
+                if iter.next().is_some() {
+                    return Err(length_mismatch());
+                }
+                Ok(topics)
             }
         }
     )+};
@@ -61,11 +65,14 @@ impl TopicList for () {
     const COUNT: usize = 0;
 
     #[inline]
-    fn detokenize<I, D>(_: I) -> Result<Self::RustType>
+    fn detokenize<I, D>(topics: I) -> Result<Self::RustType>
     where
         I: IntoIterator<Item = D>,
         D: Into<WordToken>,
     {
+        if topics.into_iter().next().is_some() {
+            return Err(length_mismatch());
+        }
         Ok(())
     }
 }

--- a/crates/sol-types/tests/macros/sol/mod.rs
+++ b/crates/sol-types/tests/macros/sol/mod.rs
@@ -1237,6 +1237,7 @@ fn event_check_signature() {
     sol! {
         #[derive(Debug)]
         event MyEvent();
+        #[derive(Debug)]
         event MyEventAnonymous() anonymous;
     }
 
@@ -1247,10 +1248,26 @@ fn event_check_signature() {
     assert_eq!(e.to_string(), "topic list length mismatch");
     let e = MyEvent::decode_raw_log([B256::ZERO], &[]).unwrap_err();
     assert!(e.to_string().contains("invalid signature hash"), "{e:?}");
+    let e = MyEvent::decode_raw_log([MyEvent::SIGNATURE_HASH, B256::ZERO], &[]).unwrap_err();
+    assert_eq!(e.to_string(), "topic list length mismatch");
     let MyEvent {} = MyEvent::decode_raw_log([MyEvent::SIGNATURE_HASH], &[]).unwrap();
 
     assert!(MyEventAnonymous::ANONYMOUS);
     let MyEventAnonymous {} = MyEventAnonymous::decode_raw_log(no_topics, &[]).unwrap();
+}
+
+// https://github.com/alloy-rs/core/issues/1038
+#[test]
+fn empty_anonymous_event_rejects_extra_topics() {
+    sol! {
+        #[derive(Debug)]
+        event MyEvent();
+        #[derive(Debug)]
+        event MyEventAnonymous() anonymous;
+    }
+
+    let e = MyEventAnonymous::decode_raw_log([MyEvent::SIGNATURE_HASH], &[]).unwrap_err();
+    assert_eq!(e.to_string(), "topic list length mismatch");
 }
 
 // https://github.com/alloy-rs/core/issues/811


### PR DESCRIPTION
## Summary
- require event topic decoding to consume exactly the expected number of topics
- reject extra topics for zero-topic events, including empty anonymous events
- add regression coverage for #1038

## Tests
- cargo test -p alloy-sol-types

Fixes #1038