### PR TITLE
chore(crates/primitives): migrate to new versions of `rand` and `k256`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         rust: [
             "stable",
             "nightly",
-            "1.88", # MSRV
+            "1.90", # MSRV
           ]
         flags: [
             # No features
@@ -39,10 +39,10 @@ jobs:
         include:
           # MSRV features
           - os: "ubuntu-latest"
-            rust: "1.88" # MSRV
+            rust: "1.90" # MSRV
             flags: "--features json"
           - os: "windows-latest"
-            rust: "1.88" # MSRV
+            rust: "1.90" # MSRV
             flags: "--features json"
           # All features
           - os: "ubuntu-latest"
@@ -63,14 +63,14 @@ jobs:
           cache-on-failure: true
       # Only run tests on latest stable and above
       - name: pin deps
-        if: ${{ matrix.rust == '1.88' }} # MSRV
+        if: ${{ matrix.rust == '1.90' }} # MSRV
         run: cargo +nightly update -Z minimal-versions
       - name: build
-        if: ${{ matrix.rust == '1.88' }} # MSRV
+        if: ${{ matrix.rust == '1.90' }} # MSRV
         run: cargo build --workspace ${{ matrix.flags }}
 
       - name: test
-        if: ${{ matrix.rust != '1.88' }} # MSRV
+        if: ${{ matrix.rust != '1.90' }} # MSRV
         run: cargo test --workspace ${{ matrix.flags }}
 
   miri:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         rust: [
             "stable",
             "nightly",
-            "1.85", # MSRV
+            "1.88", # MSRV
           ]
         flags: [
             # No features
@@ -39,10 +39,10 @@ jobs:
         include:
           # MSRV features
           - os: "ubuntu-latest"
-            rust: "1.85" # MSRV
+            rust: "1.88" # MSRV
             flags: "--features json"
           - os: "windows-latest"
-            rust: "1.85" # MSRV
+            rust: "1.88" # MSRV
             flags: "--features json"
           # All features
           - os: "ubuntu-latest"
@@ -63,14 +63,14 @@ jobs:
           cache-on-failure: true
       # Only run tests on latest stable and above
       - name: pin deps
-        if: ${{ matrix.rust == '1.85' }} # MSRV
+        if: ${{ matrix.rust == '1.88' }} # MSRV
         run: cargo +nightly update -Z minimal-versions
       - name: build
-        if: ${{ matrix.rust == '1.85' }} # MSRV
+        if: ${{ matrix.rust == '1.88' }} # MSRV
         run: cargo build --workspace ${{ matrix.flags }}
 
       - name: test
-        if: ${{ matrix.rust != '1.85' }} # MSRV
+        if: ${{ matrix.rust != '1.88' }} # MSRV
         run: cargo test --workspace ${{ matrix.flags }}
 
   miri:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [workspace]
 members = ["crates/*", "tests/*"]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 version = "1.6.1"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 authors = ["Alloy Contributors"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/alloy-rs/core"
@@ -70,7 +70,7 @@ derive_more = { version = "2.0", default-features = false }
 paste = "1.0"
 
 # crypto
-k256 = { version = "0.13", default-features = false }
+k256 = { version = "0.14", default-features = false }
 secp256k1 = { version = "0.31", default-features = false, features = ["recovery", "alloc"] }
 keccak-asm = { version = "0.1.5", default-features = false }
 tiny-keccak = { version = "2.0", default-features = false }
@@ -91,7 +91,7 @@ bcs = "0.2.1"
 bincode = "=1.3.3"
 bytes = { version = "1", default-features = false }
 criterion = "0.7"
-diesel = "2.2"
+diesel = "2.3.10"
 getrandom = "0.4"
 hex = { package = "const-hex", version = "1.14", default-features = false, features = [
     "alloc",
@@ -102,7 +102,7 @@ postgres-types = "0.2.6"
 pretty_assertions = "1.4"
 proptest = { version = "1", default-features = false }
 proptest-derive = "0.8"
-rand = { version = "0.9", default-features = false, features = ["os_rng"] }
+rand = { version = "0.10", default-features = false, features = ["sys_rng"] }
 rayon = { version = "1.2", default-features = false }
 ruint = { version = "1.16.0", default-features = false, features = ["alloc"] }
 winnow = { version = "1.0", default-features = false, features = ["alloc", "ascii"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 [workspace.package]
 version = "1.6.1"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.90"
 authors = ["Alloy Contributors"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/alloy-rs/core"
@@ -104,7 +104,7 @@ proptest = { version = "1", default-features = false }
 proptest-derive = "0.8"
 rand = { version = "0.10", default-features = false, features = ["sys_rng"] }
 rayon = { version = "1.2", default-features = false }
-ruint = { version = "1.16.0", default-features = false, features = ["alloc"] }
+ruint = { version = "1.20", default-features = false, features = ["alloc"] }
 winnow = { version = "1.0", default-features = false, features = ["alloc", "ascii"] }
 fixed-cache = { version = "0.1.8", default-features = false }
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ When updating this, also update:
 - .github/workflows/ci.yml
 -->
 
-The current MSRV (minimum supported rust version) is 1.85.
+The current MSRV (minimum supported rust version) is 1.88.
 
 Alloy will keep a rolling MSRV policy of **at least** two versions behind the
 latest stable release (so if the latest stable release is 1.58, we would

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ When updating this, also update:
 - .github/workflows/ci.yml
 -->
 
-The current MSRV (minimum supported rust version) is 1.88.
+The current MSRV (minimum supported rust version) is 1.90.
 
 Alloy will keep a rolling MSRV policy of **at least** two versions behind the
 latest stable release (so if the latest stable release is 1.58, we would

--- a/crates/dyn-abi/src/arbitrary.rs
+++ b/crates/dyn-abi/src/arbitrary.rs
@@ -554,6 +554,9 @@ fn adjust_fb(mut word: B256, size: usize) -> B256 {
 
 #[cfg(all(test, not(miri)))] // doesn't run in isolation and would take too long
 mod tests {
+    // `is_multiple_of` is newer than the crate's MSRV.
+    #![allow(clippy::manual_is_multiple_of)]
+
     use super::*;
     use alloy_primitives::hex;
     #[cfg(feature = "eip712")]

--- a/crates/dyn-abi/src/eip712/coerce.rs
+++ b/crates/dyn-abi/src/eip712/coerce.rs
@@ -80,14 +80,15 @@ fn uint(n: usize, value: &serde_json::Value) -> Option<U256> {
 }
 
 fn fixed_bytes(n: usize, value: &serde_json::Value) -> Option<Word> {
-    if let Some(Ok(buf)) = value.as_str().map(hex::decode) {
-        if n <= Word::len_bytes() && buf.len() == n {
-            let mut word = Word::ZERO;
-            if n != 0 {
-                word[..n].copy_from_slice(&buf);
-            }
-            return Some(word);
+    if let Some(Ok(buf)) = value.as_str().map(hex::decode)
+        && n <= Word::len_bytes()
+        && buf.len() == n
+    {
+        let mut word = Word::ZERO;
+        if n != 0 {
+            word[..n].copy_from_slice(&buf);
         }
+        return Some(word);
     }
     None
 }
@@ -118,10 +119,10 @@ fn bytes(value: &serde_json::Value) -> Option<Vec<u8>> {
 }
 
 fn tuple(inner: &[DynSolType], value: &serde_json::Value) -> Option<Result<Vec<DynSolValue>>> {
-    if let Some(arr) = value.as_array() {
-        if inner.len() == arr.len() {
-            return Some(core::iter::zip(arr, inner).map(|(v, t)| t.coerce_json(v)).collect());
-        }
+    if let Some(arr) = value.as_array()
+        && inner.len() == arr.len()
+    {
+        return Some(core::iter::zip(arr, inner).map(|(v, t)| t.coerce_json(v)).collect());
     }
     None
 }
@@ -138,10 +139,10 @@ fn fixed_array(
     n: usize,
     value: &serde_json::Value,
 ) -> Option<Result<Vec<DynSolValue>>> {
-    if let Some(arr) = value.as_array() {
-        if arr.len() == n {
-            return Some(arr.iter().map(|v| inner.coerce_json(v)).collect());
-        }
+    if let Some(arr) = value.as_array()
+        && arr.len() == n
+    {
+        return Some(arr.iter().map(|v| inner.coerce_json(v)).collect());
     }
     None
 }

--- a/crates/dyn-abi/src/specifier.rs
+++ b/crates/dyn-abi/src/specifier.rs
@@ -62,10 +62,11 @@ impl Specifier<DynSolType> for RootType<'_> {
             "int" => Ok(DynSolType::Int(256)),
             name => {
                 if let Some(sz) = name.strip_prefix("bytes") {
-                    if let Ok(sz) = sz.parse() {
-                        if sz != 0 && sz <= 32 {
-                            return Ok(DynSolType::FixedBytes(sz));
-                        }
+                    if let Ok(sz) = sz.parse()
+                        && sz != 0
+                        && sz <= 32
+                    {
+                        return Ok(DynSolType::FixedBytes(sz));
                     }
                     return Err(parser::Error::invalid_size(name).into());
                 }
@@ -75,14 +76,16 @@ impl Specifier<DynSolType> for RootType<'_> {
                     if let Some(s) = name.strip_prefix('u') { (s, true) } else { (name, false) };
 
                 if let Some(sz) = s.strip_prefix("int") {
-                    if let Ok(sz) = sz.parse() {
-                        if sz != 0 && sz <= 256 && sz % 8 == 0 {
-                            return if is_uint {
-                                Ok(DynSolType::Uint(sz))
-                            } else {
-                                Ok(DynSolType::Int(sz))
-                            };
-                        }
+                    if let Ok(sz) = sz.parse()
+                        && sz != 0
+                        && sz <= 256
+                        && sz % 8 == 0
+                    {
+                        return if is_uint {
+                            Ok(DynSolType::Uint(sz))
+                        } else {
+                            Ok(DynSolType::Int(sz))
+                        };
                     }
                     Err(parser::Error::invalid_size(name).into())
                 } else {

--- a/crates/json-abi/src/abi.rs
+++ b/crates/json-abi/src/abi.rs
@@ -582,12 +582,12 @@ impl<'de> Visitor<'de> for ContractObjectVisitor {
                         if ignore_unlinked_bytecode {
                             return Ok(None);
                         }
-                        if let Some((_, unlinked)) = unlinked.split_once("__$") {
-                            if let Some((addr, _)) = unlinked.split_once("$__") {
-                                return Err(E::custom(format!(
-                                    "expected bytecode, found unlinked bytecode with placeholder: {addr}. Use the `ignore_unlinked` sol attribute to bypass this error."
-                                )));
-                            }
+                        if let Some((_, unlinked)) = unlinked.split_once("__$")
+                            && let Some((addr, _)) = unlinked.split_once("$__")
+                        {
+                            return Err(E::custom(format!(
+                                "expected bytecode, found unlinked bytecode with placeholder: {addr}. Use the `ignore_unlinked` sol attribute to bypass this error."
+                            )));
                         }
                         Err(E::custom("invalid contract bytecode"))
                     }
@@ -612,15 +612,15 @@ impl<'de> Visitor<'de> for ContractObjectVisitor {
                 "abi" => set_if_none!(@serde abi, map.next_value()?),
                 "evm" => {
                     let evm = map.next_value::<EvmObj>()?;
-                    if let Some(bytes) = evm.bytecode {
-                        if let Some(b) = bytes.ensure_bytes(self.ignore_unlinked_bytecode)? {
-                            set_if_none!(@serde bytecode, b);
-                        }
+                    if let Some(bytes) = evm.bytecode
+                        && let Some(b) = bytes.ensure_bytes(self.ignore_unlinked_bytecode)?
+                    {
+                        set_if_none!(@serde bytecode, b);
                     }
-                    if let Some(bytes) = evm.deployed_bytecode {
-                        if let Some(b) = bytes.ensure_bytes(self.ignore_unlinked_bytecode)? {
-                            set_if_none!(@serde deployed_bytecode, b);
-                        }
+                    if let Some(bytes) = evm.deployed_bytecode
+                        && let Some(b) = bytes.ensure_bytes(self.ignore_unlinked_bytecode)?
+                    {
+                        set_if_none!(@serde deployed_bytecode, b);
                     }
                 }
                 "bytecode" | "bin" => {

--- a/crates/json-abi/src/to_sol.rs
+++ b/crates/json-abi/src/to_sol.rs
@@ -338,12 +338,12 @@ impl<'a, 'e> InternalTypes<'a, 'e> {
             }
             Some(it @ InternalType::Other { contract, ty }) => {
                 // `Other` is a UDVT if it's not a basic Solidity type.
-                if let Some(it) = it.other_specifier() {
-                    if it.try_basic_solidity().is_err() {
-                        let ty = ty.split('[').next().unwrap();
-                        let real_ty = real_ty.split('[').next().unwrap();
-                        self.extend_one(contract, It::new(ty, ItKind::Udvt(real_ty)));
-                    }
+                if let Some(it) = it.other_specifier()
+                    && it.try_basic_solidity().is_err()
+                {
+                    let ty = ty.split('[').next().unwrap();
+                    let real_ty = real_ty.split('[').next().unwrap();
+                    self.extend_one(contract, It::new(ty, ItKind::Udvt(real_ty)));
                 }
             }
         }
@@ -669,11 +669,11 @@ impl<IN: ToSol> ToSol for AbiFunction<'_, IN> {
             out.push_str(visibility.as_str());
         }
 
-        if let Some(state_mutability) = self.state_mutability {
-            if let Some(state_mutability) = state_mutability.as_str() {
-                out.push(' ');
-                out.push_str(state_mutability);
-            }
+        if let Some(state_mutability) = self.state_mutability
+            && let Some(state_mutability) = state_mutability.as_str()
+        {
+            out.push(' ');
+            out.push_str(state_mutability);
         }
 
         if !self.outputs.is_empty() {
@@ -786,11 +786,11 @@ fn param(
         }
         // primitive type
         _ => {
-            if let Some(contract_name) = contract_name {
-                if contract_name != out.name {
-                    out.push_ident(contract_name);
-                    out.push('.');
-                }
+            if let Some(contract_name) = contract_name
+                && contract_name != out.name
+            {
+                out.push_ident(contract_name);
+                out.push('.');
             }
             out.push_ident(type_name);
         }

--- a/crates/json-abi/src/utils.rs
+++ b/crates/json-abi/src/utils.rs
@@ -57,11 +57,11 @@ pub(crate) fn full_signature(
         sig.push(' ');
         sig.push_str(state_mutability_str);
     }
-    if let Some(outputs) = outputs {
-        if !outputs.is_empty() {
-            sig.push_str(" returns ");
-            params_tuple(outputs, &mut sig);
-        }
+    if let Some(outputs) = outputs
+        && !outputs.is_empty()
+    {
+        sig.push_str(" returns ");
+        params_tuple(outputs, &mut sig);
     }
     sig
 }
@@ -131,10 +131,10 @@ pub(crate) fn parse_maybe_prefixed<F: FnOnce(&str) -> R, R>(
     prefix: &str,
     parser: F,
 ) -> R {
-    if let Some(stripped) = s.strip_prefix(prefix) {
-        if stripped.starts_with(char::is_whitespace) {
-            s = stripped.trim_start();
-        }
+    if let Some(stripped) = s.strip_prefix(prefix)
+        && stripped.starts_with(char::is_whitespace)
+    {
+        s = stripped.trim_start();
     }
     parser(s)
 }

--- a/crates/json-abi/tests/abi.rs
+++ b/crates/json-abi/tests/abi.rs
@@ -287,11 +287,11 @@ fn test_param(param: &Param) {
 /// Checks that the `file` has the specified `contents`. If that is not the
 /// case, updates the file and then fails the test.
 fn ensure_file_contents(file: &Path, contents: &str) {
-    if let Ok(old_contents) = fs::read_to_string(file) {
-        if normalize_newlines(&old_contents) == normalize_newlines(contents) {
-            // File is already up to date.
-            return;
-        }
+    if let Ok(old_contents) = fs::read_to_string(file)
+        && normalize_newlines(&old_contents) == normalize_newlines(contents)
+    {
+        // File is already up to date.
+        return;
     }
 
     eprintln!("\n\x1b[31;1merror\x1b[0m: {} was not up-to-date, updating\n", file.display());

--- a/crates/primitives/src/bits/address.rs
+++ b/crates/primitives/src/bits/address.rs
@@ -508,9 +508,9 @@ impl Address {
     #[cfg(feature = "k256")]
     #[doc(alias = "from_verifying_key")]
     pub fn from_public_key(pubkey: &k256::ecdsa::VerifyingKey) -> Self {
-        use k256::elliptic_curve::sec1::ToEncodedPoint;
+        use k256::elliptic_curve::sec1::ToSec1Point;
         let affine: &k256::AffinePoint = pubkey.as_ref();
-        let encoded = affine.to_encoded_point(false);
+        let encoded = affine.to_sec1_point(false);
         Self::from_raw_public_key(&encoded.as_bytes()[1..])
     }
 

--- a/crates/primitives/src/bits/fixed.rs
+++ b/crates/primitives/src/bits/fixed.rs
@@ -444,7 +444,7 @@ impl<const N: usize> FixedBytes<N> {
     #[cfg(feature = "rand")]
     #[inline]
     #[doc(alias = "random_using")]
-    pub fn random_with<R: rand::RngCore + ?Sized>(rng: &mut R) -> Self {
+    pub fn random_with<R: rand::Rng + ?Sized>(rng: &mut R) -> Self {
         let mut bytes = Self::ZERO;
         bytes.randomize_with(rng);
         bytes
@@ -453,7 +453,7 @@ impl<const N: usize> FixedBytes<N> {
     /// Tries to create a new [`FixedBytes`] with the given random number generator.
     #[cfg(feature = "rand")]
     #[inline]
-    pub fn try_random_with<R: rand::TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
+    pub fn try_random_with<R: rand::TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error> {
         let mut bytes = Self::ZERO;
         bytes.try_randomize_with(rng)?;
         Ok(bytes)
@@ -491,14 +491,14 @@ impl<const N: usize> FixedBytes<N> {
     #[cfg(feature = "rand")]
     #[inline]
     #[doc(alias = "randomize_using")]
-    pub fn randomize_with<R: rand::RngCore + ?Sized>(&mut self, rng: &mut R) {
+    pub fn randomize_with<R: rand::Rng + ?Sized>(&mut self, rng: &mut R) {
         rng.fill_bytes(&mut self.0);
     }
 
     /// Tries to fill this [`FixedBytes`] with the given random number generator.
     #[inline]
     #[cfg(feature = "rand")]
-    pub fn try_randomize_with<R: rand::TryRngCore + ?Sized>(
+    pub fn try_randomize_with<R: rand::TryRng + ?Sized>(
         &mut self,
         rng: &mut R,
     ) -> Result<(), R::Error> {

--- a/crates/primitives/src/bits/macros.rs
+++ b/crates/primitives/src/bits/macros.rs
@@ -545,14 +545,14 @@ macro_rules! impl_rand {
         #[inline]
         #[doc(alias = "random_using")]
         #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
-        pub fn random_with<R: $crate::private::rand::RngCore + ?Sized>(rng: &mut R) -> Self {
+        pub fn random_with<R: $crate::private::rand::Rng + ?Sized>(rng: &mut R) -> Self {
             Self($crate::FixedBytes::random_with(rng))
         }
 
         /// Tries to create a new fixed byte array with the given random number generator.
         #[inline]
         #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
-        pub fn try_random_with<R: $crate::private::rand::TryRngCore + ?Sized>(
+        pub fn try_random_with<R: $crate::private::rand::TryRng + ?Sized>(
             rng: &mut R,
         ) -> $crate::private::Result<Self, R::Error> {
             $crate::FixedBytes::try_random_with(rng).map(Self)
@@ -562,14 +562,14 @@ macro_rules! impl_rand {
         #[inline]
         #[doc(alias = "randomize_using")]
         #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
-        pub fn randomize_with<R: $crate::private::rand::RngCore + ?Sized>(&mut self, rng: &mut R) {
+        pub fn randomize_with<R: $crate::private::rand::Rng + ?Sized>(&mut self, rng: &mut R) {
             self.0.randomize_with(rng);
         }
 
         /// Tries to fill this fixed byte array with the given random number generator.
         #[inline]
         #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
-        pub fn try_randomize_with<R: $crate::private::rand::TryRngCore + ?Sized>(
+        pub fn try_randomize_with<R: $crate::private::rand::TryRng + ?Sized>(
             &mut self,
             rng: &mut R,
         ) -> $crate::private::Result<(), R::Error> {

--- a/crates/primitives/src/log/mod.rs
+++ b/crates/primitives/src/log/mod.rs
@@ -48,7 +48,7 @@ impl LogData {
 
     /// True if valid, false otherwise.
     #[inline]
-    pub fn is_valid(&self) -> bool {
+    pub const fn is_valid(&self) -> bool {
         self.topics.len() <= 4
     }
 

--- a/crates/primitives/src/map/fixed.rs
+++ b/crates/primitives/src/map/fixed.rs
@@ -146,29 +146,29 @@ fn write_bytes_unrolled(hasher: &mut FbHasherInner, mut bytes: &[u8]) {
         hasher.write_usize(usize::from_ne_bytes(*chunk));
         bytes = rest;
     }
-    if usize::BITS > 64 {
-        if let Some((chunk, rest)) = bytes.split_first_chunk() {
-            hasher.write_u64(u64::from_ne_bytes(*chunk));
-            bytes = rest;
-        }
+    if usize::BITS > 64
+        && let Some((chunk, rest)) = bytes.split_first_chunk()
+    {
+        hasher.write_u64(u64::from_ne_bytes(*chunk));
+        bytes = rest;
     }
-    if usize::BITS > 32 {
-        if let Some((chunk, rest)) = bytes.split_first_chunk() {
-            hasher.write_u32(u32::from_ne_bytes(*chunk));
-            bytes = rest;
-        }
+    if usize::BITS > 32
+        && let Some((chunk, rest)) = bytes.split_first_chunk()
+    {
+        hasher.write_u32(u32::from_ne_bytes(*chunk));
+        bytes = rest;
     }
-    if usize::BITS > 16 {
-        if let Some((chunk, rest)) = bytes.split_first_chunk() {
-            hasher.write_u16(u16::from_ne_bytes(*chunk));
-            bytes = rest;
-        }
+    if usize::BITS > 16
+        && let Some((chunk, rest)) = bytes.split_first_chunk()
+    {
+        hasher.write_u16(u16::from_ne_bytes(*chunk));
+        bytes = rest;
     }
-    if usize::BITS > 8 {
-        if let Some((chunk, rest)) = bytes.split_first_chunk() {
-            hasher.write_u8(u8::from_ne_bytes(*chunk));
-            bytes = rest;
-        }
+    if usize::BITS > 8
+        && let Some((chunk, rest)) = bytes.split_first_chunk()
+    {
+        hasher.write_u8(u8::from_ne_bytes(*chunk));
+        bytes = rest;
     }
 
     debug_assert!(bytes.is_empty());

--- a/crates/primitives/src/postgres.rs
+++ b/crates/primitives/src/postgres.rs
@@ -314,6 +314,8 @@ impl<'a, const BITS: usize, const LIMBS: usize> FromSql<'a> for Signed<BITS, LIM
                     return Err(Box::new(FromSqlError::ParseError(ty.clone())));
                 }
                 let mut error = false;
+                // `slice::as_chunks` is newer than the crate's MSRV.
+                #[allow(clippy::chunks_exact_to_as_chunks)]
                 let iter = raw.chunks_exact(2).filter_map(|raw| {
                     if error {
                         return None;

--- a/crates/primitives/src/signed/int.rs
+++ b/crates/primitives/src/signed/int.rs
@@ -211,10 +211,10 @@ impl<const BITS: usize, const LIMBS: usize> Signed<BITS, LIMBS> {
         // if the last limb contains the sign bit, then we're negative
         // because we can't set any higher bits to 1, we use >= as a proxy
         // check to avoid bit comparison
-        if let Some(limb) = self.0.as_limbs().last() {
-            if *limb >= Self::SIGN_BIT {
-                return Sign::Negative;
-            }
+        if let Some(limb) = self.0.as_limbs().last()
+            && *limb >= Self::SIGN_BIT
+        {
+            return Sign::Negative;
         }
         Sign::Positive
     }
@@ -655,7 +655,12 @@ mod tests {
                 assert_eq!(value.into_sign_and_abs(), (Sign::Positive, unsigned));
 
                 let err = <$i_struct>::from_dec_str("invalid string").unwrap_err();
-                assert_eq!(err, ParseSignedError::Ruint(ParseError::InvalidDigit('i')));
+                assert_eq!(
+                    err,
+                    ParseSignedError::Ruint(ParseError::BaseConvertError(
+                        BaseConvertError::InvalidDigit(18, 10),
+                    )),
+                );
 
                 let err = <$i_struct>::from_dec_str(&format!("1{}", <$u_struct>::MAX)).unwrap_err();
                 assert_eq!(err, ParseSignedError::IntegerOverflow);

--- a/crates/primitives/src/utils/mod.rs
+++ b/crates/primitives/src/utils/mod.rs
@@ -435,7 +435,7 @@ mod tests {
     #[cfg(all(feature = "keccak-cache", feature = "rand"))]
     fn test_keccak256_cache_multithreaded() {
         use keccak256_cached as keccak256;
-        use rand::{Rng, SeedableRng};
+        use rand::{RngExt, SeedableRng};
         use std::{sync::Arc, thread};
 
         // Test parameters (reduced for miri).

--- a/crates/sol-macro-expander/src/expand/mod.rs
+++ b/crates/sol-macro-expander/src/expand/mod.rs
@@ -719,10 +719,10 @@ impl<'ast> ExpCtxt<'ast> {
         I: IntoIterator<Item = T>,
         T: Borrow<Type>,
     {
-        if let Some(extra) = &self.attrs.extra_derives {
-            if !extra.is_empty() {
-                attrs.push(parse_quote! { #[derive(#(#extra),*)] });
-            }
+        if let Some(extra) = &self.attrs.extra_derives
+            && !extra.is_empty()
+        {
+            attrs.push(parse_quote! { #[derive(#(#extra),*)] });
         }
 
         let Some(true) = self.attrs.all_derives else {
@@ -755,10 +755,10 @@ impl<'ast> ExpCtxt<'ast> {
     /// from the underlying items' parameter types. Enums never derive
     /// `Default`.
     fn enum_derives(&self, attrs: &mut Vec<Attribute>, can_derive_builtin: bool) {
-        if let Some(extra) = &self.attrs.extra_derives {
-            if !extra.is_empty() {
-                attrs.push(parse_quote! { #[derive(#(#extra),*)] });
-            }
+        if let Some(extra) = &self.attrs.extra_derives
+            && !extra.is_empty()
+        {
+            attrs.push(parse_quote! { #[derive(#(#extra),*)] });
         }
 
         if self.attrs.all_derives == Some(true) && can_derive_builtin {
@@ -777,15 +777,15 @@ impl<'ast> ExpCtxt<'ast> {
         let mut errored = false;
         for param in params {
             param.ty.visit(|ty| {
-                if let Type::Custom(name) = ty {
-                    if self.try_custom_type(name).is_none() {
-                        let note = (!errored).then(|| {
-                            errored = true;
-                            "Custom types must be declared inside of the same scope they are referenced in,\n\
-                             or \"imported\" as a UDT with `type ... is (...);`"
-                        });
-                        emit_error!(name.span(), "unresolved type"; help =? note);
-                    }
+                if let Type::Custom(name) = ty
+                    && self.try_custom_type(name).is_none()
+                {
+                    let note = (!errored).then(|| {
+                        errored = true;
+                        "Custom types must be declared inside of the same scope they are referenced in,\n\
+                         or \"imported\" as a UDT with `type ... is (...);`"
+                    });
+                    emit_error!(name.span(), "unresolved type"; help =? note);
                 }
             });
         }

--- a/crates/sol-macro-expander/src/expand/ty.rs
+++ b/crates/sol-macro-expander/src/expand/ty.rs
@@ -369,10 +369,10 @@ impl<'a> ArraySizeEvaluator<'a> {
             return Err(EvalErrorKind::RecursionLimitReached.spanned(expr.span()));
         }
         let mut r = self.try_eval_expr(expr);
-        if let Err(e) = &mut r {
-            if e.span.is_none() {
-                e.span = Some(expr.span());
-            }
+        if let Err(e) = &mut r
+            && e.span.is_none()
+        {
+            e.span = Some(expr.span());
         }
         self.depth -= 1;
         r

--- a/crates/sol-macro-expander/src/utils.rs
+++ b/crates/sol-macro-expander/src/utils.rs
@@ -98,10 +98,10 @@ pub(crate) fn pme_compat_result(
         }),
         false,
     );
-    if let Some(r) = r {
-        if e.is_empty() || r.is_err() {
-            return r;
-        }
+    if let Some(r) = r
+        && (e.is_empty() || r.is_err())
+    {
+        return r;
     }
     Ok(e.into())
 }

--- a/crates/sol-macro-input/src/json.rs
+++ b/crates/sol-macro-input/src/json.rs
@@ -141,17 +141,17 @@ fn extract_derive_attrs(attrs: &[syn::Attribute]) -> (Vec<&syn::Attribute>, Vec<
     attrs.iter().fold((Vec::new(), Vec::new()), |(mut derives, mut sol_derives), attr| {
         if attr.path().is_ident("derive") {
             derives.push(attr);
-        } else if attr.path().is_ident("sol") {
-            if let Ok(meta) = attr.meta.require_list() {
-                let mut contains_derives = false;
-                let _ = meta.parse_nested_meta(|meta| {
-                    contains_derives |=
-                        meta.path.is_ident("all_derives") || meta.path.is_ident("extra_derives");
-                    Ok(())
-                });
-                if contains_derives {
-                    sol_derives.push(attr);
-                }
+        } else if attr.path().is_ident("sol")
+            && let Ok(meta) = attr.meta.require_list()
+        {
+            let mut contains_derives = false;
+            let _ = meta.parse_nested_meta(|meta| {
+                contains_derives |=
+                    meta.path.is_ident("all_derives") || meta.path.is_ident("extra_derives");
+                Ok(())
+            });
+            if contains_derives {
+                sol_derives.push(attr);
             }
         }
         (derives, sol_derives)

--- a/crates/sol-type-parser/src/root.rs
+++ b/crates/sol-type-parser/src/root.rs
@@ -142,10 +142,11 @@ impl<'a> RootType<'a> {
             "address" | "bool" | "string" | "bytes" | "uint" | "int" | "function" => Ok(()),
             name => {
                 if let Some(sz) = name.strip_prefix("bytes") {
-                    if let Ok(sz) = sz.parse::<usize>() {
-                        if sz != 0 && sz <= 32 {
-                            return Ok(());
-                        }
+                    if let Ok(sz) = sz.parse::<usize>()
+                        && sz != 0
+                        && sz <= 32
+                    {
+                        return Ok(());
                     }
                     return Err(Error::invalid_size(name));
                 }
@@ -154,10 +155,12 @@ impl<'a> RootType<'a> {
                 let s = name.strip_prefix('u').unwrap_or(name);
 
                 if let Some(sz) = s.strip_prefix("int") {
-                    if let Ok(sz) = sz.parse::<usize>() {
-                        if sz != 0 && sz <= 256 && sz % 8 == 0 {
-                            return Ok(());
-                        }
+                    if let Ok(sz) = sz.parse::<usize>()
+                        && sz != 0
+                        && sz <= 256
+                        && sz % 8 == 0
+                    {
+                        return Ok(());
                     }
                     return Err(Error::invalid_size(name));
                 }

--- a/crates/sol-type-parser/src/type_spec.rs
+++ b/crates/sol-type-parser/src/type_spec.rs
@@ -165,7 +165,7 @@ impl<'a> TypeSpecifier<'a> {
 
     /// Returns true if this type is an array.
     #[inline]
-    pub fn is_array(&self) -> bool {
+    pub const fn is_array(&self) -> bool {
         !self.sizes.is_empty()
     }
 }

--- a/crates/sol-types/src/types/interface/mod.rs
+++ b/crates/sol-types/src/types/interface/mod.rs
@@ -492,7 +492,7 @@ impl<T: SolInterface + fmt::Display> RevertReason<T> {
 
 impl<T> RevertReason<T> {
     /// Returns the raw string error message if this type is a [`RevertReason::RawString`]
-    pub fn as_raw_error(&self) -> Option<&str> {
+    pub const fn as_raw_error(&self) -> Option<&str> {
         match self {
             Self::RawString(error) => Some(error.as_str()),
             _ => None,

--- a/crates/syn-solidity/src/attribute/function.rs
+++ b/crates/syn-solidity/src/attribute/function.rs
@@ -58,12 +58,11 @@ impl Parse for FunctionAttributes {
                 FunctionAttribute::Visibility(_)
                     | FunctionAttribute::Mutability(_)
                     | FunctionAttribute::Virtual(_)
-            ) {
-                if let Some(prev) = attributes.iter().find(|a| **a == attr) {
-                    let mut e = Error::new(attr.span(), "duplicate attribute");
-                    e.combine(Error::new(prev.span(), "previous declaration is here"));
-                    return Err(e);
-                }
+            ) && let Some(prev) = attributes.iter().find(|a| **a == attr)
+            {
+                let mut e = Error::new(attr.span(), "duplicate attribute");
+                e.combine(Error::new(prev.span(), "previous declaration is here"));
+                return Err(e);
             }
             attributes.push(attr);
         }

--- a/crates/syn-solidity/src/expr/mod.rs
+++ b/crates/syn-solidity/src/expr/mod.rs
@@ -203,10 +203,10 @@ impl Expr {
     }
 
     fn peel_paren(&self) -> Option<&Self> {
-        if let Self::Tuple(t) = self {
-            if t.elems.len() == 1 {
-                return Some(&t.elems[0]);
-            }
+        if let Self::Tuple(t) = self
+            && t.elems.len() == 1
+        {
+            return Some(&t.elems[0]);
         }
         None
     }


### PR DESCRIPTION
## Motivation

Since new version of [`k256`](https://docs.rs/k256) has been released, it would be wise to support it

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Breaking changes
