### PR TITLE
fix: switch to proc-macro-error3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ schemars = { version = "1", default-features = false }
 rkyv = "0.8"
 
 # macros
-proc-macro2-diagnostics = "0.10"
+proc-macro-error2 = ">=2.0.0, <=2.0.1" # We directly use the `entry_point` private API.
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ schemars = { version = "1", default-features = false }
 rkyv = "0.8"
 
 # macros
-proc-macro-error2 = ">=2.0.0, <=2.0.1" # We directly use the `entry_point` private API.
+proc-macro-error3 = ">=3.0.0, <=3.0.1" # We directly use the `entry_point` private API.
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ schemars = { version = "1", default-features = false }
 rkyv = "0.8"
 
 # macros
-proc-macro-error2 = ">=2.0.0, <=2.0.1" # We directly use the `entry_point` private API.
+proc-macro2-diagnostics = "0.10"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "2.0"

--- a/crates/sol-macro-expander/Cargo.toml
+++ b/crates/sol-macro-expander/Cargo.toml
@@ -35,7 +35,7 @@ syn = { workspace = true, features = ["extra-traits"] }
 heck = "0.5"
 hex.workspace = true
 indexmap = "2"
-proc-macro-error2.workspace = true
+proc-macro-error3.workspace = true
 sha3.workspace = true
 
 # json

--- a/crates/sol-macro-expander/Cargo.toml
+++ b/crates/sol-macro-expander/Cargo.toml
@@ -35,7 +35,7 @@ syn = { workspace = true, features = ["extra-traits"] }
 heck = "0.5"
 hex.workspace = true
 indexmap = "2"
-proc-macro2-diagnostics.workspace = true
+proc-macro-error2.workspace = true
 sha3.workspace = true
 
 # json

--- a/crates/sol-macro-expander/Cargo.toml
+++ b/crates/sol-macro-expander/Cargo.toml
@@ -35,7 +35,7 @@ syn = { workspace = true, features = ["extra-traits"] }
 heck = "0.5"
 hex.workspace = true
 indexmap = "2"
-proc-macro-error2.workspace = true
+proc-macro2-diagnostics.workspace = true
 sha3.workspace = true
 
 # json

--- a/crates/sol-macro-expander/src/expand/mod.rs
+++ b/crates/sol-macro-expander/src/expand/mod.rs
@@ -7,7 +7,6 @@ use ast::{
     Spanned, Type, VariableDeclaration, Visit, VisitMut, visit_mut,
 };
 use indexmap::IndexMap;
-use proc_macro_error2::{abort, emit_error};
 use proc_macro2::{Delimiter, Group, Ident, Punct, Spacing, Span, TokenStream, TokenTree};
 use quote::{TokenStreamExt, format_ident, quote};
 use std::{
@@ -21,6 +20,71 @@ use syn::{Attribute, Error, Result, ext::IdentExt, parse_quote};
 
 #[macro_use]
 mod macros;
+
+macro_rules! abort {
+    ($span:expr, $fmt:literal $(, $arg:expr)*; note = $note_span:expr => $note_msg:expr $(;)?) => {{
+        let diag = proc_macro2_diagnostics::Diagnostic::spanned(
+            $span,
+            proc_macro2_diagnostics::Level::Error,
+            format!($fmt $(, $arg)*),
+        )
+        .spanned_child($note_span, proc_macro2_diagnostics::Level::Note, $note_msg);
+        panic!("{}", syn::Error::from(diag));
+    }};
+    ($span:expr, $fmt:literal $(, $arg:expr)*; $($rest:tt)*) => {{
+        let diag = proc_macro2_diagnostics::Diagnostic::spanned(
+            $span,
+            proc_macro2_diagnostics::Level::Error,
+            format!($fmt $(, $arg)*),
+        );
+        panic!("{}", syn::Error::from(diag));
+    }};
+    ($span:expr, $fmt:literal $(, $arg:expr)* $(,)?) => {{
+        let diag = proc_macro2_diagnostics::Diagnostic::spanned(
+            $span,
+            proc_macro2_diagnostics::Level::Error,
+            format!($fmt $(, $arg)*),
+        );
+        panic!("{}", syn::Error::from(diag));
+    }};
+}
+
+macro_rules! emit_error {
+    ($span:expr, $fmt:literal $(, $arg:expr)*; note = $note_span:expr => $note_msg:expr $(;)?) => {{
+        crate::utils::emit_diagnostic(proc_macro2_diagnostics::Diagnostic::spanned(
+            $span,
+            proc_macro2_diagnostics::Level::Error,
+            format!($fmt $(, $arg)*),
+        )
+        .spanned_child($note_span, proc_macro2_diagnostics::Level::Note, $note_msg));
+    }};
+    ($span:expr, $fmt:literal $(, $arg:expr)*; help =? $help_msg:expr $(;)?) => {{
+        let diag = proc_macro2_diagnostics::Diagnostic::spanned(
+            $span,
+            proc_macro2_diagnostics::Level::Error,
+            format!($fmt $(, $arg)*),
+        );
+        crate::utils::emit_diagnostic(if let Some(help) = $help_msg {
+            diag.child(proc_macro2_diagnostics::Level::Help, help)
+        } else {
+            diag
+        });
+    }};
+    ($span:expr, $fmt:literal $(, $arg:expr)*; $($rest:tt)*) => {{
+        crate::utils::emit_diagnostic(proc_macro2_diagnostics::Diagnostic::spanned(
+            $span,
+            proc_macro2_diagnostics::Level::Error,
+            format!($fmt $(, $arg)*),
+        ));
+    }};
+    ($span:expr, $fmt:literal $(, $arg:expr)* $(,)?) => {{
+        crate::utils::emit_diagnostic(proc_macro2_diagnostics::Diagnostic::spanned(
+            $span,
+            proc_macro2_diagnostics::Level::Error,
+            format!($fmt $(, $arg)*),
+        ));
+    }};
+}
 
 mod contract;
 mod r#enum;

--- a/crates/sol-macro-expander/src/expand/mod.rs
+++ b/crates/sol-macro-expander/src/expand/mod.rs
@@ -7,7 +7,7 @@ use ast::{
     Spanned, Type, VariableDeclaration, Visit, VisitMut, visit_mut,
 };
 use indexmap::IndexMap;
-use proc_macro_error2::{abort, emit_error};
+use proc_macro_error3::{abort, emit_error};
 use proc_macro2::{Delimiter, Group, Ident, Punct, Spacing, Span, TokenStream, TokenTree};
 use quote::{TokenStreamExt, format_ident, quote};
 use std::{

--- a/crates/sol-macro-expander/src/expand/mod.rs
+++ b/crates/sol-macro-expander/src/expand/mod.rs
@@ -7,6 +7,7 @@ use ast::{
     Spanned, Type, VariableDeclaration, Visit, VisitMut, visit_mut,
 };
 use indexmap::IndexMap;
+use proc_macro_error2::{abort, emit_error};
 use proc_macro2::{Delimiter, Group, Ident, Punct, Spacing, Span, TokenStream, TokenTree};
 use quote::{TokenStreamExt, format_ident, quote};
 use std::{
@@ -20,71 +21,6 @@ use syn::{Attribute, Error, Result, ext::IdentExt, parse_quote};
 
 #[macro_use]
 mod macros;
-
-macro_rules! abort {
-    ($span:expr, $fmt:literal $(, $arg:expr)*; note = $note_span:expr => $note_msg:expr $(;)?) => {{
-        let diag = proc_macro2_diagnostics::Diagnostic::spanned(
-            $span,
-            proc_macro2_diagnostics::Level::Error,
-            format!($fmt $(, $arg)*),
-        )
-        .spanned_child($note_span, proc_macro2_diagnostics::Level::Note, $note_msg);
-        panic!("{}", syn::Error::from(diag));
-    }};
-    ($span:expr, $fmt:literal $(, $arg:expr)*; $($rest:tt)*) => {{
-        let diag = proc_macro2_diagnostics::Diagnostic::spanned(
-            $span,
-            proc_macro2_diagnostics::Level::Error,
-            format!($fmt $(, $arg)*),
-        );
-        panic!("{}", syn::Error::from(diag));
-    }};
-    ($span:expr, $fmt:literal $(, $arg:expr)* $(,)?) => {{
-        let diag = proc_macro2_diagnostics::Diagnostic::spanned(
-            $span,
-            proc_macro2_diagnostics::Level::Error,
-            format!($fmt $(, $arg)*),
-        );
-        panic!("{}", syn::Error::from(diag));
-    }};
-}
-
-macro_rules! emit_error {
-    ($span:expr, $fmt:literal $(, $arg:expr)*; note = $note_span:expr => $note_msg:expr $(;)?) => {{
-        crate::utils::emit_diagnostic(proc_macro2_diagnostics::Diagnostic::spanned(
-            $span,
-            proc_macro2_diagnostics::Level::Error,
-            format!($fmt $(, $arg)*),
-        )
-        .spanned_child($note_span, proc_macro2_diagnostics::Level::Note, $note_msg));
-    }};
-    ($span:expr, $fmt:literal $(, $arg:expr)*; help =? $help_msg:expr $(;)?) => {{
-        let diag = proc_macro2_diagnostics::Diagnostic::spanned(
-            $span,
-            proc_macro2_diagnostics::Level::Error,
-            format!($fmt $(, $arg)*),
-        );
-        crate::utils::emit_diagnostic(if let Some(help) = $help_msg {
-            diag.child(proc_macro2_diagnostics::Level::Help, help)
-        } else {
-            diag
-        });
-    }};
-    ($span:expr, $fmt:literal $(, $arg:expr)*; $($rest:tt)*) => {{
-        crate::utils::emit_diagnostic(proc_macro2_diagnostics::Diagnostic::spanned(
-            $span,
-            proc_macro2_diagnostics::Level::Error,
-            format!($fmt $(, $arg)*),
-        ));
-    }};
-    ($span:expr, $fmt:literal $(, $arg:expr)* $(,)?) => {{
-        crate::utils::emit_diagnostic(proc_macro2_diagnostics::Diagnostic::spanned(
-            $span,
-            proc_macro2_diagnostics::Level::Error,
-            format!($fmt $(, $arg)*),
-        ));
-    }};
-}
 
 mod contract;
 mod r#enum;

--- a/crates/sol-macro-expander/src/expand/struct.rs
+++ b/crates/sol-macro-expander/src/expand/struct.rs
@@ -207,7 +207,7 @@ fn expand_encode_type_fns(
             Some(Item::Enum(_)) => *ty = Type::Uint(ty.span(), NonZeroU16::new(8)),
             Some(Item::Udt(udt)) => *ty = udt.ty.clone(),
             Some(item) => {
-                proc_macro_error2::abort!(item.span(), "Invalid type in struct field: {:?}", item)
+                proc_macro_error3::abort!(item.span(), "Invalid type in struct field: {:?}", item)
             }
         }
     });

--- a/crates/sol-macro-expander/src/expand/struct.rs
+++ b/crates/sol-macro-expander/src/expand/struct.rs
@@ -207,7 +207,7 @@ fn expand_encode_type_fns(
             Some(Item::Enum(_)) => *ty = Type::Uint(ty.span(), NonZeroU16::new(8)),
             Some(Item::Udt(udt)) => *ty = udt.ty.clone(),
             Some(item) => {
-                abort!(item.span(), "Invalid type in struct field: {:?}", item)
+                proc_macro_error2::abort!(item.span(), "Invalid type in struct field: {:?}", item)
             }
         }
     });

--- a/crates/sol-macro-expander/src/expand/struct.rs
+++ b/crates/sol-macro-expander/src/expand/struct.rs
@@ -207,7 +207,7 @@ fn expand_encode_type_fns(
             Some(Item::Enum(_)) => *ty = Type::Uint(ty.span(), NonZeroU16::new(8)),
             Some(Item::Udt(udt)) => *ty = udt.ty.clone(),
             Some(item) => {
-                proc_macro_error2::abort!(item.span(), "Invalid type in struct field: {:?}", item)
+                abort!(item.span(), "Invalid type in struct field: {:?}", item)
             }
         }
     });

--- a/crates/sol-macro-expander/src/expand/ty.rs
+++ b/crates/sol-macro-expander/src/expand/ty.rs
@@ -2,7 +2,6 @@
 
 use super::ExpCtxt;
 use ast::{Item, Parameters, Spanned, Type, TypeArray};
-use proc_macro_error2::{abort, emit_error};
 use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::{ToTokens, quote_spanned};
 use std::{fmt, num::NonZeroU16};

--- a/crates/sol-macro-expander/src/expand/ty.rs
+++ b/crates/sol-macro-expander/src/expand/ty.rs
@@ -2,7 +2,7 @@
 
 use super::ExpCtxt;
 use ast::{Item, Parameters, Spanned, Type, TypeArray};
-use proc_macro_error2::{abort, emit_error};
+use proc_macro_error3::{abort, emit_error};
 use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::{ToTokens, quote_spanned};
 use std::{fmt, num::NonZeroU16};

--- a/crates/sol-macro-expander/src/expand/ty.rs
+++ b/crates/sol-macro-expander/src/expand/ty.rs
@@ -2,6 +2,7 @@
 
 use super::ExpCtxt;
 use ast::{Item, Parameters, Spanned, Type, TypeArray};
+use proc_macro_error2::{abort, emit_error};
 use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::{ToTokens, quote_spanned};
 use std::{fmt, num::NonZeroU16};

--- a/crates/sol-macro-expander/src/utils.rs
+++ b/crates/sol-macro-expander/src/utils.rs
@@ -2,6 +2,8 @@ use ast::Spanned;
 use proc_macro2::{Span, TokenStream};
 use quote::ToTokens;
 use sha3::{Digest, Keccak256};
+use std::cell::RefCell;
+use std::panic::{self, AssertUnwindSafe};
 
 /// Simple interface to the [`keccak256`] hash function.
 ///
@@ -26,6 +28,30 @@ pub(crate) fn combine_errors(v: impl IntoIterator<Item = syn::Error>) -> syn::Re
         Some(e) => Err(e),
         None => Ok(()),
     }
+}
+
+thread_local! {
+    static DIAGNOSTICS: RefCell<Vec<proc_macro2_diagnostics::Diagnostic>> =
+        const { RefCell::new(Vec::new()) };
+}
+
+pub(crate) fn emit_diagnostic(diag: proc_macro2_diagnostics::Diagnostic) {
+    DIAGNOSTICS.with(|diagnostics| diagnostics.borrow_mut().push(diag));
+}
+
+fn take_diagnostics() -> Vec<proc_macro2_diagnostics::Diagnostic> {
+    DIAGNOSTICS.with(|diagnostics| diagnostics.take())
+}
+
+fn diagnostics_to_error(
+    diagnostics: Vec<proc_macro2_diagnostics::Diagnostic>,
+) -> Option<syn::Error> {
+    let mut diagnostics = diagnostics.into_iter();
+    let mut error = syn::Error::from(diagnostics.next()?);
+    for diagnostic in diagnostics {
+        error.combine(syn::Error::from(diagnostic));
+    }
+    Some(error)
 }
 
 #[derive(Clone, Debug)]
@@ -81,27 +107,32 @@ impl<T: ToTokens> ToTokens for ExprArray<T> {
     }
 }
 
-/// Applies [`proc_macro_error2`] programmatically.
+/// Applies macro expansion compatibility handling programmatically.
 pub(crate) fn pme_compat(f: impl FnOnce() -> TokenStream) -> TokenStream {
     pme_compat_result(|| Ok(f())).unwrap()
 }
 
-/// Applies [`proc_macro_error2`] programmatically.
+/// Applies macro expansion compatibility handling programmatically.
 pub(crate) fn pme_compat_result(
     f: impl FnOnce() -> syn::Result<TokenStream>,
 ) -> syn::Result<TokenStream> {
-    let mut r = None;
-    let e = proc_macro_error2::entry_point(
-        std::panic::AssertUnwindSafe(|| {
-            r = Some(f());
-            Default::default()
-        }),
-        false,
-    );
-    if let Some(r) = r {
-        if e.is_empty() || r.is_err() {
-            return r;
+    take_diagnostics();
+    let mut result = match panic::catch_unwind(AssertUnwindSafe(f)) {
+        Ok(result) => result,
+        Err(payload) => {
+            let message = payload
+                .downcast_ref::<String>()
+                .map(String::as_str)
+                .or_else(|| payload.downcast_ref::<&str>().copied())
+                .unwrap_or("procedural macro expansion aborted");
+            Err(syn::Error::new(Span::call_site(), message))
+        }
+    };
+    if let Some(diagnostics) = diagnostics_to_error(take_diagnostics()) {
+        match &mut result {
+            Ok(_) => result = Err(diagnostics),
+            Err(error) => error.combine(diagnostics),
         }
     }
-    Ok(e.into())
+    result
 }

--- a/crates/sol-macro-expander/src/utils.rs
+++ b/crates/sol-macro-expander/src/utils.rs
@@ -81,17 +81,17 @@ impl<T: ToTokens> ToTokens for ExprArray<T> {
     }
 }
 
-/// Applies [`proc_macro_error2`] programmatically.
+/// Applies [`proc_macro_error3`] programmatically.
 pub(crate) fn pme_compat(f: impl FnOnce() -> TokenStream) -> TokenStream {
     pme_compat_result(|| Ok(f())).unwrap()
 }
 
-/// Applies [`proc_macro_error2`] programmatically.
+/// Applies [`proc_macro_error3`] programmatically.
 pub(crate) fn pme_compat_result(
     f: impl FnOnce() -> syn::Result<TokenStream>,
 ) -> syn::Result<TokenStream> {
     let mut r = None;
-    let e = proc_macro_error2::entry_point(
+    let e = proc_macro_error3::entry_point(
         std::panic::AssertUnwindSafe(|| {
             r = Some(f());
             Default::default()

--- a/crates/sol-macro-expander/src/utils.rs
+++ b/crates/sol-macro-expander/src/utils.rs
@@ -2,8 +2,6 @@ use ast::Spanned;
 use proc_macro2::{Span, TokenStream};
 use quote::ToTokens;
 use sha3::{Digest, Keccak256};
-use std::cell::RefCell;
-use std::panic::{self, AssertUnwindSafe};
 
 /// Simple interface to the [`keccak256`] hash function.
 ///
@@ -28,30 +26,6 @@ pub(crate) fn combine_errors(v: impl IntoIterator<Item = syn::Error>) -> syn::Re
         Some(e) => Err(e),
         None => Ok(()),
     }
-}
-
-thread_local! {
-    static DIAGNOSTICS: RefCell<Vec<proc_macro2_diagnostics::Diagnostic>> =
-        const { RefCell::new(Vec::new()) };
-}
-
-pub(crate) fn emit_diagnostic(diag: proc_macro2_diagnostics::Diagnostic) {
-    DIAGNOSTICS.with(|diagnostics| diagnostics.borrow_mut().push(diag));
-}
-
-fn take_diagnostics() -> Vec<proc_macro2_diagnostics::Diagnostic> {
-    DIAGNOSTICS.with(|diagnostics| diagnostics.take())
-}
-
-fn diagnostics_to_error(
-    diagnostics: Vec<proc_macro2_diagnostics::Diagnostic>,
-) -> Option<syn::Error> {
-    let mut diagnostics = diagnostics.into_iter();
-    let mut error = syn::Error::from(diagnostics.next()?);
-    for diagnostic in diagnostics {
-        error.combine(syn::Error::from(diagnostic));
-    }
-    Some(error)
 }
 
 #[derive(Clone, Debug)]
@@ -107,32 +81,27 @@ impl<T: ToTokens> ToTokens for ExprArray<T> {
     }
 }
 
-/// Applies macro expansion compatibility handling programmatically.
+/// Applies [`proc_macro_error2`] programmatically.
 pub(crate) fn pme_compat(f: impl FnOnce() -> TokenStream) -> TokenStream {
     pme_compat_result(|| Ok(f())).unwrap()
 }
 
-/// Applies macro expansion compatibility handling programmatically.
+/// Applies [`proc_macro_error2`] programmatically.
 pub(crate) fn pme_compat_result(
     f: impl FnOnce() -> syn::Result<TokenStream>,
 ) -> syn::Result<TokenStream> {
-    take_diagnostics();
-    let mut result = match panic::catch_unwind(AssertUnwindSafe(f)) {
-        Ok(result) => result,
-        Err(payload) => {
-            let message = payload
-                .downcast_ref::<String>()
-                .map(String::as_str)
-                .or_else(|| payload.downcast_ref::<&str>().copied())
-                .unwrap_or("procedural macro expansion aborted");
-            Err(syn::Error::new(Span::call_site(), message))
-        }
-    };
-    if let Some(diagnostics) = diagnostics_to_error(take_diagnostics()) {
-        match &mut result {
-            Ok(_) => result = Err(diagnostics),
-            Err(error) => error.combine(diagnostics),
+    let mut r = None;
+    let e = proc_macro_error2::entry_point(
+        std::panic::AssertUnwindSafe(|| {
+            r = Some(f());
+            Default::default()
+        }),
+        false,
+    );
+    if let Some(r) = r {
+        if e.is_empty() || r.is_err() {
+            return r;
         }
     }
-    result
+    Ok(e.into())
 }

--- a/crates/sol-macro/Cargo.toml
+++ b/crates/sol-macro/Cargo.toml
@@ -31,6 +31,7 @@ workspace = true
 alloy-sol-macro-input.workspace = true
 alloy-sol-macro-expander.workspace = true
 
+proc-macro-error2.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn = { workspace = true, features = ["extra-traits"] }

--- a/crates/sol-macro/Cargo.toml
+++ b/crates/sol-macro/Cargo.toml
@@ -31,7 +31,7 @@ workspace = true
 alloy-sol-macro-input.workspace = true
 alloy-sol-macro-expander.workspace = true
 
-proc-macro-error2.workspace = true
+proc-macro-error3.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn = { workspace = true, features = ["extra-traits"] }

--- a/crates/sol-macro/Cargo.toml
+++ b/crates/sol-macro/Cargo.toml
@@ -31,7 +31,6 @@ workspace = true
 alloy-sol-macro-input.workspace = true
 alloy-sol-macro-expander.workspace = true
 
-proc-macro-error2.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn = { workspace = true, features = ["extra-traits"] }

--- a/crates/sol-macro/src/lib.rs
+++ b/crates/sol-macro/src/lib.rs
@@ -14,6 +14,9 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[macro_use]
+extern crate proc_macro_error2;
+
 use alloy_sol_macro_expander::expand;
 use alloy_sol_macro_input::{SolAttrs, SolInput, SolInputExpander, SolInputKind};
 use proc_macro::TokenStream;
@@ -164,7 +167,7 @@ use syn::parse_macro_input;
 /// ```ignore
 #[doc = include_str!("../doctests/structs.rs")]
 /// ```
-///
+/// 
 /// ### UDVT and type aliases
 ///
 /// User defined value types (UDVT) generate a tuple struct with the type as
@@ -173,7 +176,7 @@ use syn::parse_macro_input;
 /// ```ignore
 #[doc = include_str!("../doctests/types.rs")]
 /// ```
-///
+/// 
 /// ### State variables
 ///
 /// Public and external state variables will generate a getter function just like in Solidity.
@@ -206,7 +209,7 @@ use syn::parse_macro_input;
 ///     pub unlocked: bools,
 /// }
 /// ```
-///
+/// 
 /// Whereas, if the solidity function returns a single value, the singular return value will yielded by the call.
 /// ```ignore
 /// sol! {
@@ -218,7 +221,7 @@ use syn::parse_macro_input;
 ///
 /// let balance: U256 = erc20.balanceOf(owner).call().await?;
 /// ```
-///
+/// 
 /// In the case of overloaded functions, an underscore and the index of the
 /// function will be appended to `<name>` (like `foo_0`, `foo_1`...) for
 /// disambiguation, but the signature will remain the same.
@@ -229,7 +232,7 @@ use syn::parse_macro_input;
 /// ```ignore
 #[doc = include_str!("../doctests/function_like.rs")]
 /// ```
-///
+/// 
 /// ### Events
 ///
 /// Events generate a struct that implements `SolEvent`.
@@ -241,7 +244,7 @@ use syn::parse_macro_input;
 /// ```ignore
 #[doc = include_str!("../doctests/events.rs")]
 /// ```
-///
+/// 
 /// ### Contracts/interfaces
 ///
 /// Contracts generate a module with the same name, which contains all the items.
@@ -254,7 +257,7 @@ use syn::parse_macro_input;
 /// ```ignore
 #[doc = include_str!("../doctests/contracts.rs")]
 /// ```
-///
+/// 
 /// ## JSON ABI
 ///
 /// Contracts can also be generated from ABI JSON strings and files, similar to
@@ -279,9 +282,10 @@ use syn::parse_macro_input;
 /// ```ignore
 #[doc = include_str!("../doctests/json.rs")]
 /// ```
-///
+/// 
 /// [`alloy-contract`]: https://github.com/alloy-rs/alloy
 #[proc_macro]
+#[proc_macro_error]
 pub fn sol(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as alloy_sol_macro_input::SolInput);
 

--- a/crates/sol-macro/src/lib.rs
+++ b/crates/sol-macro/src/lib.rs
@@ -14,9 +14,6 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-#[macro_use]
-extern crate proc_macro_error2;
-
 use alloy_sol_macro_expander::expand;
 use alloy_sol_macro_input::{SolAttrs, SolInput, SolInputExpander, SolInputKind};
 use proc_macro::TokenStream;
@@ -167,7 +164,7 @@ use syn::parse_macro_input;
 /// ```ignore
 #[doc = include_str!("../doctests/structs.rs")]
 /// ```
-/// 
+///
 /// ### UDVT and type aliases
 ///
 /// User defined value types (UDVT) generate a tuple struct with the type as
@@ -176,7 +173,7 @@ use syn::parse_macro_input;
 /// ```ignore
 #[doc = include_str!("../doctests/types.rs")]
 /// ```
-/// 
+///
 /// ### State variables
 ///
 /// Public and external state variables will generate a getter function just like in Solidity.
@@ -209,7 +206,7 @@ use syn::parse_macro_input;
 ///     pub unlocked: bools,
 /// }
 /// ```
-/// 
+///
 /// Whereas, if the solidity function returns a single value, the singular return value will yielded by the call.
 /// ```ignore
 /// sol! {
@@ -221,7 +218,7 @@ use syn::parse_macro_input;
 ///
 /// let balance: U256 = erc20.balanceOf(owner).call().await?;
 /// ```
-/// 
+///
 /// In the case of overloaded functions, an underscore and the index of the
 /// function will be appended to `<name>` (like `foo_0`, `foo_1`...) for
 /// disambiguation, but the signature will remain the same.
@@ -232,7 +229,7 @@ use syn::parse_macro_input;
 /// ```ignore
 #[doc = include_str!("../doctests/function_like.rs")]
 /// ```
-/// 
+///
 /// ### Events
 ///
 /// Events generate a struct that implements `SolEvent`.
@@ -244,7 +241,7 @@ use syn::parse_macro_input;
 /// ```ignore
 #[doc = include_str!("../doctests/events.rs")]
 /// ```
-/// 
+///
 /// ### Contracts/interfaces
 ///
 /// Contracts generate a module with the same name, which contains all the items.
@@ -257,7 +254,7 @@ use syn::parse_macro_input;
 /// ```ignore
 #[doc = include_str!("../doctests/contracts.rs")]
 /// ```
-/// 
+///
 /// ## JSON ABI
 ///
 /// Contracts can also be generated from ABI JSON strings and files, similar to
@@ -282,10 +279,9 @@ use syn::parse_macro_input;
 /// ```ignore
 #[doc = include_str!("../doctests/json.rs")]
 /// ```
-/// 
+///
 /// [`alloy-contract`]: https://github.com/alloy-rs/alloy
 #[proc_macro]
-#[proc_macro_error]
 pub fn sol(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as alloy_sol_macro_input::SolInput);
 

--- a/crates/sol-macro/src/lib.rs
+++ b/crates/sol-macro/src/lib.rs
@@ -15,7 +15,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[macro_use]
-extern crate proc_macro_error2;
+extern crate proc_macro_error3;
 
 use alloy_sol_macro_expander::expand;
 use alloy_sol_macro_input::{SolAttrs, SolInput, SolInputExpander, SolInputKind};


### PR DESCRIPTION
Replaces proc-macro-error2 with proc-macro-error3 while preserving the existing proc-macro-error API usage.

The dependency is pinned to `>=3.0.0, <=3.0.1` to avoid accepting later unreviewed releases.

Prompted by: @DaniPopes

Fixes https://github.com/alloy-rs/core/issues/1120