### PR TITLE
chore: disable rustc-hash nightly feature

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -148,7 +148,8 @@ nightly = [
     "hex/nightly",
     # TODO: Re-enable on next ruint version (>1.17.2)
     # "ruint/nightly",
-    "rustc-hash/nightly",
+    # TODO: Re-enable after https://github.com/rust-lang/rustc-hash/pull/77
+    # "rustc-hash/nightly",
     "fixed-cache?/nightly",
 ]
 


### PR DESCRIPTION
Temporarily comments out the `rustc-hash/nightly` feature while upstream support is pending.