### PR TITLE
fix(primitives): require list header when decoding logs

### DIFF
--- a/crates/primitives/src/log/mod.rs
+++ b/crates/primitives/src/log/mod.rs
@@ -225,6 +225,9 @@ where
 impl alloy_rlp::Decodable for Log {
     fn decode(buf: &mut &[u8]) -> Result<Self, alloy_rlp::Error> {
         let h = alloy_rlp::Header::decode(buf)?;
+        if !h.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
         let pre = buf.len();
 
         let address = alloy_rlp::Decodable::decode(buf)?;
@@ -251,5 +254,19 @@ mod tests {
         let mut buf = Vec::<u8>::new();
         log.encode(&mut buf);
         assert_eq!(Log::decode(&mut &buf[..]).unwrap(), log);
+    }
+
+    #[test]
+    fn rejects_string_wrapped_log() {
+        let canonical = alloy_rlp::encode(Log::default());
+        let mut payload = canonical.as_slice();
+        let header = alloy_rlp::Header::decode(&mut payload).unwrap();
+        assert!(header.list);
+
+        let mut encoded = Vec::new();
+        alloy_rlp::Header { list: false, payload_length: payload.len() }.encode(&mut encoded);
+        encoded.extend_from_slice(payload);
+
+        assert!(Log::decode(&mut encoded.as_slice()).is_err());
     }
 }


### PR DESCRIPTION
## Motivation

An Ethereum log is encoded as the RLP list `[address, topics, data]`.

`Log::decode` validated the payload length but did not require the decoded RLP header to be a list. A string containing otherwise valid log fields was therefore accepted and re-encoded as a list, violating canonical decode/encode behavior.

## Solution

Return `UnexpectedString` when the log's outer RLP header is not a list.

The regression test verifies rejection of a string-wrapped log, while the existing canonical log round-trip test remains unchanged.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

## Specification

The [Ethereum Wire Protocol receipt encoding](https://github.com/ethereum/devp2p/blob/77264dbc983a06aab74a79aec85d9e18361df03e/caps/eth.md#L330-L346) defines every log as the RLP list `[address, topics, data]`. go-ethereum models those same consensus fields in [`types.Log`](https://github.com/ethereum/go-ethereum/blob/02b73d4ea7181464175e0a6cbecc0a3a2655a562/core/types/log.go#L31-L38), and its [generated RLP encoder](https://github.com/ethereum/go-ethereum/blob/02b73d4ea7181464175e0a6cbecc0a3a2655a562/core/types/gen_log_rlp.go#L8-L20) emits an outer list.