### PR TITLE
fix(primitives): reject underflowing native signed ints

### DIFF
--- a/crates/primitives/src/signed/conversions.rs
+++ b/crates/primitives/src/signed/conversions.rs
@@ -307,8 +307,9 @@ macro_rules! impl_conversions {
                     }
 
                     let abs = (!uint).wrapping_add(1);
-                    let tc = twos_complement(Uint::<BITS, LIMBS>::from(abs));
-                    Ok(Self(tc))
+                    let abs =
+                        Uint::<BITS, LIMBS>::try_from(abs).map_err(|_| BigIntConversionError)?;
+                    Self::checked_from_sign_and_abs(Sign::Negative, abs).ok_or(BigIntConversionError)
                 }
             }
 

--- a/crates/primitives/src/signed/int.rs
+++ b/crates/primitives/src/signed/int.rs
@@ -1698,5 +1698,9 @@ mod tests {
         assert!(<I128 as UintTryTo<I24>>::uint_try_to(&I128::MIN).is_err());
         assert!(I24::uint_try_from(I128::MAX).is_err());
         assert!(<I128 as UintTryTo<I24>>::uint_try_to(&I128::MAX).is_err());
+
+        assert_eq!(I24::try_from(-8_388_608i32), Ok(I24::MIN));
+        assert!(I24::try_from(-8_388_609i32).is_err());
+        assert!(I24::try_from(i32::MIN).is_err());
     }
 }


### PR DESCRIPTION
## Summary

- Convert negative native integers through a fallible unsigned resize and signed bounds check.
- Preserve acceptance of the narrow signed minimum while rejecting values below it.

## Regression

- Extended `test_int_conversion`, which failed before the fix because `I24::try_from(-8_388_609i32)` succeeded.

## Test Plan

- `cargo test -p alloy-primitives test_int_conversion`
