### PR TITLE
test: remove needless hash borrow

### DIFF
--- a/crates/primitives/src/map/fixed.rs
+++ b/crates/primitives/src/map/fixed.rs
@@ -179,7 +179,7 @@ mod tests {
     use super::*;
 
     fn hash_zero<const N: usize>() -> u64 {
-        FbBuildHasher::<N>::default().hash_one(&FixedBytes::<N>::ZERO)
+        FbBuildHasher::<N>::default().hash_one(FixedBytes::<N>::ZERO)
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

The Clippy CI job on `main` fails on `clippy::needless_borrows_for_generic_args` in the fixed-bytes hasher test.

## Solution

Pass `FixedBytes::<N>::ZERO` directly to `hash_one`, as suggested by Clippy.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

Prompted by: @DaniPopes
