### PR TITLE
perf: manual Ord for FixedBytes using integer chunk comparison

### DIFF
--- a/crates/primitives/benches/primitives.rs
+++ b/crates/primitives/benches/primitives.rs
@@ -2,7 +2,7 @@
 
 use alloy_primitives::{Address, B256, keccak256};
 use criterion::{Criterion, criterion_group, criterion_main};
-use std::hint::black_box;
+use std::{collections::BTreeMap, hint::black_box};
 
 fn primitives(c: &mut Criterion) {
     let mut g = c.benchmark_group("primitives");
@@ -24,5 +24,89 @@ fn primitives(c: &mut Criterion) {
     g.finish();
 }
 
-criterion_group!(benches, primitives);
+/// Baseline for the `Ord` benchmarks: byte-slice comparison, which is what the
+/// derived `Ord` implementation produced (lowers to a `memcmp` libcall).
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct SliceOrd<const N: usize>([u8; N]);
+
+impl<const N: usize> PartialOrd for SliceOrd<N> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<const N: usize> Ord for SliceOrd<N> {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.0.as_slice().cmp(other.0.as_slice())
+    }
+}
+
+fn fixed_bytes_ord(c: &mut Criterion) {
+    let mut g = c.benchmark_group("fixed_bytes_ord");
+
+    // Raw comparison throughput over random pairs (~50% of real map-search
+    // comparisons decide on the first chunk; random pairs model that).
+    let address_pairs: Vec<(Address, Address)> =
+        (0..1024).map(|_| (Address::random(), Address::random())).collect();
+    let address_slice_pairs: Vec<(SliceOrd<20>, SliceOrd<20>)> =
+        address_pairs.iter().map(|(x, y)| (SliceOrd(x.0.0), SliceOrd(y.0.0))).collect();
+    g.bench_function("address/cmp/chunked", |b| {
+        b.iter(|| {
+            for (x, y) in &address_pairs {
+                black_box(x.cmp(y));
+            }
+        })
+    });
+    g.bench_function("address/cmp/slice_baseline", |b| {
+        b.iter(|| {
+            for (x, y) in &address_slice_pairs {
+                black_box(x.cmp(y));
+            }
+        })
+    });
+
+    let b256_pairs: Vec<(B256, B256)> =
+        (0..1024).map(|_| (B256::random(), B256::random())).collect();
+    let b256_slice_pairs: Vec<(SliceOrd<32>, SliceOrd<32>)> =
+        b256_pairs.iter().map(|(x, y)| (SliceOrd(x.0), SliceOrd(y.0))).collect();
+    g.bench_function("b256/cmp/chunked", |b| {
+        b.iter(|| {
+            for (x, y) in &b256_pairs {
+                black_box(x.cmp(y));
+            }
+        })
+    });
+    g.bench_function("b256/cmp/slice_baseline", |b| {
+        b.iter(|| {
+            for (x, y) in &b256_slice_pairs {
+                black_box(x.cmp(y));
+            }
+        })
+    });
+
+    // Real-world shape: BTreeMap keyed by Address, hit lookups.
+    let keys: Vec<Address> = (0..100_000).map(|_| Address::random()).collect();
+    let map: BTreeMap<Address, u64> =
+        keys.iter().enumerate().map(|(i, k)| (*k, i as u64)).collect();
+    let slice_map: BTreeMap<SliceOrd<20>, u64> =
+        keys.iter().enumerate().map(|(i, k)| (SliceOrd(k.0.0), i as u64)).collect();
+    g.bench_function("address/btreemap_get/chunked", |b| {
+        let mut i = 0;
+        b.iter(|| {
+            i = (i + 1) % keys.len();
+            black_box(map.get(black_box(&keys[i])));
+        })
+    });
+    g.bench_function("address/btreemap_get/slice_baseline", |b| {
+        let mut i = 0;
+        b.iter(|| {
+            i = (i + 1) % keys.len();
+            black_box(slice_map.get(black_box(&SliceOrd(keys[i].0.0))));
+        })
+    });
+
+    g.finish();
+}
+
+criterion_group!(benches, primitives, fixed_bytes_ord);
 criterion_main!(benches);

--- a/crates/primitives/benches/primitives.rs
+++ b/crates/primitives/benches/primitives.rs
@@ -1,6 +1,6 @@
 #![allow(unknown_lints, clippy::incompatible_msrv, missing_docs)]
 
-use alloy_primitives::{Address, B256, keccak256};
+use alloy_primitives::{Address, B256, FixedBytes, keccak256};
 use criterion::{Criterion, criterion_group, criterion_main};
 use std::{collections::BTreeMap, hint::black_box};
 
@@ -41,48 +41,99 @@ impl<const N: usize> Ord for SliceOrd<N> {
     }
 }
 
+/// Unconditional chunked comparison (no `memcmp` fallback for large `N`),
+/// mirroring `FixedBytes::cmp` below its cutoff. Benchmarked against
+/// [`SliceOrd`] across sizes to locate the cutoff.
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct ChunkedOrd<const N: usize>([u8; N]);
+
+impl<const N: usize> PartialOrd for ChunkedOrd<N> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<const N: usize> Ord for ChunkedOrd<N> {
+    #[inline]
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        use core::cmp::Ordering;
+        let (mut lhs, mut rhs) = (self.0.as_slice(), other.0.as_slice());
+        while let (Some((a, lhs_rest)), Some((b, rhs_rest))) =
+            (lhs.split_first_chunk(), rhs.split_first_chunk())
+        {
+            match u64::from_be_bytes(*a).cmp(&u64::from_be_bytes(*b)) {
+                Ordering::Equal => (lhs, rhs) = (lhs_rest, rhs_rest),
+                unequal => return unequal,
+            }
+        }
+        if let (Some((a, lhs_rest)), Some((b, rhs_rest))) =
+            (lhs.split_first_chunk(), rhs.split_first_chunk())
+        {
+            match u32::from_be_bytes(*a).cmp(&u32::from_be_bytes(*b)) {
+                Ordering::Equal => (lhs, rhs) = (lhs_rest, rhs_rest),
+                unequal => return unequal,
+            }
+        }
+        if let (Some((a, lhs_rest)), Some((b, rhs_rest))) =
+            (lhs.split_first_chunk(), rhs.split_first_chunk())
+        {
+            match u16::from_be_bytes(*a).cmp(&u16::from_be_bytes(*b)) {
+                Ordering::Equal => (lhs, rhs) = (lhs_rest, rhs_rest),
+                unequal => return unequal,
+            }
+        }
+        if let (Some(a), Some(b)) = (lhs.first(), rhs.first()) {
+            match a.cmp(b) {
+                Ordering::Equal => {}
+                unequal => return unequal,
+            }
+        }
+        Ordering::Equal
+    }
+}
+
+/// Benchmarks chunked vs slice (`memcmp`) comparison for a single size `N`,
+/// over random pairs (typical map-search comparison: the first chunk decides)
+/// and equal pairs (worst case: the full length is compared, where `memcmp`'s
+/// vectorization pays off and a cutoff is expected).
+fn bench_ord_crossover<const N: usize>(
+    g: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+) {
+    let random: Vec<(FixedBytes<N>, FixedBytes<N>)> =
+        (0..1024).map(|_| (FixedBytes::random(), FixedBytes::random())).collect();
+    let equal: Vec<(FixedBytes<N>, FixedBytes<N>)> =
+        (0..1024).map(|_| FixedBytes::random()).map(|x| (x, x)).collect();
+
+    for (input, pairs) in [("random", &random), ("equal", &equal)] {
+        g.bench_function(format!("{N}/{input}/chunked"), |b| {
+            let pairs: Vec<_> =
+                pairs.iter().map(|(x, y)| (ChunkedOrd(x.0), ChunkedOrd(y.0))).collect();
+            b.iter(|| {
+                for (x, y) in &pairs {
+                    black_box(x.cmp(y));
+                }
+            })
+        });
+        g.bench_function(format!("{N}/{input}/memcmp"), |b| {
+            let pairs: Vec<_> = pairs.iter().map(|(x, y)| (SliceOrd(x.0), SliceOrd(y.0))).collect();
+            b.iter(|| {
+                for (x, y) in &pairs {
+                    black_box(x.cmp(y));
+                }
+            })
+        });
+    }
+}
+
 fn fixed_bytes_ord(c: &mut Criterion) {
     let mut g = c.benchmark_group("fixed_bytes_ord");
 
-    // Raw comparison throughput over random pairs (~50% of real map-search
-    // comparisons decide on the first chunk; random pairs model that).
-    let address_pairs: Vec<(Address, Address)> =
-        (0..1024).map(|_| (Address::random(), Address::random())).collect();
-    let address_slice_pairs: Vec<(SliceOrd<20>, SliceOrd<20>)> =
-        address_pairs.iter().map(|(x, y)| (SliceOrd(x.0.0), SliceOrd(y.0.0))).collect();
-    g.bench_function("address/cmp/chunked", |b| {
-        b.iter(|| {
-            for (x, y) in &address_pairs {
-                black_box(x.cmp(y));
-            }
-        })
-    });
-    g.bench_function("address/cmp/slice_baseline", |b| {
-        b.iter(|| {
-            for (x, y) in &address_slice_pairs {
-                black_box(x.cmp(y));
-            }
-        })
-    });
-
-    let b256_pairs: Vec<(B256, B256)> =
-        (0..1024).map(|_| (B256::random(), B256::random())).collect();
-    let b256_slice_pairs: Vec<(SliceOrd<32>, SliceOrd<32>)> =
-        b256_pairs.iter().map(|(x, y)| (SliceOrd(x.0), SliceOrd(y.0))).collect();
-    g.bench_function("b256/cmp/chunked", |b| {
-        b.iter(|| {
-            for (x, y) in &b256_pairs {
-                black_box(x.cmp(y));
-            }
-        })
-    });
-    g.bench_function("b256/cmp/slice_baseline", |b| {
-        b.iter(|| {
-            for (x, y) in &b256_slice_pairs {
-                black_box(x.cmp(y));
-            }
-        })
-    });
+    bench_ord_crossover::<8>(&mut g);
+    bench_ord_crossover::<20>(&mut g);
+    bench_ord_crossover::<32>(&mut g);
+    bench_ord_crossover::<64>(&mut g);
+    bench_ord_crossover::<128>(&mut g);
+    bench_ord_crossover::<256>(&mut g);
 
     // Real-world shape: BTreeMap keyed by Address, hit lookups.
     let keys: Vec<Address> = (0..100_000).map(|_| Address::random()).collect();

--- a/crates/primitives/src/bits/fixed.rs
+++ b/crates/primitives/src/bits/fixed.rs
@@ -44,36 +44,63 @@ impl<const N: usize> PartialOrd for FixedBytes<N> {
 impl<const N: usize> Ord for FixedBytes<N> {
     #[inline]
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        let mut i = 0;
-        while i + 8 <= N {
-            let a = u64::from_be_bytes(self.0[i..i + 8].try_into().unwrap());
-            let b = u64::from_be_bytes(other.0[i..i + 8].try_into().unwrap());
-            if a != b {
-                return a.cmp(&b);
-            }
-            i += 8;
+        if N <= CMP_UNROLLED_CUTOFF {
+            cmp_bytes_unrolled(&self.0, &other.0)
+        } else {
+            self.0.as_slice().cmp(other.0.as_slice())
         }
-        if i + 4 <= N {
-            let a = u32::from_be_bytes(self.0[i..i + 4].try_into().unwrap());
-            let b = u32::from_be_bytes(other.0[i..i + 4].try_into().unwrap());
-            if a != b {
-                return a.cmp(&b);
-            }
-            i += 4;
-        }
-        if i + 2 <= N {
-            let a = u16::from_be_bytes(self.0[i..i + 2].try_into().unwrap());
-            let b = u16::from_be_bytes(other.0[i..i + 2].try_into().unwrap());
-            if a != b {
-                return a.cmp(&b);
-            }
-            i += 2;
-        }
-        if i < N {
-            return self.0[i].cmp(&other.0[i]);
-        }
-        core::cmp::Ordering::Equal
     }
+}
+
+/// Largest `N` for which [`cmp_bytes_unrolled`] beats the `memcmp` libcall in
+/// the worst case (equal inputs) on both x86-64 and aarch64; see the
+/// `fixed_bytes_ord` benchmarks.
+const CMP_UNROLLED_CUTOFF: usize = 32;
+
+/// Compares byte slices as big-endian integer chunks of decreasing size,
+/// preserving byte-lexicographic order. Counterpart to
+/// `map::fixed::write_bytes_unrolled`.
+#[inline(always)]
+fn cmp_bytes_unrolled(mut lhs: &[u8], mut rhs: &[u8]) -> core::cmp::Ordering {
+    use core::cmp::Ordering;
+
+    debug_assert_eq!(lhs.len(), rhs.len());
+    while let (Some((a, lhs_rest)), Some((b, rhs_rest))) =
+        (lhs.split_first_chunk(), rhs.split_first_chunk())
+    {
+        match u64::from_be_bytes(*a).cmp(&u64::from_be_bytes(*b)) {
+            Ordering::Equal => (lhs, rhs) = (lhs_rest, rhs_rest),
+            unequal => return unequal,
+        }
+    }
+    if let (Some((a, lhs_rest)), Some((b, rhs_rest))) =
+        (lhs.split_first_chunk(), rhs.split_first_chunk())
+    {
+        match u32::from_be_bytes(*a).cmp(&u32::from_be_bytes(*b)) {
+            Ordering::Equal => (lhs, rhs) = (lhs_rest, rhs_rest),
+            unequal => return unequal,
+        }
+    }
+    if let (Some((a, lhs_rest)), Some((b, rhs_rest))) =
+        (lhs.split_first_chunk(), rhs.split_first_chunk())
+    {
+        match u16::from_be_bytes(*a).cmp(&u16::from_be_bytes(*b)) {
+            Ordering::Equal => (lhs, rhs) = (lhs_rest, rhs_rest),
+            unequal => return unequal,
+        }
+    }
+    if let (Some((a, lhs_rest)), Some((b, rhs_rest))) =
+        (lhs.split_first_chunk(), rhs.split_first_chunk())
+    {
+        match u8::from_be_bytes(*a).cmp(&u8::from_be_bytes(*b)) {
+            Ordering::Equal => (lhs, rhs) = (lhs_rest, rhs_rest),
+            unequal => return unequal,
+        }
+    }
+
+    debug_assert!(lhs.is_empty());
+    debug_assert!(rhs.is_empty());
+    Ordering::Equal
 }
 
 impl<const N: usize> Default for FixedBytes<N> {
@@ -786,7 +813,9 @@ mod tests {
         check::<8>(&mut rng);
         check::<20>(&mut rng);
         check::<32>(&mut rng);
+        // Above `CMP_UNROLLED_CUTOFF`: exercises the slice-comparison fallback.
         check::<64>(&mut rng);
+        check::<128>(&mut rng);
     }
 
     #[test]

--- a/crates/primitives/src/bits/fixed.rs
+++ b/crates/primitives/src/bits/fixed.rs
@@ -13,19 +13,7 @@ use hex::FromHex;
 /// lengths should use the [`wrap_fixed_bytes!`](crate::wrap_fixed_bytes) macro
 /// to create a new fixed-length byte array type.
 #[derive(
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Deref,
-    DerefMut,
-    From,
-    Index,
-    IndexMut,
-    IntoIterator,
+    Clone, Copy, PartialEq, Eq, Hash, Deref, DerefMut, From, Index, IndexMut, IntoIterator,
 )]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary, proptest_derive::Arbitrary))]
 #[cfg_attr(feature = "allocative", derive(allocative::Allocative))]
@@ -36,6 +24,57 @@ use hex::FromHex;
 pub struct FixedBytes<const N: usize>(#[into_iterator(owned, ref, ref_mut)] pub [u8; N]);
 
 crate::impl_fb_traits!(FixedBytes<N>, N, const);
+
+impl<const N: usize> PartialOrd for FixedBytes<N> {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Byte-lexicographic ordering, identical to the ordering of the underlying
+/// `[u8; N]`, computed over big-endian integer chunks.
+///
+/// The derived implementation lowers to a `memcmp` libcall; for the short,
+/// fixed lengths used as map keys (`Address`, `B256`, ...) the call overhead
+/// dominates the comparison itself. Comparing big-endian `u64` chunks (a
+/// single byte-swapped load per side) preserves the exact ordering while
+/// letting the comparison inline into callers such as `BTreeMap` node
+/// searches.
+impl<const N: usize> Ord for FixedBytes<N> {
+    #[inline]
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        let mut i = 0;
+        while i + 8 <= N {
+            let a = u64::from_be_bytes(self.0[i..i + 8].try_into().unwrap());
+            let b = u64::from_be_bytes(other.0[i..i + 8].try_into().unwrap());
+            if a != b {
+                return a.cmp(&b);
+            }
+            i += 8;
+        }
+        if i + 4 <= N {
+            let a = u32::from_be_bytes(self.0[i..i + 4].try_into().unwrap());
+            let b = u32::from_be_bytes(other.0[i..i + 4].try_into().unwrap());
+            if a != b {
+                return a.cmp(&b);
+            }
+            i += 4;
+        }
+        if i + 2 <= N {
+            let a = u16::from_be_bytes(self.0[i..i + 2].try_into().unwrap());
+            let b = u16::from_be_bytes(other.0[i..i + 2].try_into().unwrap());
+            if a != b {
+                return a.cmp(&b);
+            }
+            i += 2;
+        }
+        if i < N {
+            return self.0[i].cmp(&other.0[i]);
+        }
+        core::cmp::Ordering::Equal
+    }
+}
 
 impl<const N: usize> Default for FixedBytes<N> {
     #[inline]
@@ -699,6 +738,55 @@ mod tests {
         const ACTUAL: FixedBytes<4> = A.concat_const(B);
 
         assert_eq!(ACTUAL, EXPECTED);
+    }
+
+    /// The chunked `Ord` must order exactly like the underlying byte slices
+    /// (what the previous derived implementation produced).
+    #[test]
+    fn ord_matches_slice_ord() {
+        // Deterministic LCG so failures are reproducible.
+        fn step(rng: &mut u64) -> u8 {
+            *rng = rng.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            (*rng >> 56) as u8
+        }
+
+        fn fill<const N: usize>(rng: &mut u64) -> [u8; N] {
+            let mut out = [0u8; N];
+            for b in &mut out {
+                *b = step(rng);
+            }
+            out
+        }
+
+        fn check<const N: usize>(rng: &mut u64) {
+            for i in 0..1000 {
+                let a: [u8; N] = fill(rng);
+                let mut b: [u8; N] = fill(rng);
+                // Every third pair: equal inputs; every fifth: single-byte diff.
+                if i % 3 == 0 {
+                    b = a;
+                }
+                if i % 5 == 0 {
+                    b = a;
+                    let pos = step(rng) as usize % N;
+                    b[pos] = b[pos].wrapping_add(1);
+                }
+                let (fa, fb) = (FixedBytes(a), FixedBytes(b));
+                assert_eq!(fa.cmp(&fb), a.as_slice().cmp(b.as_slice()), "{fa} vs {fb}");
+                assert_eq!(fa.partial_cmp(&fb), Some(a.as_slice().cmp(b.as_slice())));
+            }
+        }
+
+        let mut rng = 0x243F6A8885A308D3u64;
+        check::<1>(&mut rng);
+        check::<2>(&mut rng);
+        check::<3>(&mut rng);
+        check::<4>(&mut rng);
+        check::<7>(&mut rng);
+        check::<8>(&mut rng);
+        check::<20>(&mut rng);
+        check::<32>(&mut rng);
+        check::<64>(&mut rng);
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

The derived `Ord` for `FixedBytes<N>` lowers to a `memcmp` libcall. For the
short fixed lengths used as map keys (`Address` = 20 bytes, `B256` = 32
bytes), the call overhead dominates the comparison itself, and the libcall is
opaque to the inliner.

In a downstream application (an order-matching engine that keeps its state in
`BTreeMap<Address, _>`), `memcmp` reached 17.6% flat CPU in profiles.
Replacing the derived `Ord` with chunked comparison raised application
throughput by ~10% on a 16-core Xeon.

## Solution

Implement `Ord` manually: compare big-endian integer chunks of decreasing
size (`u64` / `u32` / `u16` / `u8`), written with `split_first_chunk` in the
same style as `map::fixed::write_bytes_unrolled`. Each chunk is one
byte-swapped load per side, and the whole function inlines into callers such
as `BTreeMap` node searches.

For `N > 32` the implementation falls back to the plain slice comparison:
benchmarks over both random pairs (the first chunk decides) and equal pairs
(worst case: the full length is compared) show that 32 is the largest size
where the unrolled comparison wins the worst case on both x86-64 (glibc's
AVX2 `memcmp` takes over between 32 and 64) and aarch64 (between 128 and
256). The cutoff also caps the amount of inlined code.

The ordering is bit-for-bit identical to the derived (byte-lexicographic)
one. `ord_matches_slice_ord` pins `cmp` against the slice ordering across
many values of `N` — including sizes above the cutoff — with equal arrays and
single-byte differences at every position.

## Benchmarks

`fixed_bytes_ord` compares the unrolled comparison against the slice-based
ordering (the previous derived impl) in the same binary.

Headline numbers (1024 random pairs / 100k-key `BTreeMap<Address, _>` hit
lookups):

| benchmark | unrolled | memcmp | change |
|---|---|---|---|
| x86-64: 20B `cmp` | 936.7 ns | 1605 ns | −41.6% |
| x86-64: 32B `cmp` | 938.5 ns | 1601 ns | −41.4% |
| x86-64: `btreemap_get` | 91.1 ns | 126.9 ns | −28.2% |
| aarch64: 20B `cmp` | 345.9 ns | 532.4 ns | −35.0% |
| aarch64: 32B `cmp` | 517.9 ns | 538.1 ns | −3.8% |
| aarch64: `btreemap_get` | 63.1 ns | 69.7 ns | −9.5% |

Cutoff: equal pairs (worst case, full-length compare), 1024 pairs:

| N | x86-64 unrolled | x86-64 memcmp | aarch64 unrolled | aarch64 memcmp |
|---|---|---|---|---|
| 8 | **403 ns** | 1074 ns | **397 ns** | 462 ns |
| 20 | **674 ns** | 1335 ns | **549 ns** | 784 ns |
| 32 | **1.21 µs** | 1.34 µs | **689 ns** | 895 ns |
| 64 | 2.09 µs | **1.61 µs** | **1.38 µs** | 1.53 µs |
| 128 | 3.77 µs | **2.55 µs** | 3.34 µs | 3.38 µs |
| 256 | 8.21 µs | **4.35 µs** | 6.62 µs | **5.47 µs** |

x86-64: Intel Xeon, Linux (glibc); aarch64: Apple M-series, macOS. Each
number is the criterion median, taken as the median across repeated runs.

Reproduce with:

```sh
cargo bench -p alloy-primitives --features rand --bench primitives -- fixed_bytes_ord
```

PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
