### PR TITLE
fix(sol-macro): fix UDT NAME constant generation stringify typo

### DIFF
--- a/crates/sol-macro-expander/src/expand/udt.rs
+++ b/crates/sol-macro-expander/src/expand/udt.rs
@@ -64,7 +64,7 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, udt: &ItemUdt) -> Result<TokenStream> {
 
             impl #name {
                 /// The Solidity type name.
-                pub const NAME: &'static str = stringify!(@name);
+                pub const NAME: &'static str = stringify!(#name);
 
                 /// Convert from the underlying value type.
                 #[inline]

--- a/tests/core-sol/src/lib.rs
+++ b/tests/core-sol/src/lib.rs
@@ -205,4 +205,5 @@ fn do_stuff() {
         Default::default(),
     );
     assert_eq!(set.len(), 1);
+    assert_eq!(MyType::NAME, "MyType");
 }


### PR DESCRIPTION
## Motivation

The UDVT macro expansion generated an incorrect `NAME` constant due to a typo in
`expand/udt.rs`.

The generated code used:

```rust
stringify!(@name)
```

instead of:

```rust
stringify!(#name)
```

As a result, `NAME` evaluated to `"@ name"` instead of the Solidity type name.

## Solution

Replace `@name` with `#name` so the generated `NAME` constant expands to the
correct identifier.

Also adds a regression test asserting:

```rust
assert_eq!(MyType::NAME, "MyType");
```