### PR TITLE
fix(json-abi):  preserve anonymous event full signatures

### DIFF
--- a/crates/json-abi/src/item.rs
+++ b/crates/json-abi/src/item.rs
@@ -675,6 +675,15 @@ mod tests {
     }
 
     #[test]
+    fn anonymous_event_full_signature_roundtrips() {
+        let event = Event::parse("event foo() anonymous").unwrap();
+        let full_signature = event.full_signature();
+
+        assert_eq!(full_signature, "event foo() anonymous");
+        assert_eq!(Event::parse(&full_signature), Ok(event));
+    }
+
+    #[test]
     fn parse_error_prefix() {
         let new = |name: &str| Error { name: name.into(), inputs: vec![] };
         assert_eq!(Error::parse("foo()"), Ok(new("foo")));

--- a/crates/json-abi/src/item.rs
+++ b/crates/json-abi/src/item.rs
@@ -605,14 +605,14 @@ impl Event {
     }
 
     /// Returns this event's full signature
-    /// `event $name($($inputs indexed $names),*)`.
+    /// `event $name($($inputs indexed $names),*) $(anonymous)?`.
     ///
     /// This is a full human-readable string, including all parameter names, any optional modifiers
     /// (e.g. indexed) and white-space to aid in human readability. This is useful for
     /// storing a string which can still fully reconstruct the original Fragment
     #[inline]
     pub fn full_signature(&self) -> String {
-        event_full_signature(&self.name, &self.inputs)
+        event_full_signature(&self.name, &self.inputs, self.anonymous)
     }
 
     /// Computes this event's selector: `keccak256(self.signature())`

--- a/crates/json-abi/src/utils.rs
+++ b/crates/json-abi/src/utils.rs
@@ -94,8 +94,8 @@ pub(crate) fn event_signature(name: &str, inputs: &[EventParam]) -> String {
     preimage
 }
 
-/// `$name($($inputs indexed names),*)`
-pub(crate) fn event_full_signature(name: &str, inputs: &[EventParam]) -> String {
+/// `$name($($inputs indexed names),*) $(anonymous)?`
+pub(crate) fn event_full_signature(name: &str, inputs: &[EventParam], anonymous: bool) -> String {
     let mut sig = String::with_capacity("event ".len() + name.len() + 2 + inputs.len() * PARAM_CAP);
     sig.push_str("event ");
     sig.push_str(name);
@@ -114,6 +114,9 @@ pub(crate) fn event_full_signature(name: &str, inputs: &[EventParam]) -> String 
         }
     }
     sig.push(')');
+    if anonymous {
+        sig.push_str(" anonymous");
+    }
     sig
 }
 
@@ -355,15 +358,17 @@ mod tests {
 
     #[test]
     fn test_event_full_signature() {
-        assert_eq!(event_full_signature("foo", &[]), "event foo()");
+        assert_eq!(event_full_signature("foo", &[], false), "event foo()");
+        assert_eq!(event_full_signature("foo", &[], true), "event foo() anonymous");
         assert_eq!(
-            event_full_signature("foo", &[eparam2("bool", "confirmed", true)]),
+            event_full_signature("foo", &[eparam2("bool", "confirmed", true)], false),
             "event foo(bool indexed confirmed)"
         );
         assert_eq!(
             event_full_signature(
                 "foo",
-                &[eparam2("bool", "confirmed", true), eparam2("string", "message", false)]
+                &[eparam2("bool", "confirmed", true), eparam2("string", "message", false)],
+                false
             ),
             "event foo(bool indexed confirmed, string message)"
         );
@@ -383,7 +388,8 @@ mod tests {
         assert_eq!(
             event_full_signature(
                 "SetupDirectDebit",
-                &[eparam2("address", "debtor", true), eparam2("address", "receiver", true), info,]
+                &[eparam2("address", "debtor", true), eparam2("address", "receiver", true), info,],
+                false
             ),
             "event SetupDirectDebit(address indexed debtor, address indexed receiver, tuple(uint256 amount, uint256 startTime, uint256 interval) info)"
         );


### PR DESCRIPTION
## Summary

- Preserve `anonymous` in `Event::full_signature()`.
- Add a regression that round-trips an anonymous event full signature.

## Tests

- `cargo test -p alloy-json-abi`
