### PR TITLE
feat(primitives): use foldhash for fixed-size maps

### DIFF
--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -95,7 +95,7 @@ hashbrown = { workspace = true, optional = true, features = [
 indexmap = { workspace = true, optional = true }
 foldhash = { workspace = true, optional = true }
 rapidhash = { workspace = true, optional = true }
-rustc-hash.workspace = true # Always on for FbHasher
+rustc-hash = { workspace = true, optional = true }
 
 # arbitrary
 arbitrary = { workspace = true, optional = true, features = ["derive"] }
@@ -137,7 +137,7 @@ std = [
     "proptest?/std",
     "rand?/std",
     "rand?/thread_rng",
-    "rustc-hash/std",
+    "rustc-hash?/std",
     "serde?/std",
     "fixed-cache?/std",
 ]
@@ -161,12 +161,12 @@ keccak-cache = ["std", "dep:rapidhash", "dep:fixed-cache"]
 keccak-cache-global = ["keccak-cache"]
 keccak-cache-stats = ["keccak-cache", "fixed-cache/stats"]
 
-map = ["dep:hashbrown"]
+map = ["dep:hashbrown", "dep:foldhash"]
 map-hashbrown = ["map"]
 map-indexmap = ["map", "dep:indexmap"]
 map-foldhash = ["map", "dep:foldhash"]
 map-rapidhash = ["map", "dep:rapidhash"]
-map-fxhash = ["map"]
+map-fxhash = ["map", "dep:rustc-hash"]
 
 getrandom = ["dep:getrandom"]
 k256 = ["dep:k256"]
@@ -176,7 +176,7 @@ rand = [
     "getrandom",
     "ruint/rand-09",
     "rapidhash?/rand",
-    "rustc-hash/rand",
+    "rustc-hash?/rand",
 ]
 rayon = ["dep:rayon", "hashbrown?/rayon", "indexmap?/rayon"]
 rkyv = ["dep:rkyv", "ruint/rkyv"]

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -14,7 +14,6 @@
 extern crate alloc;
 
 use paste as _;
-use rustc_hash as _;
 use sha3 as _;
 #[cfg(feature = "tiny-keccak")]
 use tiny_keccak as _;

--- a/crates/primitives/src/map/fixed.rs
+++ b/crates/primitives/src/map/fixed.rs
@@ -52,12 +52,14 @@ macro_rules! fb_alias_maps {
 
 fb_alias_maps!(Selector<4>, Address<20>, B256<32>, U256<32>);
 
-type FbBuildHasherInner = super::FxBuildHasherInner;
-type FbHasherInner = rustc_hash::FxHasher;
+type FbBuildHasherInner = foldhash::fast::RandomState;
+type FbHasherInner = foldhash::fast::FoldHasher<'static>;
 
 /// [`BuildHasher`] optimized for hashing [fixed-size byte arrays](FixedBytes).
 ///
 /// **NOTE:** this hasher accepts only `N`-length byte arrays! It is invalid to hash anything else.
+///
+/// The hasher uses the randomly initialized fast foldhash state.
 #[derive(Clone, Default)]
 pub struct FbBuildHasher<const N: usize> {
     inner: FbBuildHasherInner,
@@ -114,7 +116,7 @@ impl<const N: usize> Hasher for FbHasher<N> {
     fn write(&mut self, bytes: &[u8]) {
         // SAFETY: Precondition.
         unsafe { core::hint::assert_unchecked(bytes.len() == N) };
-        // Threshold decided by some basic micro-benchmarks with fxhash.
+        // Avoid slice overhead for short fixed-size inputs.
         if N > 32 {
             self.inner.write(bytes);
         } else {

--- a/crates/primitives/src/map/fixed.rs
+++ b/crates/primitives/src/map/fixed.rs
@@ -58,8 +58,6 @@ type FbHasherInner = foldhash::fast::FoldHasher<'static>;
 /// [`BuildHasher`] optimized for hashing [fixed-size byte arrays](FixedBytes).
 ///
 /// **NOTE:** this hasher accepts only `N`-length byte arrays! It is invalid to hash anything else.
-///
-/// The hasher uses the randomly initialized fast foldhash state.
 #[derive(Clone, Default)]
 pub struct FbBuildHasher<const N: usize> {
     inner: FbBuildHasherInner,

--- a/crates/primitives/src/map/hasher.rs
+++ b/crates/primitives/src/map/hasher.rs
@@ -16,7 +16,8 @@ cfg_if! {
     }
 }
 
-// Used by `FbHasher`.
+// Used by the optional `FxBuildHasher`.
+#[cfg(feature = "map-fxhash")]
 cfg_if! {
     if #[cfg(all(feature = "std", feature = "rand"))] {
         pub(super) use rustc_hash::FxRandomState as FxBuildHasherInner;


### PR DESCRIPTION
Fixed-size map aliases such as U256Map now use foldhash's fast RandomState through FbBuildHasher instead of FxHash. The fixed-byte map aliases retain their existing API and specialized hashing path, while foldhash supplies randomized per-builder state in both std and no_std builds. The old rustc-hash dependency is now only needed when map-fxhash is enabled.

Generic map::HashMap defaults remain unchanged. The fixed-map test suite, feature checks, and workspace compilation pass.
