### PR TITLE
fix(json-abi): dedup canonical signatures

### DIFF
--- a/crates/json-abi/src/abi.rs
+++ b/crates/json-abi/src/abi.rs
@@ -2,7 +2,11 @@ use crate::{
     AbiItem, Constructor, Error, Event, Fallback, Function, Receive,
     to_sol::{SolPrinter, ToSolConfig},
 };
-use alloc::{collections::btree_map, string::String, vec::Vec};
+use alloc::{
+    collections::{BTreeSet, btree_map},
+    string::String,
+    vec::Vec,
+};
 use alloy_primitives::{Bytes, Selector};
 use btree_map::BTreeMap;
 use core::{fmt, iter, iter::Flatten};
@@ -32,6 +36,11 @@ macro_rules! entry_and_push {
 type FlattenValues<'a, V> = Flatten<btree_map::Values<'a, String, Vec<V>>>;
 type FlattenValuesMut<'a, V> = Flatten<btree_map::ValuesMut<'a, String, Vec<V>>>;
 type FlattenIntoValues<V> = Flatten<btree_map::IntoValues<String, Vec<V>>>;
+
+fn dedup_by_signature<T>(items: &mut Vec<T>, signature: impl Fn(&T) -> String) {
+    let mut signatures = BTreeSet::new();
+    items.retain(|item| signatures.insert(signature(item)));
+}
 
 /// The JSON contract ABI, as specified in the [Solidity ABI spec][ref].
 ///
@@ -212,25 +221,16 @@ impl JsonAbi {
         SolPrinter::new(out, name, config.unwrap_or_default()).print(self);
     }
 
-    /// Deduplicates all functions, errors, and events which have the same name and inputs.
+    /// Deduplicates all functions, errors, and events with the same canonical signature.
     pub fn dedup(&mut self) {
-        macro_rules! same_bucket {
-            () => {
-                |a, b| {
-                    // Already grouped by name
-                    debug_assert_eq!(a.name, b.name);
-                    a.inputs == b.inputs
-                }
-            };
-        }
         for functions in self.functions.values_mut() {
-            functions.dedup_by(same_bucket!());
+            dedup_by_signature(functions, Function::signature);
         }
         for errors in self.errors.values_mut() {
-            errors.dedup_by(same_bucket!());
+            dedup_by_signature(errors, Error::signature);
         }
         for events in self.events.values_mut() {
-            events.dedup_by(same_bucket!());
+            dedup_by_signature(events, Event::signature);
         }
     }
 

--- a/crates/json-abi/src/abi.rs
+++ b/crates/json-abi/src/abi.rs
@@ -2,11 +2,7 @@ use crate::{
     AbiItem, Constructor, Error, Event, Fallback, Function, Receive,
     to_sol::{SolPrinter, ToSolConfig},
 };
-use alloc::{
-    collections::{BTreeSet, btree_map},
-    string::String,
-    vec::Vec,
-};
+use alloc::{collections::btree_map, string::String, vec::Vec};
 use alloy_primitives::{Bytes, Selector};
 use btree_map::BTreeMap;
 use core::{fmt, iter, iter::Flatten};
@@ -36,11 +32,6 @@ macro_rules! entry_and_push {
 type FlattenValues<'a, V> = Flatten<btree_map::Values<'a, String, Vec<V>>>;
 type FlattenValuesMut<'a, V> = Flatten<btree_map::ValuesMut<'a, String, Vec<V>>>;
 type FlattenIntoValues<V> = Flatten<btree_map::IntoValues<String, Vec<V>>>;
-
-fn dedup_by_signature<T>(items: &mut Vec<T>, signature: impl Fn(&T) -> String) {
-    let mut signatures = BTreeSet::new();
-    items.retain(|item| signatures.insert(signature(item)));
-}
 
 /// The JSON contract ABI, as specified in the [Solidity ABI spec][ref].
 ///
@@ -223,14 +214,23 @@ impl JsonAbi {
 
     /// Deduplicates all functions, errors, and events with the same canonical signature.
     pub fn dedup(&mut self) {
+        macro_rules! same_bucket {
+            () => {
+                |a, b| {
+                    // Already grouped by name
+                    debug_assert_eq!(a.name, b.name);
+                    a.signature() == b.signature()
+                }
+            };
+        }
         for functions in self.functions.values_mut() {
-            dedup_by_signature(functions, Function::signature);
+            functions.dedup_by(same_bucket!());
         }
         for errors in self.errors.values_mut() {
-            dedup_by_signature(errors, Error::signature);
+            errors.dedup_by(same_bucket!());
         }
         for events in self.events.values_mut() {
-            dedup_by_signature(events, Event::signature);
+            events.dedup_by(same_bucket!());
         }
     }
 

--- a/crates/json-abi/tests/abi.rs
+++ b/crates/json-abi/tests/abi.rs
@@ -72,14 +72,14 @@ fn abi_test(s: &str, path: &str, run_solc: bool) {
 fn dedup_uses_canonical_signatures() {
     let mut abi = JsonAbi::parse([
         "function foo(uint256 first)",
-        "function foo(address other)",
         "function foo(uint256 second)",
+        "function foo(address other)",
         "error DuplicateError(uint256 first)",
-        "error DuplicateError(address other)",
         "error DuplicateError(uint256 second)",
+        "error DuplicateError(address other)",
         "event DuplicateEvent(uint256 indexed first)",
-        "event DuplicateEvent(address indexed other)",
         "event DuplicateEvent(uint256 indexed second)",
+        "event DuplicateEvent(address indexed other)",
     ])
     .unwrap();
 

--- a/crates/json-abi/tests/abi.rs
+++ b/crates/json-abi/tests/abi.rs
@@ -68,6 +68,45 @@ fn abi_test(s: &str, path: &str, run_solc: bool) {
     iterator_test(abi1.clone().into_items(), abi1.into_items().rev(), len);
 }
 
+#[test]
+fn dedup_uses_canonical_signatures() {
+    let mut abi = JsonAbi::parse([
+        "function foo(uint256 first)",
+        "function foo(address other)",
+        "function foo(uint256 second)",
+        "error DuplicateError(uint256 first)",
+        "error DuplicateError(address other)",
+        "error DuplicateError(uint256 second)",
+        "event DuplicateEvent(uint256 indexed first)",
+        "event DuplicateEvent(address indexed other)",
+        "event DuplicateEvent(uint256 indexed second)",
+    ])
+    .unwrap();
+
+    abi.dedup();
+
+    let functions = abi.function("foo").unwrap();
+    assert_eq!(
+        functions.iter().map(|item| item.signature()).collect::<Vec<_>>(),
+        ["foo(uint256)", "foo(address)",]
+    );
+    assert_eq!(functions[0].inputs[0].name, "first");
+
+    let errors = abi.error("DuplicateError").unwrap();
+    assert_eq!(
+        errors.iter().map(|item| item.signature()).collect::<Vec<_>>(),
+        ["DuplicateError(uint256)", "DuplicateError(address)",]
+    );
+    assert_eq!(errors[0].inputs[0].name, "first");
+
+    let events = abi.event("DuplicateEvent").unwrap();
+    assert_eq!(
+        events.iter().map(|item| item.signature()).collect::<Vec<_>>(),
+        ["DuplicateEvent(uint256)", "DuplicateEvent(address)",]
+    );
+    assert_eq!(events[0].inputs[0].name, "first");
+}
+
 #[cfg(all(feature = "std", feature = "serde_json"))]
 fn load_test(path: &str, abi: &JsonAbi) {
     use std::{fs::File, io::BufReader};


### PR DESCRIPTION
## Motivation

`JsonAbi::dedup` compares complete ABI parameters, so inherited declarations with the same canonical signature are retained when only parameter metadata such as names differs. Passing such an ABI to `sol!` then produces duplicate items. In Foundry, this makes `forge bind` panic for the reproduction in https://github.com/foundry-rs/foundry/issues/11538.

## Solution

Keep the existing `Vec::dedup_by` flow, but compare canonical signatures instead of complete parameter metadata. The regression test covers all three item kinds, different parameter names, and retaining distinct overloads.