### PR TITLE
fix(dyn-abi): correct packed encoded size for Function

### DIFF
--- a/crates/dyn-abi/src/dynamic/ty.rs
+++ b/crates/dyn-abi/src/dynamic/ty.rs
@@ -699,6 +699,25 @@ mod tests {
     }
 
     #[test]
+    fn test_function_packed_encoding_size() {
+        use alloy_primitives::Function;
+
+        let addr = Address::repeat_byte(0x01);
+        let val_addr = DynSolValue::Address(addr);
+        assert_eq!(val_addr.abi_packed_encoded_size(), 20);
+        assert_eq!(val_addr.abi_encode_packed().len(), val_addr.abi_packed_encoded_size());
+
+        let func = Function::from((addr, [0x02; 4]));
+        let val_func = DynSolValue::Function(func);
+        assert_eq!(val_func.abi_packed_encoded_size(), 24);
+        assert_eq!(val_func.abi_encode_packed().len(), val_func.abi_packed_encoded_size());
+
+        let val_array = DynSolValue::Array(vec![val_func.clone(), val_func]);
+        assert_eq!(val_array.abi_packed_encoded_size(), 64);
+        assert_eq!(val_array.abi_encode_packed().len(), val_array.abi_packed_encoded_size());
+    }
+
+    #[test]
     fn tuple_matches_rejects_short_values() {
         let ty = DynSolType::Tuple(vec![DynSolType::Uint(256), DynSolType::Bool]);
         let value = DynSolValue::Tuple(vec![DynSolValue::Uint(U256::ZERO, 256)]);

--- a/crates/dyn-abi/src/dynamic/value.rs
+++ b/crates/dyn-abi/src/dynamic/value.rs
@@ -733,7 +733,8 @@ impl DynSolValue {
     /// See [`abi_encode_packed`](Self::abi_encode_packed) for more details.
     pub fn abi_packed_encoded_size(&self) -> usize {
         match self {
-            Self::Address(_) | Self::Function(_) => 20,
+            Self::Address(_) => 20,
+            Self::Function(_) => 24,
             Self::Bool(_) => 1,
             Self::String(s) => s.len(),
             Self::Bytes(b) => b.len(),


### PR DESCRIPTION
## Motivation

`DynSolValue::abi_packed_encoded_size()` returned `20` bytes for `Function` values by grouping them with `Address`, even though Solidity function pointers occupy `24` bytes (20-byte address + 4-byte selector).

This caused two issues:

1. The initial buffer size for packed encoding was underestimated by 4 bytes per function.
2. The reported packed encoded size was inconsistent with the actual encoding, which also affects padding calculations performed during packed encoding of arrays of function values.

## Solution

- Return `24` for `DynSolValue::Function` in `abi_packed_encoded_size()`, while keeping `Address` at `20`.
- Add a regression test verifying:
  - `Address` reports the correct packed encoded size.
  - `Function` reports the correct packed encoded size.
  - The reported packed encoded size matches the length of `abi_encode_packed()`.
  - Arrays of `Function` values report the expected packed encoded size and encoded length.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes