### PR TITLE
fix(sol-macro): derive builtin traits on overloaded event/error enums

### DIFF
--- a/crates/sol-macro-expander/src/expand/contract.rs
+++ b/crates/sol-macro-expander/src/expand/contract.rs
@@ -576,6 +576,12 @@ struct ExpandData {
     min_data_len: usize,
     trait_: Ident,
     selectors: Vec<ExprArray<u8>>,
+    /// Whether the builtin `#[sol(all_derives)]` traits can be derived on the
+    /// generated enum. Computed from the underlying items' parameter types,
+    /// because the variant type names may be synthetic (overloaded items get
+    /// `_N` suffixes, call variants use `*Call` structs) and thus not
+    /// resolvable as items.
+    can_derive_builtin: bool,
 }
 
 impl ExpandData {
@@ -642,6 +648,9 @@ impl ToExpand<'_> {
                         .unwrap(),
                     trait_: format_ident!("SolCall"),
                     selectors: functions.iter().map(|f| cx.function_selector(f)).collect(),
+                    can_derive_builtin: functions
+                        .iter()
+                        .all(|f| f.parameters.types().all(|ty| cx.can_derive_builtin_traits(ty))),
                 }
             }
 
@@ -656,6 +665,9 @@ impl ToExpand<'_> {
                     .unwrap(),
                 trait_: format_ident!("SolError"),
                 selectors: errors.iter().map(|e| cx.error_selector(e)).collect(),
+                can_derive_builtin: errors.iter().all(|&error| {
+                    error.parameters.types().all(|ty| cx.can_derive_builtin_traits(ty))
+                }),
             },
 
             Self::Events(events) => {
@@ -673,6 +685,9 @@ impl ToExpand<'_> {
                         .unwrap(),
                     trait_: format_ident!("SolEvent"),
                     selectors: events.iter().map(|e| cx.event_selector(e)).collect(),
+                    can_derive_builtin: events.iter().all(|&event| {
+                        event.parameters.iter().all(|p| cx.can_derive_builtin_traits(&p.ty))
+                    }),
                 }
             }
         }
@@ -915,7 +930,7 @@ impl CallLikeExpander<'_> {
         assert!(selectors.iter().all(|s| s.array.len() == selector_len));
         let selector_type = quote!([u8; #selector_len]);
 
-        self.cx.type_derives(&mut attrs, types.iter().cloned().map(ast::Type::custom), false);
+        self.cx.enum_derives(&mut attrs, data.can_derive_builtin);
         let trait_ = &data.trait_;
 
         let mut tokens = quote! {

--- a/crates/sol-macro-expander/src/expand/mod.rs
+++ b/crates/sol-macro-expander/src/expand/mod.rs
@@ -726,6 +726,26 @@ impl<'ast> ExpCtxt<'ast> {
         attrs.push(parse_quote! { #[derive(#(#derives), *)] });
     }
 
+    /// Like [`type_derives`](Self::type_derives), but for the generated `*Calls`
+    /// / `*Errors` / `*Events` enums.
+    ///
+    /// The enum variant types may be synthetic names that don't resolve as
+    /// items (overloaded items get `_N` suffixes; call variants use `*Call`
+    /// structs), so whether the builtin traits can be derived is precomputed
+    /// from the underlying items' parameter types. Enums never derive
+    /// `Default`.
+    fn enum_derives(&self, attrs: &mut Vec<Attribute>, can_derive_builtin: bool) {
+        if let Some(extra) = &self.attrs.extra_derives {
+            if !extra.is_empty() {
+                attrs.push(parse_quote! { #[derive(#(#extra),*)] });
+            }
+        }
+
+        if self.attrs.all_derives == Some(true) && can_derive_builtin {
+            attrs.push(parse_quote! { #[derive(Debug, PartialEq, Eq, Hash)] });
+        }
+    }
+
     /// Returns an error if any of the types in the parameters are unresolved.
     ///
     /// Provides a better error message than an `unwrap` or `expect` when we

--- a/crates/sol-types/tests/derives.rs
+++ b/crates/sol-types/tests/derives.rs
@@ -86,3 +86,35 @@ fn test_extra_derives() {
     // Should not increase size since they're equal
     assert_eq!(errors_set.len(), 1);
 }
+
+// Overloaded events (same name, different params) get suffixed variant names
+// (e.g. `Swap_0`, `Swap_1`). The generated `*Events` enum must still receive
+// the `#[sol(all_derives)]` traits. See alloy-rs/alloy#3856.
+#[test]
+#[allow(non_snake_case)]
+fn test_all_derives_overloaded_events() {
+    sol! {
+        #[sol(all_derives)]
+        contract OverloadedEvents {
+            event Swap(address indexed sender, uint256 amount0);
+            event Swap(address indexed sender, address indexed to, int256 amount0, int256 amount1);
+        }
+    }
+
+    use OverloadedEvents::*;
+
+    let a =
+        OverloadedEventsEvents::Swap_0(Swap_0 { sender: Address::ZERO, amount0: U256::from(1) });
+    let b =
+        OverloadedEventsEvents::Swap_0(Swap_0 { sender: Address::ZERO, amount0: U256::from(1) });
+
+    // Debug + PartialEq
+    assert_eq!(a, b);
+    let _ = format!("{a:?}");
+
+    // Hash + Eq
+    let mut set = HashSet::new();
+    set.insert(a);
+    set.insert(b);
+    assert_eq!(set.len(), 1);
+}


### PR DESCRIPTION
Fixes alloy-rs/core#1133

The generated `*Events` / `*Errors` enum decided whether the `#[sol(all_derives)]`
builtin traits (`Debug`, `PartialEq`, `Eq`, `Hash`) could be derived by resolving
each variant's *type name* against the item table. Overloaded items get synthetic
`_N`-suffixed names (`Swap_0`, `Swap_1`, …) which don't resolve as items, so the
check hit the conservative `false` arm and silently dropped the derives — e.g. the
Uniswap V3 Pool (two `Swap` events) produced a `PoolEvents` enum that didn't impl
the std traits.

Compute derivability from the underlying items' parameter types (available when
building `ExpandData`) rather than from the synthetic variant type names. The
functions enum is unaffected (contract-level `all_derives` is intentionally not
propagated there).

Added a regression test with overloaded events under `#[sol(all_derives)]`.
