### PR TITLE
fix(dyn-abi): error on primitive EIP-712 data

### DIFF
--- a/crates/dyn-abi/src/eip712/typed_data.rs
+++ b/crates/dyn-abi/src/eip712/typed_data.rs
@@ -319,6 +319,23 @@ mod tests {
     }
 
     #[test]
+    fn primitive_primary_type_returns_error() {
+        let json = json!({
+            "types": {
+                "EIP712Domain": [],
+                "uint256": []
+            },
+            "primaryType": "uint256",
+            "domain": {},
+            "message": "1"
+        });
+
+        let typed_data: TypedData = serde_json::from_value(json).unwrap();
+
+        assert!(typed_data.hash_struct().is_err());
+    }
+
+    #[test]
     fn test_encode_custom_array_type() {
         let json = json!({
             "domain": {},

--- a/crates/dyn-abi/src/eip712/typed_data.rs
+++ b/crates/dyn-abi/src/eip712/typed_data.rs
@@ -188,7 +188,9 @@ impl TypedData {
     /// [`encodeData`]: https://eips.ethereum.org/EIPS/eip-712#definition-of-encodedata
     pub fn encode_data(&self) -> Result<Vec<u8>> {
         let s = self.coerce()?;
-        Ok(self.resolver.encode_data(&s)?.unwrap())
+        self.resolver
+            .encode_data(&s)?
+            .ok_or_else(|| crate::Error::custom("EIP-712 primary type must be a struct"))
     }
 
     /// Calculate the [`encodeType`] for this value.


### PR DESCRIPTION
## Summary

- Return an error when EIP-712 `encode_data` resolves to a primitive value instead of a struct-like encodable payload.
- Remove the `unwrap()` path that could panic for primitive-named primary types.

## Regression

- Added `primitive_primary_type_returns_error`, which failed before the fix by panicking in `TypedData::encode_data`.

## Test Plan

- `cargo test -p alloy-dyn-abi --features eip712 primitive_primary_type_returns_error`
