### PR TITLE
feat: keccak cache stats

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -138,6 +138,7 @@ std = [
     "rand?/thread_rng",
     "rustc-hash/std",
     "serde?/std",
+    "fixed-cache?/std",
 ]
 nightly = [
     "foldhash?/nightly",
@@ -156,6 +157,7 @@ sha3-keccak = []
 tiny-keccak = ["dep:tiny-keccak"]
 keccak-cache = ["std", "dep:rapidhash", "dep:fixed-cache"]
 keccak-cache-global = ["keccak-cache"]
+keccak-cache-stats = ["keccak-cache", "fixed-cache/stats"]
 
 map = ["dep:hashbrown"]
 map-hashbrown = ["map"]

--- a/crates/primitives/src/utils/keccak_cache.rs
+++ b/crates/primitives/src/utils/keccak_cache.rs
@@ -1,22 +1,27 @@
 //! A minimalistic one-way set associative cache for Keccak256 values.
 //!
 //! This cache has a fixed size to allow fast access and minimize per-call overhead.
+//!
+//! With the `keccak-cache-stats` feature, hit/miss/insert/collision counts are
+//! tracked in the global [`KECCAK_CACHE_STATS`] static.
 
 use super::{hint::unlikely, keccak256_impl as keccak256};
 use crate::{B256, KECCAK256_EMPTY};
-use std::mem::MaybeUninit;
+use std::{mem::MaybeUninit, sync::OnceLock};
+
+#[cfg(feature = "keccak-cache-stats")]
+pub use stats::{KECCAK_CACHE_STATS, KeccakCacheStats};
 
 /// Maximum input length that can be cached.
 pub(super) const MAX_INPUT_LEN: usize =
     128 - size_of::<B256>() - size_of::<u8>() - size_of::<usize>();
 
 const COUNT: usize = 1 << 17; // ~131k entries * 128 bytes = 16MiB
-static CACHE: fixed_cache::Cache<Key, B256, BuildHasher, CacheConfig> =
-    fixed_cache::static_cache!(Key, B256, COUNT, BuildHasher::new());
+static CACHE: OnceLock<fixed_cache::Cache<Key, B256, BuildHasher, CacheConfig>> = OnceLock::new();
 
 struct CacheConfig {}
 impl fixed_cache::CacheConfig for CacheConfig {
-    const STATS: bool = false;
+    const STATS: bool = cfg!(feature = "keccak-cache-stats");
     const EPOCHS: bool = false;
 }
 
@@ -25,7 +30,13 @@ pub(super) fn compute(input: &[u8], imp: impl FnOnce(&[u8]) -> B256) -> B256 {
         return if input.is_empty() { KECCAK256_EMPTY } else { keccak256(input) };
     }
 
-    CACHE.get_or_insert_with_ref(input, imp, |input| {
+    let cache = CACHE.get_or_init(|| {
+        let cache = fixed_cache::Cache::new(COUNT, BuildHasher::new());
+        #[cfg(feature = "keccak-cache-stats")]
+        let cache = cache.with_stats(Some(fixed_cache::Stats::new(&stats::KECCAK_CACHE_STATS)));
+        cache
+    });
+    cache.get_or_insert_with_ref(input, imp, |input| {
         let mut data = [MaybeUninit::uninit(); MAX_INPUT_LEN];
         unsafe {
             std::ptr::copy_nonoverlapping(input.as_ptr(), data.as_mut_ptr().cast(), input.len())
@@ -110,6 +121,105 @@ impl Key {
     const fn get(&self) -> &[u8] {
         unsafe { std::slice::from_raw_parts(self.data.as_ptr().cast(), self.len as usize) }
     }
+}
+
+#[cfg(feature = "keccak-cache-stats")]
+mod stats {
+    use super::Key;
+    use crate::B256;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Counters for the global keccak cache.
+    ///
+    /// Accessed via the [`KECCAK_CACHE_STATS`] static. All counters use relaxed atomics.
+    ///
+    /// Available only with the `keccak-cache-stats` feature.
+    #[derive(Debug, Default)]
+    pub struct KeccakCacheStats {
+        hits: AtomicU64,
+        misses: AtomicU64,
+        inserts: AtomicU64,
+        collisions: AtomicU64,
+    }
+
+    impl KeccakCacheStats {
+        const fn new() -> Self {
+            Self {
+                hits: AtomicU64::new(0),
+                misses: AtomicU64::new(0),
+                inserts: AtomicU64::new(0),
+                collisions: AtomicU64::new(0),
+            }
+        }
+
+        /// Returns the number of cache hits.
+        #[inline]
+        pub fn hits(&self) -> u64 {
+            self.hits.load(Ordering::Relaxed)
+        }
+
+        /// Returns the number of cache misses.
+        #[inline]
+        pub fn misses(&self) -> u64 {
+            self.misses.load(Ordering::Relaxed)
+        }
+
+        /// Returns the number of inserted entries.
+        ///
+        /// Includes inserts that evicted a different key on hash collision (see
+        /// [`collisions`](Self::collisions)).
+        #[inline]
+        pub fn inserts(&self) -> u64 {
+            self.inserts.load(Ordering::Relaxed)
+        }
+
+        /// Returns the number of collisions (a different key was evicted on insert).
+        #[inline]
+        pub fn collisions(&self) -> u64 {
+            self.collisions.load(Ordering::Relaxed)
+        }
+
+        /// Resets all counters to zero.
+        pub fn reset(&self) {
+            self.hits.store(0, Ordering::Relaxed);
+            self.misses.store(0, Ordering::Relaxed);
+            self.inserts.store(0, Ordering::Relaxed);
+            self.collisions.store(0, Ordering::Relaxed);
+        }
+    }
+
+    impl fixed_cache::StatsHandler<Key, B256> for &'static KeccakCacheStats {
+        #[inline]
+        fn on_hit(&self, _key: &Key, _value: &B256) {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+        }
+
+        #[inline]
+        fn on_miss(&self, _key: fixed_cache::AnyRef<'_>) {
+            self.misses.fetch_add(1, Ordering::Relaxed);
+        }
+
+        #[inline]
+        fn on_insert(&self, key: &Key, _value: &B256, evicted: Option<(&Key, &B256)>) {
+            match evicted {
+                // Race: another thread inserted the same key concurrently. Same input
+                // always produces the same hash, so this is a no-op redundant write.
+                Some((old, _)) if old == key => {}
+                Some(_) => {
+                    self.inserts.fetch_add(1, Ordering::Relaxed);
+                    self.collisions.fetch_add(1, Ordering::Relaxed);
+                }
+                None => {
+                    self.inserts.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }
+    }
+
+    /// Global counters for the keccak cache.
+    ///
+    /// Available only with the `keccak-cache-stats` feature.
+    pub static KECCAK_CACHE_STATS: KeccakCacheStats = KeccakCacheStats::new();
 }
 
 #[cfg(test)]

--- a/crates/primitives/src/utils/mod.rs
+++ b/crates/primitives/src/utils/mod.rs
@@ -18,6 +18,8 @@ mod hint;
 
 #[cfg(feature = "keccak-cache")]
 mod keccak_cache;
+#[cfg(feature = "keccak-cache-stats")]
+pub use keccak_cache::{KECCAK_CACHE_STATS, KeccakCacheStats};
 
 /// The prefix used for hashing messages according to EIP-191.
 pub const EIP191_PREFIX: &str = "\x19Ethereum Signed Message:\n";


### PR DESCRIPTION
Exposes `KeccakCacheStats` struct that contains atomic with hits, misses, inserts and collisions stats