### PR TITLE
fix(primitives): return Err on parse_units multiply overflow

### DIFF
--- a/crates/primitives/src/utils/units.rs
+++ b/crates/primitives/src/utils/units.rs
@@ -273,17 +273,23 @@ impl ParseUnits {
             if amount == "-" {
                 Ok(Self::I256(I256::ZERO))
             } else {
-                let mut n = I256::from_dec_str(amount)?;
-                n *= I256::try_from(10u8)
+                let n = I256::from_dec_str(amount)?;
+                let multiplier = I256::try_from(10u8)
                     .unwrap()
                     .checked_pow(U256::from(exponent - dec_len))
+                    .ok_or(UnitsError::ParseSigned(ParseSignedError::IntegerOverflow))?;
+                let n = n
+                    .checked_mul(multiplier)
                     .ok_or(UnitsError::ParseSigned(ParseSignedError::IntegerOverflow))?;
                 Ok(Self::I256(n))
             }
         } else {
-            let mut a_uint = U256::from_str_radix(amount, 10)?;
-            a_uint *= U256::from(10)
+            let a_uint = U256::from_str_radix(amount, 10)?;
+            let multiplier = U256::from(10)
                 .checked_pow(U256::from(exponent - dec_len))
+                .ok_or(UnitsError::ParseSigned(ParseSignedError::IntegerOverflow))?;
+            let a_uint = a_uint
+                .checked_mul(multiplier)
                 .ok_or(UnitsError::ParseSigned(ParseSignedError::IntegerOverflow))?;
             Ok(Self::U256(a_uint))
         }
@@ -802,6 +808,21 @@ mod tests {
 
         let n: U256 = parse_units("", 3).unwrap().into();
         assert_eq!(n, U256::ZERO, "empty");
+    }
+
+    #[test]
+    fn test_parse_units_mul_overflow() {
+        // Regression: `10^exponent` fits in the target integer (so `checked_pow` succeeds) but
+        // multiplying it by the mantissa overflows. This must return `Err`, matching the
+        // documented behavior for out-of-range inputs (e.g. `parse_units("1", 80)`), instead of
+        // silently wrapping to a wrong value (unsigned `U256`, all profiles) or panicking on the
+        // `debug_assert!` in `Signed::mul` (signed `I256`, debug profile).
+
+        // Unsigned: `10^77 < U256::MAX < 2 * 10^77`, so `2 * 10^77` overflows `U256`.
+        assert!(parse_units("2", 77).is_err(), "unsigned mantissa*10^n overflow must be Err");
+
+        // Signed: `10^76 < I256::MAX < 6 * 10^76`, so `-6 * 10^76` overflows `I256`.
+        assert!(parse_units("-6", 76).is_err(), "signed mantissa*10^n overflow must be Err");
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`ParseUnits::parse_units` returns a `Result` and is documented/tested to reject out-of-range inputs with an `Err` — see the existing `assert!(parse_units("1", 80).is_err(), "overflow")` test. It correctly guards the `10^exponent` factor with `checked_pow`, but then folds that factor into the parsed mantissa with an **unchecked** `*=`:

```rust
let mut a_uint = U256::from_str_radix(amount, 10)?;
a_uint *= U256::from(10)
    .checked_pow(U256::from(exponent - dec_len))
    .ok_or(UnitsError::ParseSigned(ParseSignedError::IntegerOverflow))?;
```

When `10^exponent` fits in the target integer (so `checked_pow` succeeds) but `mantissa * 10^exponent` does **not**, the overflow is silently swallowed:

- **Unsigned `U256`**: ruint implements `Mul`/`MulAssign` via `wrapping_mul`, so the multiply wraps to a wrong value in **every** build profile. For example `parse_units("2", 77)` — `10^77 < U256::MAX < 2·10^77` — returns `Ok(<wrapped garbage>)` instead of `Err`.
- **Signed `I256`**: `Signed::mul` uses `debug_assert!(!overflow)`, so the equivalent input panics in debug builds and silently wraps in release. For example `parse_units("-6", 76)` (`10^76 < I256::MAX < 6·10^76`).

Both outcomes contradict the intended contract (graceful `Err` on overflow).

## Solution

Replace the unchecked `*=` with `checked_mul` on both the unsigned and signed paths, propagating the same `UnitsError::ParseSigned(ParseSignedError::IntegerOverflow)` already used for the `checked_pow` guard. Minimal change, no new error variants.

Adds a regression test (`test_parse_units_mul_overflow`) covering the unsigned wrap and signed overflow paths. It fails before this change (unsigned returns `Ok`; signed panics in debug) and passes after.

## Testing

`cargo test -p alloy-primitives --lib utils::units` — all pass. `cargo +nightly fmt --check` clean.
