### PR TITLE
fix(sol-macro-expander): propagate extra_derives to the functions enum

### DIFF
--- a/crates/sol-macro-expander/src/expand/contract.rs
+++ b/crates/sol-macro-expander/src/expand/contract.rs
@@ -191,9 +191,6 @@ pub(super) fn expand(cx: &mut ExpCtxt<'_>, contract: &ItemContract) -> Result<To
         }
     });
 
-    // Do not propagate contract-level derives to the functions enum.
-    cx.attrs = prev_cx_attrs;
-
     let functions_enum = (!functions.is_empty()).then(|| {
         let mut attrs = enum_attrs;
         let doc_str = format!("Container for all the [`{name}`](self) function calls.");
@@ -202,6 +199,12 @@ pub(super) fn expand(cx: &mut ExpCtxt<'_>, contract: &ItemContract) -> Result<To
         let enum_expander = CallLikeExpander { cx, contract_name: name.clone(), extra_methods };
         enum_expander.expand(ToExpand::Functions(&functions), attrs)
     });
+
+    // Restore the context attributes now that the errors, events and functions enums have all
+    // been expanded with the contract-level `extra_derives`/`all_derives`. Previously the
+    // functions (calls) enum was expanded after this reset, so it only derived `Clone` while the
+    // errors and events enums (and the call structs themselves) got the user's extra derives.
+    cx.attrs = prev_cx_attrs;
 
     let mod_descr_doc = (docs && docs_str(&mod_attrs).trim().is_empty())
         .then(|| mk_doc("Module containing a contract's types and functions."));

--- a/crates/sol-types/tests/derives.rs
+++ b/crates/sol-types/tests/derives.rs
@@ -69,9 +69,15 @@ fn test_extra_derives() {
     let errors_enum1 = ExtraDerivesContractErrors::InsufficientBalance(error1);
     let errors_enum2 = ExtraDerivesContractErrors::InsufficientBalance(error2);
 
+    let call1 = transferCall { to: Address::ZERO, amount: U256::from(1) };
+    let call2 = transferCall { to: Address::ZERO, amount: U256::from(1) };
+    let calls_enum1 = ExtraDerivesContractCalls::transfer(call1);
+    let calls_enum2 = ExtraDerivesContractCalls::transfer(call2);
+
     // Test PartialEq and Debug
     assert_eq!(errors_enum1, errors_enum2);
     assert_eq!(events_enum1, events_enum2);
+    assert_eq!(calls_enum1, calls_enum2);
 
     // Test Hash and Eq derives
     let mut events_set = HashSet::new();
@@ -85,4 +91,10 @@ fn test_extra_derives() {
     errors_set.insert(errors_enum2);
     // Should not increase size since they're equal
     assert_eq!(errors_set.len(), 1);
+
+    let mut calls_set = HashSet::new();
+    calls_set.insert(calls_enum1);
+    calls_set.insert(calls_enum2);
+    // Should not increase size since they're equal
+    assert_eq!(calls_set.len(), 1);
 }


### PR DESCRIPTION
Closes #3857.

## Problem

For a contract generated with `#[sol(extra_derives(...))]`, the function-calls enum (`<Name>Calls`) only derived `Clone`. The errors enum, events enum, and the individual call structs all received the user's extra derives, but the calls enum did not — so e.g. `Debug`/`PartialEq` could not be used on it.

The cause: in `contract::expand`, the expansion context attributes are reset (`cx.attrs = prev_cx_attrs`) *before* the functions enum is expanded, but *after* the errors and events enums. Since `type_derives` reads the extra derives from `cx.attrs`, they never reached the functions enum.

This was already noted in #1011:
> **@DaniPopes:** Why not for the functions enum?

## Fix

Move the context-attribute reset to *after* the functions enum is expanded, so all three enums (errors, events, functions) are expanded with the contract-level derives in scope. Single-line change plus a clarifying comment.

## Tests

Extended `tests/derives.rs::test_extra_derives` to also build the `*Calls` enum and exercise `Debug`/`PartialEq`/`Eq`/`Hash` on it (via `assert_eq!` and `HashSet`). This fails to compile on `main` (the calls enum lacks those derives) and passes with the fix.

## Note

This covers `extra_derives`, which is unconditional. The `all_derives` builtin-trait set for the calls enum is still subject to the existing per-type capability check (`can_derive_builtin_traits`), which currently does not resolve the synthetic call-struct types — that is a separate, pre-existing limitation and out of scope here.

Verified: `cargo test -p alloy-sol-types --test derives`, `cargo fmt --check`, `cargo clippy -p alloy-sol-macro-expander` all pass.