### PR TITLE
fix(dyn-abi): coerce JSON int values above i64::MAX for signed types

### DIFF
--- a/crates/dyn-abi/src/eip712/coerce.rs
+++ b/crates/dyn-abi/src/eip712/coerce.rs
@@ -61,6 +61,9 @@ fn int(n: usize, value: &serde_json::Value) -> Option<I256> {
         if let Some(num) = value.as_i64() {
             return Some(I256::try_from(num).unwrap());
         }
+        if let Some(num) = value.as_u64() {
+            return Some(I256::try_from(num).unwrap());
+        }
         value.as_str().and_then(|s| s.parse().ok())
     })()
     .and_then(|x| (x.bits() <= n as u32).then_some(x))
@@ -200,6 +203,17 @@ mod tests {
         let ty = DynSolType::FixedBytes(2);
         let j = json!("0x123456");
         assert!(ty.coerce_json(&j).is_err());
+    }
+
+    #[test]
+    fn int_coerces_json_number_above_i64_max() {
+        // serde_json stores this as a u64 (it exceeds i64::MAX), but it is a valid
+        // positive int128. The number form must coerce the same as the string form.
+        let n: u64 = 9223372036854775808; // 2^63
+        let ty = DynSolType::Int(128);
+        let want = DynSolValue::Int("9223372036854775808".parse().unwrap(), 128);
+        assert_eq!(ty.coerce_json(&json!(n.to_string())).unwrap(), want);
+        assert_eq!(ty.coerce_json(&json!(n)).unwrap(), want);
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`eip712` JSON coercion reads signed integers only through `serde_json`'s `as_i64`, while the sibling `uint` path uses `as_u64`. `serde_json` stores any integer literal in `(i64::MAX, u64::MAX]` as a `u64`, so a valid positive value for `int72..int256` — e.g. `2^63` coerced to `int128` — never reaches the bounds check and `coerce_json` fails with a `TypeMismatch`, even though:

- the same value coerces fine as a JSON **string** (the `FromStr` path), and
- `uint` accepts the same JSON **number**.

So `int128` accepts `9223372036854775808` as a string but rejects the identical JSON number.

## Solution

Add a `u64` fallback in `int()` mirroring `uint()` — a `u64` always fits positively in `I256`, so `I256::try_from(num)` cannot fail here. The bounds check (`x.bits() <= n`) is unchanged.

## Verification

New regression test `int_coerces_json_number_above_i64_max` asserts the number form coerces identically to the string form for `Int(128)`. It fails on `main`:

```
TypeMismatch { expected: "int128", actual: "9223372036854775808" }
```

and passes with the fix. `cargo test -p alloy-dyn-abi --features eip712 eip712::coerce` → 4 passed.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation — n/a
- [ ] Breaking changes — none (widens accepted inputs only)