### PR TITLE
fix(sol-macro): preserve nested ABI component names

### DIFF
--- a/crates/sol-macro-expander/src/expand/to_abi.rs
+++ b/crates/sol-macro-expander/src/expand/to_abi.rs
@@ -105,28 +105,23 @@ fn ty_to_param(name: Option<String>, ty: &ast::Type, cx: &ExpCtxt<'_>) -> Param 
         ty_name = format!("tuple{suffix}");
     }
 
-    let mut component_names = vec![];
     let resolved = match ty.peel_arrays() {
-        ast::Type::Custom(name) => {
-            if let ast::Item::Struct(s) = cx.item(name) {
-                component_names = s
-                    .fields
-                    .names()
-                    .map(|n| n.map(|i| i.as_string()).unwrap_or_default())
-                    .collect();
+        ast::Type::Custom(custom_name) => {
+            if let ast::Item::Struct(s) = cx.item(custom_name) {
+                return Param {
+                    ty: ty_name,
+                    name: name.unwrap_or_default(),
+                    internal_type: None,
+                    components: s.fields.to_dyn_abi(cx),
+                };
             }
-            cx.custom_type(name)
+            cx.custom_type(custom_name)
         }
         ty => ty,
     };
 
     let components = if let ast::Type::Tuple(tuple) = resolved {
-        tuple
-            .types
-            .iter()
-            .enumerate()
-            .map(|(i, ty)| ty_to_param(component_names.get(i).cloned(), ty, cx))
-            .collect()
+        tuple.types.iter().map(|ty| ty_to_param(None, ty, cx)).collect()
     } else {
         vec![]
     };

--- a/crates/sol-types/tests/macros/sol/abi.rs
+++ b/crates/sol-types/tests/macros/sol/abi.rs
@@ -122,8 +122,7 @@ fn equal_abis() {
     let custom = Param {
         ty: "tuple".into(),
         name: "cs".into(),
-        // TODO: should be `uint256 custom`, but name is lost in recursive resolution
-        components: vec![param("uint256 ")],
+        components: vec![param("uint256 custom")],
         internal_type: None,
     };
     assert_eq!(
@@ -305,22 +304,19 @@ fn recursive() {
     let chain_info = Param {
         ty: "tuple".into(),
         name: "chainInfo".into(),
-        components: vec![
-            param("uint256 "), // forkId
-            param("uint256 "), // chainId
-        ],
+        components: vec![param("uint256 forkId"), param("uint256 chainId")],
         internal_type: None,
     };
     let storage_accesses = Param {
         ty: "tuple[]".into(),
         name: "storageAccesses".into(),
         components: vec![
-            param("address "), // account
-            param("bytes32 "), // slot
-            param("bool "),    // isWrite
-            param("bytes32 "), // previousValue
-            param("bytes32 "), // newValue
-            param("bool "),    // reverted
+            param("address account"),
+            param("bytes32 slot"),
+            param("bool isWrite"),
+            param("bytes32 previousValue"),
+            param("bytes32 newValue"),
+            param("bool reverted"),
         ],
         internal_type: None,
     };
@@ -399,25 +395,17 @@ fn custom() {
         param("uint8 e"),
         param("uint8[] eArr"),
     ];
-    let custom_struct_erased = vec![
-        param("uint256 "),   // custom
-        param("uint256[] "), // customArr
-        param("uint32 "),    // udvt
-        param("uint32[] "),  // udvtArr
-        param("uint8 "),     // e
-        param("uint8[] "),   // eArr
-    ];
     let custom_struct2 = vec![
         Param {
             ty: "tuple".into(),
             name: "cs".into(),
-            components: custom_struct_erased.clone(),
+            components: custom_struct.clone(),
             internal_type: None,
         },
         Param {
             ty: "tuple[]".into(),
             name: "csArr".into(),
-            components: custom_struct_erased,
+            components: custom_struct.clone(),
             internal_type: None,
         },
     ];


### PR DESCRIPTION
## Motivation

The JSON ABI generated by `sol!` drops field names from structs nested inside other structs. This differs from solc JSON ABI output and prevents consumers from comparing complete ABI metadata.

## Solution

Build struct components recursively from their original declarations instead of their fully resolved tuple types. Existing nested-struct tests now assert that component names are preserved at every depth.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

Prompted by: @0xalpharush