### PR TITLE
fix(dyn-abi): enforce signed int string width

### DIFF
--- a/crates/dyn-abi/src/coerce.rs
+++ b/crates/dyn-abi/src/coerce.rs
@@ -657,6 +657,11 @@ mod tests {
             DynSolValue::Int(I256::MINUS_ONE, 8),
         );
         assert_eq!(
+            DynSolType::Int(8).coerce_str("-128").unwrap(),
+            DynSolValue::Int(I256::try_from(-128).unwrap(), 8),
+        );
+        assert!(DynSolType::Int(8).coerce_str("-129").is_err());
+        assert_eq!(
             DynSolType::Int(16).coerce_str("-1").unwrap(),
             DynSolValue::Int(I256::MINUS_ONE, 16),
         );

--- a/crates/dyn-abi/src/coerce.rs
+++ b/crates/dyn-abi/src/coerce.rs
@@ -302,10 +302,14 @@ fn int<'i>(size: usize) -> impl ModalParser<Input<'i>, I256, ContextError> {
     trace(
         name,
         (int_sign, uint(size)).try_map(move |(sign, abs)| {
-            if !sign.is_negative() && abs.bit_len() > size - 1 {
+            if !sign.is_negative() && abs.bit_len() > size.saturating_sub(1) {
                 return Err(Error::IntOverflow);
             }
-            I256::checked_from_sign_and_abs(sign, abs).ok_or(Error::IntOverflow)
+            let int = I256::checked_from_sign_and_abs(sign, abs).ok_or(Error::IntOverflow)?;
+            if int.bits() > size as u32 {
+                return Err(Error::IntOverflow);
+            }
+            Ok(int)
         }),
     )
 }


### PR DESCRIPTION
## Summary

- Validate the final signed `I256` value produced by `DynSolType::Int(n).coerce_str`.
- Keep `int8` minimum value `-128` accepted while rejecting below-minimum strings such as `-129`.

## Regression

- Extended `coerce_int_overflow`, which failed before the fix because `int8` string coercion accepted `-129`.

## Test Plan

- `cargo test -p alloy-dyn-abi coerce_int_overflow`
