### PR TITLE
fix(dyn-abi): reject out-of-range negative signed integer coercions

### DIFF
--- a/crates/dyn-abi/src/coerce.rs
+++ b/crates/dyn-abi/src/coerce.rs
@@ -302,7 +302,9 @@ fn int<'i>(size: usize) -> impl ModalParser<Input<'i>, I256, ContextError> {
     trace(
         name,
         (int_sign, uint(size)).try_map(move |(sign, abs)| {
-            if !sign.is_negative() && abs.bit_len() > size - 1 {
+            let limit = U256::from(1) << (size - 1);
+            let overflow = if sign.is_negative() { abs > limit } else { abs >= limit };
+            if overflow {
                 return Err(Error::IntOverflow);
             }
             I256::checked_from_sign_and_abs(sign, abs).ok_or(Error::IntOverflow)
@@ -643,23 +645,28 @@ mod tests {
         );
         assert!(DynSolType::Int(8).coerce_str("128").is_err());
         assert!(DynSolType::Int(8).coerce_str("129").is_err());
+
         assert_eq!(
-            DynSolType::Int(16).coerce_str("128").unwrap(),
-            DynSolValue::Int(I256::try_from(128).unwrap(), 16),
+            DynSolType::Int(16).coerce_str("32767").unwrap(),
+            DynSolValue::Int(I256::try_from(32767).unwrap(), 16),
         );
-        assert_eq!(
-            DynSolType::Int(16).coerce_str("129").unwrap(),
-            DynSolValue::Int(I256::try_from(129).unwrap(), 16),
-        );
+        assert!(DynSolType::Int(16).coerce_str("32768").is_err());
 
         assert_eq!(
             DynSolType::Int(8).coerce_str("-1").unwrap(),
             DynSolValue::Int(I256::MINUS_ONE, 8),
         );
         assert_eq!(
-            DynSolType::Int(16).coerce_str("-1").unwrap(),
-            DynSolValue::Int(I256::MINUS_ONE, 16),
+            DynSolType::Int(8).coerce_str("-128").unwrap(),
+            DynSolValue::Int(I256::try_from(-128).unwrap(), 8),
         );
+        assert!(DynSolType::Int(8).coerce_str("-129").is_err());
+
+        assert_eq!(
+            DynSolType::Int(16).coerce_str("-32768").unwrap(),
+            DynSolValue::Int(I256::try_from(-32768).unwrap(), 16),
+        );
+        assert!(DynSolType::Int(16).coerce_str("-32769").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`DynSolType::Int(bits).coerce_str` only validated overflow for positive values.
Negative values outside the target Solidity integer range were accepted because
`I256::checked_from_sign_and_abs` only validates the 256-bit representation.

For example, `DynSolType::Int(8).coerce_str("-129")` returned
`Ok(Int(-129, 8))`, even though `int8` only allows values in `[-128, 127]`.

## Solution

Add signed range validation during integer string coercion by checking both the
positive and negative bounds for the requested Solidity bit width before
constructing the `I256`.

Also adds regression tests covering positive/negative boundary values and
overflow cases for `int8` and `int16`.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes