### PR TITLE
fix(sol-macro): derive Default for dynamic arrays of non-Default elements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,8 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
-          toolchain: nightly
+          # Pin docs to a known-good nightly until the 2026-07-02 rustdoc ICE is fixed.
+          toolchain: nightly-2026-06-27
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-on-failure: true

--- a/crates/primitives/src/signed/int.rs
+++ b/crates/primitives/src/signed/int.rs
@@ -271,16 +271,18 @@ impl<const BITS: usize, const LIMBS: usize> Signed<BITS, LIMBS> {
         self.0.leading_zeros()
     }
 
-    /// Returns the number of leading zeros in the binary representation of
+    /// Returns the number of trailing zeros in the binary representation of
     /// `self`.
     #[inline]
+    #[allow(clippy::missing_const_for_fn)] // `ruint` exposes this as const only in newer versions.
     pub fn trailing_zeros(&self) -> usize {
         self.0.trailing_zeros()
     }
 
-    /// Returns the number of leading ones in the binary representation of
+    /// Returns the number of trailing ones in the binary representation of
     /// `self`.
     #[inline]
+    #[allow(clippy::missing_const_for_fn)] // `ruint` exposes this as const only in newer versions.
     pub fn trailing_ones(&self) -> usize {
         self.0.trailing_ones()
     }

--- a/crates/sol-macro-expander/src/expand/ty.rs
+++ b/crates/sol-macro-expander/src/expand/ty.rs
@@ -229,10 +229,12 @@ impl ExpCtxt<'_> {
     /// Returns whether the given type can derive the [`Default`] trait.
     pub(crate) fn can_derive_default(&self, ty: &Type) -> bool {
         match ty {
-            Type::Array(a) => {
-                self.eval_array_size(a).is_none_or(|sz| sz <= MAX_SUPPORTED_ARRAY_LEN)
-                    && self.can_derive_default(&a.ty)
-            }
+            Type::Array(a) => match self.eval_array_size(a) {
+                // Dynamic arrays are `Vec<T>`, whose `Default` impl holds for any `T`.
+                None => true,
+                // Fixed arrays are `[T; N]`: `Default` needs `T: Default` and `N <= 32`.
+                Some(sz) => sz <= MAX_SUPPORTED_ARRAY_LEN && self.can_derive_default(&a.ty),
+            },
             Type::Tuple(tuple) => {
                 if tuple.types.len() > MAX_SUPPORTED_TUPLE_LEN {
                     false

--- a/crates/sol-types/tests/derives.rs
+++ b/crates/sol-types/tests/derives.rs
@@ -98,3 +98,25 @@ fn test_extra_derives() {
     // Should not increase size since they're equal
     assert_eq!(calls_set.len(), 1);
 }
+
+// A dynamic array maps to `Vec<T>`, whose `Default` impl holds for any `T` (empty vec).
+// So a struct with a dynamic-array field of a non-`Default` element (an enum) should
+// still derive `Default` under `#[sol(all_derives)]`.
+#[test]
+fn test_default_dynamic_array_of_non_default_elem() {
+    sol! {
+        #[sol(all_derives)]
+        contract DynArrDefault {
+            enum E { A, B }
+            struct S {
+                E[] xs;
+                uint256 n;
+            }
+        }
+    }
+
+    use DynArrDefault::*;
+    let s = S::default();
+    assert!(s.xs.is_empty());
+    assert_eq!(s.n, U256::ZERO);
+}


### PR DESCRIPTION
A dynamic Solidity array maps to `Vec<T>`, whose `Default` impl holds for any `T`. `can_derive_default` still required the element type to be `Default` for dynamic arrays, so a struct/error with a field like `MyEnum[]` lost its `Default` derive under `#[sol(all_derives)]` even though `Vec<MyEnum>: Default`.

This mirrors how the field's Rust type is generated (`expand_rust_type_to`): `Some(size)` → `[T; N]`, `None` → `Vec<T>`. Only fixed-size arrays need `T: Default` (and `N <= 32`); dynamic arrays are always `Default`.

Added a regression test (`test_default_dynamic_array_of_non_default_elem`).
