### PR TITLE
fix(sol-types): default config trait methods

### DIFF
--- a/crates/sol-types/src/types/function.rs
+++ b/crates/sol-types/src/types/function.rs
@@ -137,10 +137,15 @@ pub trait SolCall: Sized {
     fn abi_decode_returns(data: &[u8]) -> Result<Self::Return>;
 
     /// ABI-decodes this call's return values with a custom decoder configuration.
+    ///
+    /// The default implementation ignores the configuration and delegates to
+    /// [`abi_decode_returns`](Self::abi_decode_returns).
     fn abi_decode_returns_with_config(
         data: &[u8],
-        config: AbiDecoderConfig,
-    ) -> Result<Self::Return>;
+        _config: AbiDecoderConfig,
+    ) -> Result<Self::Return> {
+        Self::abi_decode_returns(data)
+    }
 
     /// ABI decode this call's return values from the given slice, with validation.
     ///

--- a/crates/sol-types/src/types/interface/mod.rs
+++ b/crates/sol-types/src/types/interface/mod.rs
@@ -62,11 +62,16 @@ pub trait SolInterface: Sized {
     fn abi_decode_raw(selector: [u8; 4], data: &[u8]) -> Result<Self>;
 
     /// ABI-decodes the given data with a custom decoder configuration.
+    ///
+    /// The default implementation ignores the configuration and delegates to
+    /// [`abi_decode_raw`](Self::abi_decode_raw).
     fn abi_decode_raw_with_config(
         selector: [u8; 4],
         data: &[u8],
-        config: AbiDecoderConfig,
-    ) -> Result<Self>;
+        _config: AbiDecoderConfig,
+    ) -> Result<Self> {
+        Self::abi_decode_raw(selector, data)
+    }
 
     /// ABI-decodes the given data into one of the variants of `self`, with validation.
     ///


### PR DESCRIPTION
Adds default implementations for the config-aware `SolCall` and `SolInterface` decode methods. This lets bindings generated before 1.7.0 compile while current generated implementations continue to enforce the decoder configuration.

Closes #1170.
