### PR TITLE
fix(syn-solidity): strip namespaces from custom types in EIP-712 formatting

### DIFF
--- a/crates/sol-types/tests/macros/sol/eip712.rs
+++ b/crates/sol-types/tests/macros/sol/eip712.rs
@@ -90,3 +90,25 @@ fn test_eip712_interface_prefix() {
         "MyStruct(ParentStructA structA,ParentStructB structB)ParentStructA(uint256 numberA)ParentStructB(uint256 numberB)"
     );
 }
+
+#[test]
+fn test_eip712_strips_custom_type_namespaces() {
+    sol! {
+        contract A {
+            struct StructB {
+                uint256 x;
+            }
+        }
+        struct StructA {
+            A.StructB[] b;
+            A.StructB[3] c;
+            A.StructB[][] d;
+            A.StructB e;
+        }
+    }
+
+    assert_eq!(
+        StructA::eip712_encode_type(),
+        "StructA(StructB[] b,StructB[3] c,StructB[][] d,StructB e)StructB(uint256 x)"
+    );
+}

--- a/crates/syn-solidity/src/variable/mod.rs
+++ b/crates/syn-solidity/src/variable/mod.rs
@@ -67,25 +67,6 @@ impl Spanned for VariableDeclaration {
     }
 }
 
-fn fmt_type_eip712(ty: &crate::Type, f: &mut impl Write) -> fmt::Result {
-    match ty {
-        crate::Type::Custom(path) => {
-            write!(f, "{}", path.last())
-        }
-
-        crate::Type::Array(array) => {
-            fmt_type_eip712(&array.ty, f)?;
-            write!(f, "[")?;
-            if let Some(s) = array.size_lit() {
-                write!(f, "{}", s.base10_digits())?;
-            }
-            write!(f, "]")
-        }
-
-        _ => write!(f, "{ty}"),
-    }
-}
-
 impl VariableDeclaration {
     pub const fn new(ty: Type) -> Self {
         Self::new_with(ty, None, None)
@@ -98,6 +79,25 @@ impl VariableDeclaration {
     /// Formats `self` as an EIP-712 field: `<ty> <name>`
     pub fn fmt_eip712(&self, f: &mut impl Write) -> fmt::Result {
         // According to EIP-712, type strings should only contain struct name, not interface prefix
+        fn fmt_type_eip712(ty: &crate::Type, f: &mut impl Write) -> fmt::Result {
+            match ty {
+                crate::Type::Custom(path) => {
+                    write!(f, "{}", path.last())
+                }
+
+                crate::Type::Array(array) => {
+                    fmt_type_eip712(&array.ty, f)?;
+                    write!(f, "[")?;
+                    if let Some(s) = array.size_lit() {
+                        write!(f, "{}", s.base10_digits())?;
+                    }
+                    write!(f, "]")
+                }
+
+                _ => write!(f, "{ty}"),
+            }
+        }
+
         fmt_type_eip712(&self.ty, f)?;
         if let Some(name) = &self.name {
             write!(f, " {name}")?;

--- a/crates/syn-solidity/src/variable/mod.rs
+++ b/crates/syn-solidity/src/variable/mod.rs
@@ -67,6 +67,25 @@ impl Spanned for VariableDeclaration {
     }
 }
 
+fn fmt_type_eip712(ty: &crate::Type, f: &mut impl Write) -> fmt::Result {
+    match ty {
+        crate::Type::Custom(path) => {
+            write!(f, "{}", path.last())
+        }
+
+        crate::Type::Array(array) => {
+            fmt_type_eip712(&array.ty, f)?;
+            write!(f, "[")?;
+            if let Some(s) = array.size_lit() {
+                write!(f, "{}", s.base10_digits())?;
+            }
+            write!(f, "]")
+        }
+
+        _ => write!(f, "{ty}"),
+    }
+}
+
 impl VariableDeclaration {
     pub const fn new(ty: Type) -> Self {
         Self::new_with(ty, None, None)
@@ -79,14 +98,7 @@ impl VariableDeclaration {
     /// Formats `self` as an EIP-712 field: `<ty> <name>`
     pub fn fmt_eip712(&self, f: &mut impl Write) -> fmt::Result {
         // According to EIP-712, type strings should only contain struct name, not interface prefix
-        match &self.ty {
-            crate::Type::Custom(path) => {
-                write!(f, "{}", path.last())?;
-            }
-            _ => {
-                write!(f, "{}", self.ty)?;
-            }
-        }
+        fmt_type_eip712(&self.ty, f)?;
         if let Some(name) = &self.name {
             write!(f, " {name}")?;
         }

--- a/tests/core-sol/src/lib.rs
+++ b/tests/core-sol/src/lib.rs
@@ -207,25 +207,3 @@ fn do_stuff() {
     assert_eq!(set.len(), 1);
     assert_eq!(MyType::NAME, "MyType");
 }
-
-sol! {
-    contract A {
-        struct StructB {
-            uint256 x;
-        }
-    }
-    struct StructA {
-        A.StructB[] b;
-        A.StructB[3] c;
-        A.StructB[][] d;
-        A.StructB e;
-    }
-}
-
-#[test]
-fn test_eip712_strips_custom_type_namespaces() {
-    assert_eq!(
-        <StructA as alloy_core::sol_types::SolStruct>::eip712_encode_type(),
-        "StructA(StructB[] b,StructB[3] c,StructB[][] d,StructB e)StructB(uint256 x)"
-    );
-}

--- a/tests/core-sol/src/lib.rs
+++ b/tests/core-sol/src/lib.rs
@@ -207,3 +207,25 @@ fn do_stuff() {
     assert_eq!(set.len(), 1);
     assert_eq!(MyType::NAME, "MyType");
 }
+
+sol! {
+    contract A {
+        struct StructB {
+            uint256 x;
+        }
+    }
+    struct StructA {
+        A.StructB[] b;
+        A.StructB[3] c;
+        A.StructB[][] d;
+        A.StructB e;
+    }
+}
+
+#[test]
+fn test_eip712_strips_custom_type_namespaces() {
+    assert_eq!(
+        <StructA as alloy_core::sol_types::SolStruct>::eip712_encode_type(),
+        "StructA(StructB[] b,StructB[3] c,StructB[][] d,StructB e)StructB(uint256 x)"
+    );
+}


### PR DESCRIPTION
## Motivation

EIP-712 type signatures should use the bare name of referenced custom types.

While direct custom types were formatted correctly, custom types nested inside
arrays retained their fully qualified paths (e.g. `A.StructB[]`), resulting in
incorrect EIP-712 type signatures and hashes.

## Solution

Add a private recursive helper for EIP-712 type formatting that strips
namespaces from custom types while recursively formatting array element types.

Also adds regression tests covering:

- Direct custom types
- Dynamic arrays
- Fixed-size arrays
- Nested arrays

to ensure custom type names are formatted correctly in all supported array
configurations.