### PR TITLE
perf: use global secp256k1 context for signature recovery

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -132,6 +132,7 @@ std = [
     "indexmap?/std",
     "k256?/std",
     "secp256k1?/std",
+    "secp256k1?/global-context",
     "keccak-asm?/std",
     "proptest?/std",
     "rand?/std",

--- a/crates/primitives/src/signature/sig.rs
+++ b/crates/primitives/src/signature/sig.rs
@@ -407,8 +407,15 @@ impl Signature {
         let this = self.normalized_s();
         let sig = this.to_secp256k1()?;
         let msg = secp256k1::Message::from_digest(prehash.0);
-        let secp = secp256k1::Secp256k1::verification_only();
-        secp.recover_ecdsa(msg, &sig).map_err(Into::into)
+        #[cfg(feature = "std")]
+        {
+            secp256k1::SECP256K1.recover_ecdsa(msg, &sig).map_err(Into::into)
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            let secp = secp256k1::Secp256k1::verification_only();
+            secp.recover_ecdsa(msg, &sig).map_err(Into::into)
+        }
     }
 
     /// Returns the `r` component of this signature.


### PR DESCRIPTION
Switch std builds of `Signature::recover_from_prehash_secp256k1` to use the secp256k1 global context instead of constructing a fresh verification-only context for every recovery. no-std builds keep the existing per-call fallback because the global context is gated behind std upstream.

`global-context` is enabled through `alloy-primitives/std`, not unconditionally on the workspace dependency.

Validation:
- `cargo test -p alloy-primitives --features 'std secp256k1' signature`
- `cargo check -p alloy-primitives --features secp256k1 --no-default-features`

Prompted by: @DaniPopes