### PR TITLE
fix(dyn-abi): validate EIP-712 fixed bytes length

### DIFF
--- a/crates/dyn-abi/src/eip712/coerce.rs
+++ b/crates/dyn-abi/src/eip712/coerce.rs
@@ -78,10 +78,11 @@ fn uint(n: usize, value: &serde_json::Value) -> Option<U256> {
 
 fn fixed_bytes(n: usize, value: &serde_json::Value) -> Option<Word> {
     if let Some(Ok(buf)) = value.as_str().map(hex::decode) {
-        let mut word = Word::ZERO;
-        let min = n.min(buf.len());
-        if min <= 32 {
-            word[..min].copy_from_slice(&buf[..min]);
+        if n <= Word::len_bytes() && buf.len() == n {
+            let mut word = Word::ZERO;
+            if n != 0 {
+                word[..n].copy_from_slice(&buf);
+            }
             return Some(word);
         }
     }

--- a/crates/dyn-abi/src/eip712/coerce.rs
+++ b/crates/dyn-abi/src/eip712/coerce.rs
@@ -195,6 +195,13 @@ mod tests {
     }
 
     #[test]
+    fn fixed_bytes_rejects_oversized_hex() {
+        let ty = DynSolType::FixedBytes(2);
+        let j = json!("0x123456");
+        assert!(ty.coerce_json(&j).is_err());
+    }
+
+    #[test]
     fn it_coerces() {
         let j = json!({
             "message": {


### PR DESCRIPTION
## Summary

- Reject EIP-712 JSON hex values for `bytesN` unless the decoded byte length is exactly `N`.
- Preserve existing fixed-byte word construction for correctly sized values.

## Regression

- Added `fixed_bytes_rejects_oversized_hex`, which failed before the fix because `bytes2` accepted `0x123456` and truncated it.

## Test Plan

- `cargo test -p alloy-dyn-abi --features eip712 fixed_bytes_rejects_oversized_hex`
