### PR TITLE
fix(sol-macro): correct UDVT code generation for dynamic types

### DIFF
--- a/crates/sol-macro-expander/src/expand/udt.rs
+++ b/crates/sol-macro-expander/src/expand/udt.rs
@@ -48,17 +48,17 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, udt: &ItemUdt) -> Result<TokenStream> {
 
                 #[inline]
                 fn stv_eip712_data_word(&self) -> alloy_sol_types::Word {
-                    <#underlying_sol as alloy_sol_types::SolType>::tokenize(self).0
+                    alloy_sol_types::private::SolTypeValue::<#underlying_sol>::stv_eip712_data_word(self)
                 }
 
                 #[inline]
                 fn stv_abi_encode_packed_to(&self, out: &mut alloy_sol_types::private::Vec<u8>) {
-                    <#underlying_sol as alloy_sol_types::SolType>::abi_encode_packed_to(self, out)
+                    alloy_sol_types::private::SolTypeValue::<#underlying_sol>::stv_abi_encode_packed_to(self, out)
                 }
 
                 #[inline]
                 fn stv_abi_packed_encoded_size(&self) -> usize {
-                    <#underlying_sol as alloy_sol_types::SolType>::abi_encoded_size(self)
+                    alloy_sol_types::private::SolTypeValue::<#underlying_sol>::stv_abi_packed_encoded_size(self)
                 }
             }
 
@@ -74,7 +74,7 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, udt: &ItemUdt) -> Result<TokenStream> {
 
                 /// Return the underlying value.
                 #[inline]
-                pub const fn into_underlying(self) -> #underlying_rust {
+                pub fn into_underlying(self) -> #underlying_rust {
                     self.0
                 }
 

--- a/tests/core-sol/src/lib.rs
+++ b/tests/core-sol/src/lib.rs
@@ -207,3 +207,14 @@ fn do_stuff() {
     assert_eq!(set.len(), 1);
     assert_eq!(MyType::NAME, "MyType");
 }
+
+sol! {
+    type MyString is string;
+}
+
+#[test]
+fn test_udt_packed_size() {
+    use alloy_core::sol_types::SolType;
+    let s = alloy_core::sol_types::private::String::from("hello");
+    assert_eq!(<MyString as SolType>::abi_packed_encoded_size(&s), 5);
+}


### PR DESCRIPTION
## Motivation

The generated `SolTypeValue` implementation for user-defined value types (UDVTs) wrapping dynamically-sized Solidity types delegated several methods to the wrong APIs.

This caused:
- `stv_eip712_data_word` to use `SolType::tokenize`, which does not produce the expected `Word` for dynamically-sized types.
- `stv_abi_packed_encoded_size` to use `abi_encoded_size` instead of the packed size calculation, producing incorrect packed sizes for dynamic underlying types.
- `into_underlying` to be generated as a `const fn`, which is not valid for underlying types with destructors (e.g. `String`).

## Solution

Update the generated `SolTypeValue` implementation to delegate to the underlying `SolTypeValue` methods instead of the corresponding `SolType` methods.

Additionally:
- Remove the unnecessary `const` qualifier from `into_underlying`.
- Add a regression test covering a UDVT wrapping `string` to verify the generated type compiles successfully and reports the correct packed encoded size.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes