### PR TITLE
fix(sol-macro): derive namespaced custom types

### DIFF
--- a/crates/sol-macro-expander/src/expand/mod.rs
+++ b/crates/sol-macro-expander/src/expand/mod.rs
@@ -76,25 +76,35 @@ impl<T> NamespacedMap<T> {
 
     /// Given [SolPath] and current namespace, resolves item
     pub fn resolve(&self, path: &SolPath, current_namespace: &Option<SolIdent>) -> Option<&T> {
+        self.resolve_entry(path, current_namespace).map(|(_, value)| value)
+    }
+
+    /// Resolves an item and returns the namespace it was found in.
+    fn resolve_entry(
+        &self,
+        path: &SolPath,
+        current_namespace: &Option<SolIdent>,
+    ) -> Option<(&Option<SolIdent>, &T)> {
         // If path contains two components, its `Contract.Something` where `Contract` is a namespace
         if path.len() == 2 {
-            self.get_by_name_and_namespace(&Some(path.first().clone()), path.last())
+            self.get_entry_by_name_and_namespace(&Some(path.first().clone()), path.last())
         } else {
             // If there's only one component, this is either global item, or item declared in the
             // current namespace.
             //
             // NOTE: This does not account for inheritance
-            self.get_by_name_and_namespace(&None, path.last())
-                .or_else(|| self.get_by_name_and_namespace(current_namespace, path.last()))
+            self.get_entry_by_name_and_namespace(&None, path.last())
+                .or_else(|| self.get_entry_by_name_and_namespace(current_namespace, path.last()))
         }
     }
 
-    fn get_by_name_and_namespace(
+    fn get_entry_by_name_and_namespace(
         &self,
         namespace: &Option<SolIdent>,
         name: &SolIdent,
-    ) -> Option<&T> {
-        self.0.get(namespace).and_then(|vals| vals.get(name))
+    ) -> Option<(&Option<SolIdent>, &T)> {
+        let (namespace, values) = self.0.get_key_value(namespace)?;
+        values.get(name).map(|value| (namespace, value))
     }
 }
 
@@ -537,7 +547,17 @@ impl<'ast> ExpCtxt<'ast> {
     }
 
     fn try_item(&self, name: &SolPath) -> Option<&Item> {
-        self.all_items.resolve(name, &self.current_namespace).copied()
+        self.try_item_in_namespace(name, &self.current_namespace).map(|(_, item)| item)
+    }
+
+    fn try_item_in_namespace(
+        &self,
+        name: &SolPath,
+        current_namespace: &Option<SolIdent>,
+    ) -> Option<(&Option<SolIdent>, &Item)> {
+        self.all_items
+            .resolve_entry(name, current_namespace)
+            .map(|(namespace, item)| (namespace, *item))
     }
 
     fn custom_type(&self, name: &SolPath) -> &Type {

--- a/crates/sol-macro-expander/src/expand/ty.rs
+++ b/crates/sol-macro-expander/src/expand/ty.rs
@@ -1,7 +1,7 @@
 //! [`Type`] expansion.
 
 use super::ExpCtxt;
-use ast::{Item, Parameters, Spanned, Type, TypeArray};
+use ast::{Item, Parameters, SolIdent, Spanned, Type, TypeArray};
 use proc_macro_error3::{abort, emit_error};
 use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::{ToTokens, quote_spanned};
@@ -228,35 +228,54 @@ impl ExpCtxt<'_> {
 
     /// Returns whether the given type can derive the [`Default`] trait.
     pub(crate) fn can_derive_default(&self, ty: &Type) -> bool {
+        self.can_derive_default_in_namespace(ty, &self.current_namespace)
+    }
+
+    fn can_derive_default_in_namespace(
+        &self,
+        ty: &Type,
+        current_namespace: &Option<SolIdent>,
+    ) -> bool {
         match ty {
             Type::Array(a) => match self.eval_array_size(a) {
                 // Dynamic arrays are `Vec<T>`, whose `Default` impl holds for any `T`.
                 None => true,
                 // Fixed arrays are `[T; N]`: `Default` needs `T: Default` and `N <= 32`.
-                Some(sz) => sz <= MAX_SUPPORTED_ARRAY_LEN && self.can_derive_default(&a.ty),
+                Some(sz) => {
+                    sz <= MAX_SUPPORTED_ARRAY_LEN
+                        && self.can_derive_default_in_namespace(&a.ty, current_namespace)
+                }
             },
             Type::Tuple(tuple) => {
                 if tuple.types.len() > MAX_SUPPORTED_TUPLE_LEN {
                     false
                 } else {
-                    tuple.types.iter().all(|ty| self.can_derive_default(ty))
+                    tuple
+                        .types
+                        .iter()
+                        .all(|ty| self.can_derive_default_in_namespace(ty, current_namespace))
                 }
             }
 
-            Type::Custom(name) => match self.try_item(name) {
-                Some(Item::Contract(_)) => true,
-                Some(Item::Enum(_)) => false,
-                Some(Item::Error(error)) => {
-                    error.parameters.types().all(|ty| self.can_derive_default(ty))
+            Type::Custom(name) => match self.try_item_in_namespace(name, current_namespace) {
+                Some((_, Item::Contract(_))) => true,
+                Some((_, Item::Enum(_))) => false,
+                Some((namespace, Item::Error(error))) => error
+                    .parameters
+                    .types()
+                    .all(|ty| self.can_derive_default_in_namespace(ty, namespace)),
+                Some((namespace, Item::Event(event))) => event
+                    .parameters
+                    .iter()
+                    .all(|p| self.can_derive_default_in_namespace(&p.ty, namespace)),
+                Some((namespace, Item::Struct(strukt))) => strukt
+                    .fields
+                    .types()
+                    .all(|ty| self.can_derive_default_in_namespace(ty, namespace)),
+                Some((namespace, Item::Udt(udt))) => {
+                    self.can_derive_default_in_namespace(&udt.ty, namespace)
                 }
-                Some(Item::Event(event)) => {
-                    event.parameters.iter().all(|p| self.can_derive_default(&p.ty))
-                }
-                Some(Item::Struct(strukt)) => {
-                    strukt.fields.types().all(|ty| self.can_derive_default(ty))
-                }
-                Some(Item::Udt(udt)) => self.can_derive_default(&udt.ty),
-                Some(item) => abort!(item.span(), "Invalid type in struct field: {:?}", item),
+                Some((_, item)) => abort!(item.span(), "Invalid type in struct field: {:?}", item),
                 _ => false,
             },
 
@@ -267,29 +286,44 @@ impl ExpCtxt<'_> {
     /// Returns whether the given type can derive the builtin traits listed in
     /// `ExprCtxt::derives`, minus `Default`.
     pub(crate) fn can_derive_builtin_traits(&self, ty: &Type) -> bool {
+        self.can_derive_builtin_traits_in_namespace(ty, &self.current_namespace)
+    }
+
+    fn can_derive_builtin_traits_in_namespace(
+        &self,
+        ty: &Type,
+        current_namespace: &Option<SolIdent>,
+    ) -> bool {
         match ty {
-            Type::Array(a) => self.can_derive_builtin_traits(&a.ty),
+            Type::Array(a) => self.can_derive_builtin_traits_in_namespace(&a.ty, current_namespace),
             Type::Tuple(tuple) => {
                 if tuple.types.len() > MAX_SUPPORTED_TUPLE_LEN {
                     false
                 } else {
-                    tuple.types.iter().all(|ty| self.can_derive_builtin_traits(ty))
+                    tuple.types.iter().all(|ty| {
+                        self.can_derive_builtin_traits_in_namespace(ty, current_namespace)
+                    })
                 }
             }
 
-            Type::Custom(name) => match self.try_item(name) {
-                Some(Item::Contract(_)) | Some(Item::Enum(_)) => true,
-                Some(Item::Error(error)) => {
-                    error.parameters.types().all(|ty| self.can_derive_builtin_traits(ty))
+            Type::Custom(name) => match self.try_item_in_namespace(name, current_namespace) {
+                Some((_, Item::Contract(_))) | Some((_, Item::Enum(_))) => true,
+                Some((namespace, Item::Error(error))) => error
+                    .parameters
+                    .types()
+                    .all(|ty| self.can_derive_builtin_traits_in_namespace(ty, namespace)),
+                Some((namespace, Item::Event(event))) => event
+                    .parameters
+                    .iter()
+                    .all(|p| self.can_derive_builtin_traits_in_namespace(&p.ty, namespace)),
+                Some((namespace, Item::Struct(strukt))) => strukt
+                    .fields
+                    .types()
+                    .all(|ty| self.can_derive_builtin_traits_in_namespace(ty, namespace)),
+                Some((namespace, Item::Udt(udt))) => {
+                    self.can_derive_builtin_traits_in_namespace(&udt.ty, namespace)
                 }
-                Some(Item::Event(event)) => {
-                    event.parameters.iter().all(|p| self.can_derive_builtin_traits(&p.ty))
-                }
-                Some(Item::Struct(strukt)) => {
-                    strukt.fields.types().all(|ty| self.can_derive_builtin_traits(ty))
-                }
-                Some(Item::Udt(udt)) => self.can_derive_builtin_traits(&udt.ty),
-                Some(item) => abort!(item.span(), "Invalid type in struct field: {:?}", item),
+                Some((_, item)) => abort!(item.span(), "Invalid type in struct field: {:?}", item),
                 _ => false,
             },
 

--- a/crates/sol-types/tests/derives.rs
+++ b/crates/sol-types/tests/derives.rs
@@ -46,6 +46,54 @@ fn test_all_derives() {
     assert_eq!(errors_set.len(), 1);
 }
 
+mod namespaced_custom_types {
+    use super::*;
+
+    sol! {
+        #![sol(all_derives)]
+
+        library External {
+            struct Something {
+                AnotherThing value;
+            }
+
+            struct AnotherThing {
+                uint64 number;
+            }
+
+            struct WithEnum {
+                Status status;
+            }
+
+            struct WithEnumVec {
+                Status[] statuses;
+            }
+
+            enum Status {
+                A,
+                B
+            }
+        }
+
+        contract UsesExternal {
+            event EmittedLog(External.Something value);
+            event EnumLog(External.WithEnum value);
+            event EnumVecLog(External.WithEnumVec value);
+        }
+    }
+
+    #[test]
+    fn test_all_derives_namespaced_custom_types() {
+        fn assert_all_derives<T: Default + std::fmt::Debug + PartialEq + Eq + Hash>() {}
+        fn assert_builtin_derives<T: std::fmt::Debug + PartialEq + Eq + Hash>() {}
+
+        assert_all_derives::<UsesExternal::EmittedLog>();
+        assert_builtin_derives::<UsesExternal::EnumLog>();
+        assert_all_derives::<UsesExternal::EnumVecLog>();
+        assert_builtin_derives::<UsesExternal::UsesExternalEvents>();
+    }
+}
+
 #[test]
 fn test_extra_derives() {
     sol! {


### PR DESCRIPTION
## Motivation

`#[sol(all_derives)]` skips the built-in derives on events that reference a namespace-qualified struct when that struct contains an unqualified sibling custom type. The eligibility walk resolves the nested field from the consuming namespace instead of the namespace where the outer struct was declared. This is visible in generated Foundry bindings as an empty derive list on the event.

Addresses foundry-rs/foundry#10353.

## Solution

Return the namespace selected during item lookup and carry it through the recursive `Default` and built-in trait eligibility checks. This keeps the existing nominal rules intact, including enums not implementing `Default` directly while dynamic arrays of enums can. The regression covers the original nested struct case, the enum distinction, and the generated contract event enum.
