### PR TITLE
Fix dyn-abi custom struct proptest regression

### DIFF
--- a/crates/dyn-abi/proptest-regressions/arbitrary.txt
+++ b/crates/dyn-abi/proptest-regressions/arbitrary.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any novel
+# cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc f210de5c0bc2d79f8fc29863ffe54037ccf08e0438c79e14500f9c668ea127fc
+cc 4ad7078d1c0ac962ad9a1efc30aa9dbc15f4bb659c7cdd9cb95370e0d7534c4f # shrinks to bytes = [0, 0, 0, 192, 0, 0, 0, 235, 0]

--- a/crates/dyn-abi/src/arbitrary.rs
+++ b/crates/dyn-abi/src/arbitrary.rs
@@ -671,7 +671,7 @@ mod tests {
         match ty.abi_decode_params(&data) {
             // skip the check if the type contains a CustomStruct, since
             // decoding will not populate names
-            Ok(decoded) if !decoded.has_custom_struct() => prop_assert_eq!(
+            Ok(decoded) if !ty.has_custom_struct() => prop_assert_eq!(
                 &decoded,
                 &value,
                 "\n\ndecoded value doesn't match {:?} ({:?})\ndata: {:?}",


### PR DESCRIPTION
## Summary
- keep the existing dyn-abi decode behavior unchanged
- skip ABI round-trip equality when the expected type contains a custom struct, since decoding cannot repopulate custom struct names and ZST custom structs can disappear from the decoded value shape
- add regression seeds for the dynamic and fixed zero-sized custom struct cases found by proptest

## Tests
- cargo test -p alloy-dyn-abi --lib arbitrary::tests::arbitrary_value --all-features
- cargo test -p alloy-dyn-abi --lib --all-features
- git diff --check

Prompted by: @0xalpharush