### PR TITLE
feat(sol-macro): implement rename attributes

### DIFF
--- a/crates/json-abi/src/to_sol.rs
+++ b/crates/json-abi/src/to_sol.rs
@@ -10,6 +10,7 @@ use alloc::{
 };
 use core::{
     cmp::Ordering,
+    fmt::Write,
     ops::{Deref, DerefMut},
 };
 
@@ -146,6 +147,13 @@ impl<'a> SolPrinter<'a> {
         self.push_str(&s);
     }
 
+    /// Emits a `sol!` rename attribute when normalization changes an identifier.
+    fn push_rename_attr(&mut self, s: &str) {
+        if self.config.for_sol_macro && s.contains('$') {
+            write!(self.s, "#[sol(rename = {s:?})] ").unwrap();
+        }
+    }
+
     /// Normalizes `s` as a Rust identifier.
     ///
     /// All Solidity identifiers are also valid Rust identifiers, except for `$`.
@@ -194,8 +202,9 @@ impl JsonAbi {
                 if its.is_empty() {
                     continue;
                 }
+                out.push_rename_attr(name);
                 out.push_str("library ");
-                out.push_str(name);
+                out.push_ident(name);
                 out.push_str(" {\n");
                 let prev = core::mem::replace(&mut out.name, name);
                 for it in its {
@@ -208,9 +217,11 @@ impl JsonAbi {
             }
         }
 
+        let root_name = String::from(out.name);
+        out.push_rename_attr(&root_name);
         out.push_str("interface ");
-        if !out.name.is_empty() {
-            out.s.push_str(out.name);
+        if !root_name.is_empty() {
+            out.push_ident(&root_name);
             out.push(' ');
         }
         out.push('{');
@@ -457,6 +468,7 @@ impl ToSol for It<'_, '_> {
     fn to_sol(&self, out: &mut SolPrinter<'_>) {
         match &self.kind {
             ItKind::Enum(Some(variants)) => {
+                out.push_rename_attr(self.name);
                 out.push_str("enum ");
                 out.push_ident(self.name);
                 out.push_str(" { ");
@@ -464,16 +476,19 @@ impl ToSol for It<'_, '_> {
                     if i > 0 {
                         out.push_str(", ");
                     }
+                    out.push_rename_attr(variant);
                     out.push_ident(variant);
                 }
                 out.push_str(" }");
             }
             ItKind::Enum(None) => {
+                out.push_rename_attr(self.name);
                 out.push_str("type ");
                 out.push_ident(self.name);
                 out.push_str(" is uint8;");
             }
             ItKind::Udvt(ty) => {
+                out.push_rename_attr(self.name);
                 out.push_str("type ");
                 out.push_ident(self.name);
                 out.push_str(" is ");
@@ -481,6 +496,7 @@ impl ToSol for It<'_, '_> {
                 out.push(';');
             }
             ItKind::Struct(components) => {
+                out.push_rename_attr(self.name);
                 out.push_str("struct ");
                 out.push_ident(self.name);
                 out.push_str(" {\n");
@@ -642,12 +658,9 @@ impl<IN: ToSol> ToSol for AbiFunction<'_, IN> {
             out.print_param_location = true;
         }
 
-        // TODO: Enable once `#[sol(rename)]` is implemented.
-        // if let Some(name) = self.name {
-        //     if out.config.for_sol_macro && name.contains('$') {
-        //         write!(out, "#[sol(rename = \"{name}\")]").unwrap();
-        //     }
-        // }
+        if let Some(name) = self.name {
+            out.push_rename_attr(name);
+        }
 
         out.push_str(self.kw.as_str());
         if let Some(name) = self.name {
@@ -724,6 +737,9 @@ fn param(
     components: &[Param],
     out: &mut SolPrinter<'_>,
 ) {
+    if !name.is_empty() {
+        out.push_rename_attr(name);
+    }
     let mut contract_name = None::<&str>;
     let mut type_name = type_name;
     let storage;

--- a/crates/json-abi/tests/abi/Bootstrap.sol
+++ b/crates/json-abi/tests/abi/Bootstrap.sol
@@ -26,12 +26,12 @@ interface Bootstrap {
 
     receive() external payable;
 
-    function _getInitMSACalldata(BootstrapConfig[] memory _valdiators, BootstrapConfig[] memory _executors, BootstrapConfig memory _hook, BootstrapConfig[] memory _fallbacks) external view returns (bytes memory init);
+    function _getInitMSACalldata(#[sol(rename = "$valdiators")] BootstrapConfig[] memory _valdiators, #[sol(rename = "$executors")] BootstrapConfig[] memory _executors, BootstrapConfig memory _hook, BootstrapConfig[] memory _fallbacks) external view returns (bytes memory init);
     function entryPoint() external view returns (address);
     function getActiveFallbackHandler(bytes4 functionSig) external view returns (ModuleManager.FallbackHandler memory);
     function getActiveHook() external view returns (address hook);
     function getExecutorsPaginated(address cursor, uint256 size) external view returns (address[] memory array, address next);
     function getValidatorsPaginated(address cursor, uint256 size) external view returns (address[] memory array, address next);
-    function initMSA(BootstrapConfig[] memory _valdiators, BootstrapConfig[] memory _executors, BootstrapConfig memory _hook, BootstrapConfig[] memory _fallbacks) external;
+    function initMSA(#[sol(rename = "$valdiators")] BootstrapConfig[] memory _valdiators, #[sol(rename = "$executors")] BootstrapConfig[] memory _executors, BootstrapConfig memory _hook, BootstrapConfig[] memory _fallbacks) external;
     function singleInitMSA(address validator, bytes memory data) external;
 }

--- a/crates/json-abi/tests/abi/DollarIdentifiers.sol
+++ b/crates/json-abi/tests/abi/DollarIdentifiers.sol
@@ -1,10 +1,10 @@
 interface DollarIdentifiers {
-    type _dEnum is uint8;
-    type _dUDVT is uint256;
-    struct _dStruct {
-        uint256 _dField;
+    #[sol(rename = "$dEnum")] type _dEnum is uint8;
+    #[sol(rename = "$dUDVT")] type _dUDVT is uint256;
+    #[sol(rename = "$dStruct")] struct _dStruct {
+        #[sol(rename = "$dField")] uint256 _dField;
     }
 
-    function _dFunction(_dStruct memory _dStructArg, _dEnum _dEnumArg, _dUDVT _dUDVTArg) external;
-    function _dPublicVariable() external view returns (uint256 _dField);
+    #[sol(rename = "$dFunction")] function _dFunction(#[sol(rename = "$dStructArg")] _dStruct memory _dStructArg, #[sol(rename = "$dEnumArg")] _dEnum _dEnumArg, #[sol(rename = "$dUDVTArg")] _dUDVT _dUDVTArg) external;
+    #[sol(rename = "$dPublicVariable")] function _dPublicVariable() external view returns (#[sol(rename = "$dField")] uint256 _dField);
 }

--- a/crates/sol-macro-expander/src/expand/enum.rs
+++ b/crates/sol-macro-expander/src/expand/enum.rs
@@ -26,7 +26,7 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, enumm: &ItemEnum) -> Result<TokenStream> 
     cx.derives(&mut attrs, [], false);
     let docs = sol_attrs.docs.or(cx.attrs.docs).unwrap_or(true);
 
-    let name_s = name.to_string();
+    let name_s = cx.sol_name(name, &enumm.attrs);
 
     let count = variants.len();
     if count == 0 {
@@ -39,8 +39,6 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, enumm: &ItemEnum) -> Result<TokenStream> 
 
     let has_invalid_variant = max != u8::MAX;
     let invalid_variant = has_invalid_variant.then(|| {
-        let comma = (!variants.trailing_punct()).then(syn::token::Comma::default);
-
         let has_serde = derives_mapped(&attrs).any(|path| {
             let Some(last) = path.segments.last() else {
                 return false;
@@ -50,7 +48,6 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, enumm: &ItemEnum) -> Result<TokenStream> 
         let serde_other = has_serde.then(|| quote!(#[serde(other)]));
 
         quote! {
-            #comma
             /// Invalid variant.
             ///
             /// This is only used when decoding an out-of-range `u8` value.
@@ -75,6 +72,11 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, enumm: &ItemEnum) -> Result<TokenStream> 
         let idx = idx as u8;
         quote! { #idx => ::core::result::Result::Ok(Self::#ident), }
     });
+    let rust_variants = variants.iter().map(|variant| {
+        let ident = &variant.ident;
+        let attrs = variant.attrs.iter().filter(|attr| !attr.path().is_ident("sol"));
+        quote! { #(#attrs)* #ident }
+    });
 
     let doc = docs.then(|| mk_doc(format!("```solidity\n{enumm}\n```")));
     let tokens = quote! {
@@ -84,7 +86,7 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, enumm: &ItemEnum) -> Result<TokenStream> 
         #[derive(Clone, Copy)]
         #[repr(u8)]
         pub enum #name {
-            #variants
+            #(#rust_variants,)*
             #invalid_variant
         }
 

--- a/crates/sol-macro-expander/src/expand/event.rs
+++ b/crates/sol-macro-expander/src/expand/event.rs
@@ -265,7 +265,7 @@ fn expand_event_topic_field(
 ) -> TokenStream {
     let name = anon_name((i, name));
     let ty = cx.expand_event_param_type(param);
-    let attrs = &param.attrs;
+    let attrs = param.attrs.iter().filter(|attr| !attr.path().is_ident("sol"));
     quote! {
         #(#attrs)*
         #[allow(missing_docs)]

--- a/crates/sol-macro-expander/src/expand/mod.rs
+++ b/crates/sol-macro-expander/src/expand/mod.rs
@@ -376,6 +376,7 @@ impl ExpCtxt<'_> {
                 let overloaded_items = this.overloaded_items.0.get(namespace).unwrap();
                 let all_orig_names: Vec<_> =
                     overloaded_items.values().flatten().filter_map(|f| f.name()).collect();
+                let mut all_generated_names = HashMap::new();
 
                 for functions in overloaded_items.values().filter(|fs| fs.len() >= 2) {
                     // check for same parameters
@@ -398,11 +399,41 @@ impl ExpCtxt<'_> {
                         let Some(old_name) = item.name() else {
                             continue;
                         };
-                        let new_name = format!("{old_name}_{i}");
+                        let (attrs, _) = match SolAttrs::parse(item.attrs()) {
+                            Ok(attrs) => attrs,
+                            Err(e) => {
+                                failed = true;
+                                emit_error!(e.span(), "{}", e);
+                                continue;
+                            }
+                        };
+                        let (new_name, new_name_span) = if let Some(rename) = attrs.rename {
+                            match syn::parse_str::<SolIdent>(&rename.value()) {
+                                Ok(name) => (name.as_string(), rename.span()),
+                                Err(e) => {
+                                    failed = true;
+                                    emit_error!(rename.span(), "invalid rename: {}", e);
+                                    continue;
+                                }
+                            }
+                        } else {
+                            (format!("{old_name}_{i}"), old_name.span())
+                        };
                         if let Some(other) = all_orig_names.iter().find(|x| x.0 == new_name) {
                             failed = true;
                             emit_error!(
-                                old_name.span(),
+                                new_name_span,
+                                "{} `{old_name}` is overloaded, \
+                                but the generated name `{new_name}` is already in use",
+                                item.desc();
+
+                                note = other.span() => "other declaration is here";
+                            )
+                        }
+                        if let Some(other) = all_generated_names.insert(new_name.clone(), item) {
+                            failed = true;
+                            emit_error!(
+                                new_name_span,
                                 "{} `{old_name}` is overloaded, \
                                 but the generated name `{new_name}` is already in use",
                                 item.desc();
@@ -494,6 +525,14 @@ impl<'ast> From<&'ast ItemError> for OverloadedItem<'ast> {
 }
 
 impl<'a> OverloadedItem<'a> {
+    fn attrs(self) -> &'a [Attribute] {
+        match self {
+            Self::Function(f) => &f.attrs,
+            Self::Event(e) => &e.attrs,
+            Self::Error(e) => &e.attrs,
+        }
+    }
+
     fn name(self) -> Option<&'a SolIdent> {
         match self {
             Self::Function(f) => f.name.as_ref(),

--- a/crates/sol-macro-expander/src/expand/mod.rs
+++ b/crates/sol-macro-expander/src/expand/mod.rs
@@ -1,7 +1,7 @@
 //! Functions which generate Rust code from the Solidity AST.
 
 use crate::utils::{self, ExprArray};
-use alloy_sol_macro_input::{ContainsSolAttrs, SolAttrs};
+use alloy_sol_macro_input::{CasingStyle, ContainsSolAttrs, SolAttrs};
 use ast::{
     EventParameter, File, Item, ItemError, ItemEvent, ItemFunction, Parameters, SolIdent, SolPath,
     Spanned, Type, VariableDeclaration, Visit, VisitMut, visit_mut,
@@ -128,6 +128,7 @@ pub struct ExpCtxt<'ast> {
     overloads: IndexMap<Option<SolIdent>, IndexMap<String, String>>,
 
     attrs: SolAttrs,
+    root_attrs: SolAttrs,
     crates: ExternCrates,
     ast: &'ast File,
 
@@ -144,6 +145,7 @@ impl<'ast> ExpCtxt<'ast> {
             overloaded_items: Default::default(),
             overloads: IndexMap::new(),
             attrs: SolAttrs::default(),
+            root_attrs: SolAttrs::default(),
             crates: ExternCrates::default(),
             ast,
             current_namespace: None,
@@ -168,11 +170,17 @@ impl<'ast> ExpCtxt<'ast> {
 
         if let Err(e) = self.parse_file_attributes() {
             tokens.extend(e.into_compile_error());
+            abort = true;
         }
 
         self.visit_file(self.ast);
 
-        if !self.all_items.0.is_empty() {
+        if let Err(e) = self.validate_item_attributes() {
+            tokens.extend(e.into_compile_error());
+            abort = true;
+        }
+
+        if !abort && !self.all_items.0.is_empty() {
             self.resolve_custom_types();
             // Selector collisions requires resolved types.
             if self.mk_overloads_map().is_err() || self.check_selector_collisions().is_err() {
@@ -216,11 +224,59 @@ impl<'ast> ExpCtxt<'ast> {
 impl ExpCtxt<'_> {
     fn parse_file_attributes(&mut self) -> Result<()> {
         let (attrs, others) = self.ast.split_attrs()?;
+        self.root_attrs = attrs.clone();
         self.attrs = attrs;
         self.crates.fill(&self.attrs);
 
         let errs = others.iter().map(|attr| Error::new_spanned(attr, "unexpected attribute"));
         utils::combine_errors(errs)
+    }
+
+    fn validate_item_attributes(&self) -> Result<()> {
+        fn validate_params<P>(params: &Parameters<P>) -> Result<()> {
+            for param in params {
+                SolAttrs::parse(&param.attrs)?;
+            }
+            Ok(())
+        }
+
+        fn validate_item(item: &Item) -> Result<()> {
+            if let Some(attrs) = item.attrs() {
+                SolAttrs::parse(attrs)?;
+            }
+            match item {
+                Item::Contract(contract) => {
+                    for item in &contract.body {
+                        validate_item(item)?;
+                    }
+                }
+                Item::Enum(enumm) => {
+                    for variant in &enumm.variants {
+                        SolAttrs::parse(&variant.attrs)?;
+                    }
+                }
+                Item::Error(error) => validate_params(&error.parameters)?,
+                Item::Event(event) => {
+                    for param in &event.parameters {
+                        SolAttrs::parse(&param.attrs)?;
+                    }
+                }
+                Item::Function(function) => {
+                    validate_params(&function.parameters)?;
+                    if let Some(returns) = &function.returns {
+                        validate_params(&returns.returns)?;
+                    }
+                }
+                Item::Struct(strukt) => validate_params(&strukt.fields)?,
+                _ => {}
+            }
+            Ok(())
+        }
+
+        for item in &self.ast.items {
+            validate_item(item)?;
+        }
+        Ok(())
     }
 
     fn mk_types_map(&mut self) {
@@ -376,8 +432,6 @@ impl ExpCtxt<'_> {
                 let overloaded_items = this.overloaded_items.0.get(namespace).unwrap();
                 let all_orig_names: Vec<_> =
                     overloaded_items.values().flatten().filter_map(|f| f.name()).collect();
-                let mut all_generated_names = HashMap::new();
-
                 for functions in overloaded_items.values().filter(|fs| fs.len() >= 2) {
                     // check for same parameters
                     for (i, &a) in functions.iter().enumerate() {
@@ -399,41 +453,11 @@ impl ExpCtxt<'_> {
                         let Some(old_name) = item.name() else {
                             continue;
                         };
-                        let (attrs, _) = match SolAttrs::parse(item.attrs()) {
-                            Ok(attrs) => attrs,
-                            Err(e) => {
-                                failed = true;
-                                emit_error!(e.span(), "{}", e);
-                                continue;
-                            }
-                        };
-                        let (new_name, new_name_span) = if let Some(rename) = attrs.rename {
-                            match syn::parse_str::<SolIdent>(&rename.value()) {
-                                Ok(name) => (name.as_string(), rename.span()),
-                                Err(e) => {
-                                    failed = true;
-                                    emit_error!(rename.span(), "invalid rename: {}", e);
-                                    continue;
-                                }
-                            }
-                        } else {
-                            (format!("{old_name}_{i}"), old_name.span())
-                        };
+                        let new_name = format!("{old_name}_{i}");
                         if let Some(other) = all_orig_names.iter().find(|x| x.0 == new_name) {
                             failed = true;
                             emit_error!(
-                                new_name_span,
-                                "{} `{old_name}` is overloaded, \
-                                but the generated name `{new_name}` is already in use",
-                                item.desc();
-
-                                note = other.span() => "other declaration is here";
-                            )
-                        }
-                        if let Some(other) = all_generated_names.insert(new_name.clone(), item) {
-                            failed = true;
-                            emit_error!(
-                                new_name_span,
+                                old_name.span(),
                                 "{} `{old_name}` is overloaded, \
                                 but the generated name `{new_name}` is already in use",
                                 item.desc();
@@ -525,14 +549,6 @@ impl<'ast> From<&'ast ItemError> for OverloadedItem<'ast> {
 }
 
 impl<'a> OverloadedItem<'a> {
-    fn attrs(self) -> &'a [Attribute] {
-        match self {
-            Self::Function(f) => &f.attrs,
-            Self::Event(e) => &e.attrs,
-            Self::Error(e) => &e.attrs,
-        }
-    }
-
     fn name(self) -> Option<&'a SolIdent> {
         match self {
             Self::Function(f) => f.name.as_ref(),
@@ -681,8 +697,86 @@ impl<'ast> ExpCtxt<'ast> {
         Ident::new(&new_ident, function_name.span())
     }
 
+    /// Returns the `rename_all` style inherited by items in the current namespace.
+    fn scope_rename_all(&self) -> Option<CasingStyle> {
+        self.rename_all_for_namespace(&self.current_namespace)
+    }
+
+    fn rename_all_for_namespace(&self, namespace: &Option<SolIdent>) -> Option<CasingStyle> {
+        let root = self.root_attrs.rename_all;
+        let Some(namespace) = namespace.as_ref() else { return root };
+        self.ast
+            .items
+            .iter()
+            .find_map(|item| match item {
+                Item::Contract(contract) if contract.name == *namespace => {
+                    SolAttrs::parse(&contract.attrs).ok().and_then(|(attrs, _)| attrs.rename_all)
+                }
+                _ => None,
+            })
+            .or(root)
+    }
+
+    fn sol_name_in_namespace(
+        &self,
+        name: &SolIdent,
+        attrs: &[Attribute],
+        namespace: &Option<SolIdent>,
+    ) -> String {
+        let attrs = SolAttrs::parse(attrs).ok().map(|(attrs, _)| attrs).unwrap_or_default();
+        if let Some(rename) = attrs.rename {
+            rename.value()
+        } else if let Some(rename_all) = self.rename_all_for_namespace(namespace) {
+            rename_all.apply(&name.as_string())
+        } else {
+            name.as_string()
+        }
+    }
+
+    /// Returns the Solidity name for a Rust item name and its local attributes.
+    fn sol_name(&self, name: &SolIdent, attrs: &[Attribute]) -> String {
+        self.sol_name_in_namespace(name, attrs, &self.current_namespace)
+    }
+
+    /// Returns the Solidity name for a child such as a parameter or struct field.
+    fn child_sol_name(
+        &self,
+        name: &SolIdent,
+        attrs: &[Attribute],
+        parent_attrs: &[Attribute],
+    ) -> String {
+        let attrs = SolAttrs::parse(attrs).ok().map(|(attrs, _)| attrs).unwrap_or_default();
+        if let Some(rename) = attrs.rename {
+            return rename.value();
+        }
+        let parent = SolAttrs::parse(parent_attrs)
+            .ok()
+            .and_then(|(attrs, _)| attrs.rename_all)
+            .or_else(|| self.scope_rename_all());
+        parent.map_or_else(|| name.as_string(), |style| style.apply(&name.as_string()))
+    }
+
+    fn function_sol_name(&self, function: &ItemFunction) -> String {
+        self.sol_name(function.name(), &function.attrs)
+    }
+
+    fn error_sol_name(&self, error: &ItemError) -> String {
+        self.sol_name(&error.name, &error.attrs)
+    }
+
+    fn event_sol_name(&self, event: &ItemEvent) -> String {
+        self.sol_name(&event.name, &event.attrs)
+    }
+
+    fn custom_sol_name(&self, name: &SolPath) -> Option<String> {
+        let (namespace, item) = self.try_item_in_namespace(name, &self.current_namespace)?;
+        let ident = item.name()?;
+        let attrs = item.attrs()?;
+        Some(self.sol_name_in_namespace(ident, attrs, namespace))
+    }
+
     fn function_signature(&self, function: &ItemFunction) -> String {
-        self.signature(function.name().as_string(), &function.parameters)
+        self.signature(self.function_sol_name(function), &function.parameters)
     }
 
     fn function_selector(&self, function: &ItemFunction) -> ExprArray<u8> {
@@ -690,7 +784,7 @@ impl<'ast> ExpCtxt<'ast> {
     }
 
     fn error_signature(&self, error: &ItemError) -> String {
-        self.signature(error.name.as_string(), &error.parameters)
+        self.signature(self.error_sol_name(error), &error.parameters)
     }
 
     fn error_selector(&self, error: &ItemError) -> ExprArray<u8> {
@@ -698,7 +792,7 @@ impl<'ast> ExpCtxt<'ast> {
     }
 
     fn event_signature(&self, event: &ItemEvent) -> String {
-        self.signature(event.name.as_string(), &event.params())
+        self.signature(self.event_sol_name(event), &event.params())
     }
 
     fn event_selector(&self, event: &ItemEvent) -> ExprArray<u8> {
@@ -875,7 +969,7 @@ fn expand_fields<'a, P>(
     params.iter().enumerate().map(|(i, var)| {
         let name = anon_name((i, var.name.as_ref()));
         let ty = cx.expand_rust_type(&var.ty);
-        let attrs = &var.attrs;
+        let attrs = var.attrs.iter().filter(|attr| !attr.path().is_ident("sol"));
         quote! {
             #(#attrs)*
             #[allow(missing_docs)]

--- a/crates/sol-macro-expander/src/expand/struct.rs
+++ b/crates/sol-macro-expander/src/expand/struct.rs
@@ -5,7 +5,7 @@ use alloy_sol_macro_input::{ContainsSolAttrs, mk_doc};
 use ast::{Item, ItemStruct, Spanned, Type};
 use proc_macro2::TokenStream;
 use quote::quote;
-use std::num::NonZeroU16;
+use std::{fmt::Write, num::NonZeroU16};
 use syn::Result;
 
 /// Expands an [`ItemStruct`]:
@@ -28,6 +28,7 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, s: &ItemStruct) -> Result<TokenStream> {
     let ItemStruct { name, fields, .. } = s;
 
     let (sol_attrs, mut attrs) = s.split_attrs()?;
+    let sol_name = cx.sol_name(name, &s.attrs);
 
     cx.derives(&mut attrs, fields, true);
     let docs = sol_attrs.docs.or(cx.attrs.docs).unwrap_or(true);
@@ -35,7 +36,7 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, s: &ItemStruct) -> Result<TokenStream> {
     let (field_types, field_names): (Vec<_>, Vec<_>) =
         fields.iter().map(|f| (cx.expand_type(&f.ty), f.name.as_ref().unwrap())).unzip();
 
-    let eip712_encode_type_fns = expand_encode_type_fns(cx, fields, name);
+    let eip712_encode_type_fns = expand_encode_type_fns(cx, fields, &sol_name, &s.attrs);
 
     let tokenize_impl = expand_tokenize(fields, cx, super::FieldKind::Original);
 
@@ -57,7 +58,7 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, s: &ItemStruct) -> Result<TokenStream> {
 
     let attrs = attrs.iter();
     let convert = expand_from_into_tuples(&name.0, fields, cx, super::FieldKind::Original);
-    let name_s = name.as_string();
+    let name_s = sol_name;
     let fields = expand_fields(fields, cx);
 
     let doc = docs.then(|| mk_doc(format!("```solidity\n{s}\n```")));
@@ -193,7 +194,8 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, s: &ItemStruct) -> Result<TokenStream> {
 fn expand_encode_type_fns(
     cx: &ExpCtxt<'_>,
     fields: &ast::Parameters<syn::token::Semi>,
-    name: &ast::SolIdent,
+    name: &str,
+    attrs: &[syn::Attribute],
 ) -> TokenStream {
     // account for UDVTs and enums which do not implement SolStruct
     let mut fields = fields.clone();
@@ -212,7 +214,7 @@ fn expand_encode_type_fns(
         }
     });
 
-    let root = fields.eip712_signature(name.as_string());
+    let root = eip712_signature(cx, &fields, name, attrs);
 
     let custom = fields.iter().filter(|f| f.ty.has_custom());
     let n_custom = custom.clone().count();
@@ -265,5 +267,59 @@ fn expand_encode_type_fns(
         }
 
         #encode_type_impl_opt
+    }
+}
+
+fn eip712_signature(
+    cx: &ExpCtxt<'_>,
+    fields: &ast::Parameters<syn::token::Semi>,
+    name: &str,
+    attrs: &[syn::Attribute],
+) -> String {
+    let mut out = String::with_capacity(name.len() + 2 + fields.len() * 32);
+    out.push_str(name);
+    out.push('(');
+    for (i, field) in fields.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        fmt_eip712_type(cx, &field.ty, &mut out);
+        if let Some(field_name) = &field.name {
+            out.push(' ');
+            out.push_str(&cx.child_sol_name(field_name, &field.attrs, attrs));
+        }
+    }
+    out.push(')');
+    out
+}
+
+fn fmt_eip712_type(cx: &ExpCtxt<'_>, ty: &Type, out: &mut String) {
+    match ty {
+        Type::Custom(name) => {
+            if let Some(name) = cx.custom_sol_name(name) {
+                out.push_str(&name);
+            } else {
+                write!(out, "{}", name.last()).unwrap();
+            }
+        }
+        Type::Array(array) => {
+            fmt_eip712_type(cx, &array.ty, out);
+            out.push('[');
+            if let Some(size) = array.size_lit() {
+                out.push_str(size.base10_digits());
+            }
+            out.push(']');
+        }
+        Type::Tuple(tuple) => {
+            out.push('(');
+            for (i, ty) in tuple.types.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                fmt_eip712_type(cx, ty, out);
+            }
+            out.push(')');
+        }
+        ty => write!(out, "{ty}").unwrap(),
     }
 }

--- a/crates/sol-macro-expander/src/expand/to_abi.rs
+++ b/crates/sol-macro-expander/src/expand/to_abi.rs
@@ -27,9 +27,13 @@ impl ToAbi for ast::ItemFunction {
 
     fn to_dyn_abi(&self, cx: &ExpCtxt<'_>) -> Self::DynAbi {
         Function {
-            name: self.name.as_ref().map(|i| i.as_string()).unwrap_or_default(),
-            inputs: self.parameters.to_dyn_abi(cx),
-            outputs: self.returns.as_ref().map(|r| r.returns.to_dyn_abi(cx)).unwrap_or_default(),
+            name: cx.function_sol_name(self),
+            inputs: params_to_dyn_abi(&self.parameters, cx, &self.attrs),
+            outputs: self
+                .returns
+                .as_ref()
+                .map(|r| params_to_dyn_abi(&r.returns, cx, &self.attrs))
+                .unwrap_or_default(),
             state_mutability: self.attributes.to_dyn_abi(cx),
         }
     }
@@ -39,7 +43,10 @@ impl ToAbi for ast::ItemError {
     type DynAbi = Error;
 
     fn to_dyn_abi(&self, cx: &ExpCtxt<'_>) -> Self::DynAbi {
-        Error { name: self.name.as_string(), inputs: self.parameters.to_dyn_abi(cx) }
+        Error {
+            name: cx.error_sol_name(self),
+            inputs: params_to_dyn_abi(&self.parameters, cx, &self.attrs),
+        }
     }
 }
 
@@ -48,37 +55,40 @@ impl ToAbi for ast::ItemEvent {
 
     fn to_dyn_abi(&self, cx: &ExpCtxt<'_>) -> Self::DynAbi {
         Event {
-            name: self.name.as_string(),
-            inputs: self.parameters.iter().map(|e| e.to_dyn_abi(cx)).collect(),
+            name: cx.event_sol_name(self),
+            inputs: self
+                .parameters
+                .iter()
+                .map(|event| event_param_to_dyn_abi(event, cx, &self.attrs))
+                .collect(),
             anonymous: self.is_anonymous(),
         }
     }
 }
 
-impl<P> ToAbi for ast::Parameters<P> {
-    type DynAbi = Vec<Param>;
-
-    fn to_dyn_abi(&self, cx: &ExpCtxt<'_>) -> Self::DynAbi {
-        self.iter().map(|p| p.to_dyn_abi(cx)).collect()
-    }
+fn params_to_dyn_abi<P>(
+    params: &ast::Parameters<P>,
+    cx: &ExpCtxt<'_>,
+    parent_attrs: &[syn::Attribute],
+) -> Vec<Param> {
+    params
+        .iter()
+        .map(|param| {
+            let name =
+                param.name.as_ref().map(|name| cx.child_sol_name(name, &param.attrs, parent_attrs));
+            ty_to_param(name, &param.ty, cx)
+        })
+        .collect()
 }
 
-impl ToAbi for ast::VariableDeclaration {
-    type DynAbi = Param;
-
-    fn to_dyn_abi(&self, cx: &ExpCtxt<'_>) -> Self::DynAbi {
-        ty_to_param(self.name.as_ref().map(ast::SolIdent::as_string), &self.ty, cx)
-    }
-}
-
-impl ToAbi for ast::EventParameter {
-    type DynAbi = EventParam;
-
-    fn to_dyn_abi(&self, cx: &ExpCtxt<'_>) -> Self::DynAbi {
-        let name = self.name.as_ref().map(ast::SolIdent::as_string);
-        let Param { ty, name, components, internal_type } = ty_to_param(name, &self.ty, cx);
-        EventParam { ty, name, indexed: self.is_indexed(), internal_type, components }
-    }
+fn event_param_to_dyn_abi(
+    param: &ast::EventParameter,
+    cx: &ExpCtxt<'_>,
+    parent_attrs: &[syn::Attribute],
+) -> EventParam {
+    let name = param.name.as_ref().map(|name| cx.child_sol_name(name, &param.attrs, parent_attrs));
+    let Param { ty, name, components, internal_type } = ty_to_param(name, &param.ty, cx);
+    EventParam { ty, name, indexed: param.is_indexed(), internal_type, components }
 }
 
 impl ToAbi for ast::FunctionAttributes {
@@ -112,7 +122,7 @@ fn ty_to_param(name: Option<String>, ty: &ast::Type, cx: &ExpCtxt<'_>) -> Param 
                     ty: ty_name,
                     name: name.unwrap_or_default(),
                     internal_type: None,
-                    components: s.fields.to_dyn_abi(cx),
+                    components: params_to_dyn_abi(&s.fields, cx, &s.attrs),
                 };
             }
             cx.custom_type(custom_name)
@@ -161,7 +171,7 @@ fn rec_ty_abi_string_suffix(cx: &ExpCtxt<'_>, ty: &ast::Type, s: &mut String) {
 pub(super) fn constructor(function: &ItemFunction, cx: &ExpCtxt<'_>) -> Constructor {
     assert!(function.kind.is_constructor());
     Constructor {
-        inputs: function.parameters.to_dyn_abi(cx),
+        inputs: params_to_dyn_abi(&function.parameters, cx, &function.attrs),
         state_mutability: function.attributes.to_dyn_abi(cx),
     }
 }

--- a/crates/sol-macro-expander/src/expand/udt.rs
+++ b/crates/sol-macro-expander/src/expand/udt.rs
@@ -11,6 +11,7 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, udt: &ItemUdt) -> Result<TokenStream> {
     let ItemUdt { name, ty, .. } = udt;
 
     let (sol_attrs, mut attrs) = udt.split_attrs()?;
+    let sol_name = cx.sol_name(name, &udt.attrs);
     cx.type_derives(&mut attrs, std::iter::once(ty), true);
 
     let underlying_sol = cx.expand_type(ty);
@@ -64,7 +65,7 @@ pub(super) fn expand(cx: &ExpCtxt<'_>, udt: &ItemUdt) -> Result<TokenStream> {
 
             impl #name {
                 /// The Solidity type name.
-                pub const NAME: &'static str = stringify!(#name);
+                pub const NAME: &'static str = #sol_name;
 
                 /// Convert from the underlying value type.
                 #[inline]

--- a/crates/sol-macro-input/src/attr.rs
+++ b/crates/sol-macro-input/src/attr.rs
@@ -96,11 +96,11 @@ pub struct SolAttrs {
     /// `#[sol(alloy_contract = alloy_contract)]`
     pub alloy_contract: Option<Path>,
 
-    /// Overrides the generated Rust name for an overloaded function, event, or error.
+    /// Overrides the Solidity name while preserving the parsed Rust identifier.
     /// `#[sol(rename = "new_name")]`
     pub rename: Option<LitStr>,
-    // TODO: Implement
-    /// UNIMPLEMENTED: `#[sol(rename_all = "camelCase")]`
+    /// Applies a casing convention to child Solidity names.
+    /// `#[sol(rename_all = "camelCase")]`
     pub rename_all: Option<CasingStyle>,
 
     /// `#[sol(bytecode = "0x1234")]`
@@ -236,7 +236,7 @@ impl SolAttrs {
         merge_opt(&mut a.docs, &b.docs);
         merge_opt(&mut a.alloy_sol_types, &b.alloy_sol_types);
         merge_opt(&mut a.alloy_contract, &b.alloy_contract);
-        merge_opt(&mut a.rename, &b.rename);
+        // `rename` applies only to the item it annotates and is not inherited.
         merge_opt(&mut a.rename_all, &b.rename_all);
         merge_opt(&mut a.bytecode, &b.bytecode);
         merge_opt(&mut a.deployed_bytecode, &b.deployed_bytecode);
@@ -348,7 +348,6 @@ impl CasingStyle {
     }
 
     /// Apply the casing style to the given string.
-    #[allow(dead_code)]
     pub fn apply(self, s: &str) -> String {
         match self {
             Self::Pascal => s.to_upper_camel_case(),
@@ -509,6 +508,23 @@ mod tests {
             #[sol(ignore_unlinked)] => Ok(sol_attrs! { ignore_unlinked: true }),
             #[sol(ignore_unlinked = true)] => Ok(sol_attrs! { ignore_unlinked: true }),
             #[sol(ignore_unlinked = false)] => Ok(sol_attrs! { ignore_unlinked: false }),
+        }
+    }
+
+    #[test]
+    fn casing_style_apply() {
+        let cases = [
+            (CasingStyle::Camel, "someName"),
+            (CasingStyle::Kebab, "some-name"),
+            (CasingStyle::Pascal, "SomeName"),
+            (CasingStyle::ScreamingSnake, "SOME_NAME"),
+            (CasingStyle::Snake, "some_name"),
+            (CasingStyle::Lower, "somename"),
+            (CasingStyle::Upper, "SOMENAME"),
+            (CasingStyle::Verbatim, "some_name"),
+        ];
+        for (style, expected) in cases {
+            assert_eq!(style.apply("some_name"), expected);
         }
     }
 }

--- a/crates/sol-macro-input/src/attr.rs
+++ b/crates/sol-macro-input/src/attr.rs
@@ -96,8 +96,8 @@ pub struct SolAttrs {
     /// `#[sol(alloy_contract = alloy_contract)]`
     pub alloy_contract: Option<Path>,
 
-    // TODO: Implement
-    /// UNIMPLEMENTED: `#[sol(rename = "new_name")]`
+    /// Overrides the generated Rust name for an overloaded function, event, or error.
+    /// `#[sol(rename = "new_name")]`
     pub rename: Option<LitStr>,
     // TODO: Implement
     /// UNIMPLEMENTED: `#[sol(rename_all = "camelCase")]`

--- a/crates/sol-macro/doctests/events.rs
+++ b/crates/sol-macro/doctests/events.rs
@@ -21,6 +21,11 @@ sol! {
         bytes data;
     }
     event MyEvent2(Data indexed data);
+
+    #[sol(rename = "OldEvent")]
+    event RenamedEvent(uint256);
+    #[sol(rename = "NewEvent")]
+    event RenamedEvent(string);
 }
 
 #[test]
@@ -60,6 +65,9 @@ fn event() {
 
     assert_event_signature::<MyEvent2>("MyEvent2((bytes))");
     assert!(!MyEvent2::ANONYMOUS);
+
+    assert_event_signature::<OldEvent>("RenamedEvent(uint256)");
+    assert_event_signature::<NewEvent>("RenamedEvent(string)");
 }
 
 #[test]

--- a/crates/sol-macro/doctests/events.rs
+++ b/crates/sol-macro/doctests/events.rs
@@ -22,10 +22,10 @@ sol! {
     }
     event MyEvent2(Data indexed data);
 
-    #[sol(rename = "OldEvent")]
-    event RenamedEvent(uint256);
-    #[sol(rename = "NewEvent")]
-    event RenamedEvent(string);
+    #[sol(rename = "RenamedEvent")]
+    event OldEvent(uint256);
+    #[sol(rename = "RenamedEvent")]
+    event NewEvent(string);
 }
 
 #[test]

--- a/crates/sol-macro/doctests/function_like.rs
+++ b/crates/sol-macro/doctests/function_like.rs
@@ -11,12 +11,24 @@ sol! {
     function overloaded(uint256) returns (uint256);
     function overloaded(string);
 
+    // Overloaded items can override their generated Rust name without changing
+    // their Solidity signature.
+    #[sol(rename = "renamed_old")]
+    function renamed(uint256);
+    #[sol(rename = "renamed_new")]
+    function renamed(string);
+
     // State variables will generate getter functions just like in Solidity.
     mapping(uint k => bool v) public variableGetter;
 
     /// Implements [`SolError`].
     #[derive(Debug, PartialEq, Eq)]
     error MyError(uint256 a, uint256 b);
+
+    #[sol(rename = "OldError")]
+    error RenamedError(uint256);
+    #[sol(rename = "NewError")]
+    error RenamedError(string);
 }
 
 #[test]
@@ -35,6 +47,12 @@ fn function() {
     let _ = overloaded_2Call("hello".into());
     assert_call_signature::<overloaded_2Call>("overloaded(string)");
 
+    let _ = renamed_oldCall(U256::from(1));
+    assert_call_signature::<renamed_oldCall>("renamed(uint256)");
+
+    let _ = renamed_newCall("hello".into());
+    assert_call_signature::<renamed_newCall>("renamed(string)");
+
     // Exactly the same as `function variableGetter(uint256) returns (bool)`.
     let _ = variableGetterCall { k: U256::from(2) };
     assert_call_signature::<variableGetterCall>("variableGetter(uint256)");
@@ -43,6 +61,9 @@ fn function() {
 
 #[test]
 fn error() {
+    assert_error_signature::<OldError>("RenamedError(uint256)");
+    assert_error_signature::<NewError>("RenamedError(string)");
+
     assert_error_signature::<MyError>("MyError(uint256,uint256)");
     let call_data = hex!(
         "0000000000000000000000000000000000000000000000000000000000000001"

--- a/crates/sol-macro/doctests/function_like.rs
+++ b/crates/sol-macro/doctests/function_like.rs
@@ -11,12 +11,12 @@ sol! {
     function overloaded(uint256) returns (uint256);
     function overloaded(string);
 
-    // Overloaded items can override their generated Rust name without changing
-    // their Solidity signature.
-    #[sol(rename = "renamed_old")]
-    function renamed(uint256);
-    #[sol(rename = "renamed_new")]
-    function renamed(string);
+    // `rename` preserves a shared Solidity name while allowing descriptive,
+    // distinct Rust names.
+    #[sol(rename = "renamed")]
+    function renamed_old(uint256);
+    #[sol(rename = "renamed")]
+    function renamed_new(string);
 
     // State variables will generate getter functions just like in Solidity.
     mapping(uint k => bool v) public variableGetter;
@@ -25,14 +25,21 @@ sol! {
     #[derive(Debug, PartialEq, Eq)]
     error MyError(uint256 a, uint256 b);
 
-    #[sol(rename = "OldError")]
-    error RenamedError(uint256);
-    #[sol(rename = "NewError")]
-    error RenamedError(string);
+    #[sol(rename = "RenamedError")]
+    error OldError(uint256);
+    #[sol(rename = "RenamedError")]
+    error NewError(string);
+}
+
+sol! {
+    #![sol(rename_all = "camelCase")]
+
+    function snake_case(uint256);
 }
 
 #[test]
 fn function() {
+    assert_call_signature::<snake_caseCall>("snakeCase(uint256)");
     assert_call_signature::<fooCall>("foo(uint256,uint256)");
 
     let call = fooCall { a: U256::from(1), b: U256::from(2) };

--- a/crates/sol-macro/src/lib.rs
+++ b/crates/sol-macro/src/lib.rs
@@ -111,6 +111,8 @@ use syn::parse_macro_input;
 /// literals are also supported, such as `concat!` and `env!`.
 ///
 /// List of all `#[sol(...)]` supported values:
+/// - `rename = <string literal>` (overloaded functions, events, and errors only): overrides the
+///   generated Rust name without changing the Solidity signature.
 /// - `rpc [ = <bool = false>]` (contracts and alike only): generates a structs with methods to
 ///   construct `eth_call`s to an on-chain contract through Ethereum JSON RPC, similar to the
 ///   default behavior of [`abigen`]. This makes use of the [`alloy-contract`] crate.

--- a/crates/sol-macro/src/lib.rs
+++ b/crates/sol-macro/src/lib.rs
@@ -111,8 +111,12 @@ use syn::parse_macro_input;
 /// literals are also supported, such as `concat!` and `env!`.
 ///
 /// List of all `#[sol(...)]` supported values:
-/// - `rename = <string literal>` (overloaded functions, events, and errors only): overrides the
-///   generated Rust name without changing the Solidity signature.
+/// - `rename = <string literal>`: overrides the Solidity name while preserving the parsed Rust
+///   identifier. This can disambiguate overloads with semantic Rust names and preserve ABI names
+///   that are not valid Rust identifiers.
+/// - `rename_all = <casing>`: applies a casing convention to child Solidity names. Supported
+///   casings are `camelCase`, `kebab-case`, `PascalCase`, `SCREAMING_SNAKE_CASE`, `snake_case`,
+///   `lowercase`, `UPPERCASE`, and `verbatim`.
 /// - `rpc [ = <bool = false>]` (contracts and alike only): generates a structs with methods to
 ///   construct `eth_call`s to an on-chain contract through Ethereum JSON RPC, similar to the
 ///   default behavior of [`abigen`]. This makes use of the [`alloy-contract`] crate.

--- a/crates/sol-types/tests/macros/sol/abi.rs
+++ b/crates/sol-types/tests/macros/sol/abi.rs
@@ -12,6 +12,52 @@ macro_rules! abi_map {
 }
 
 #[test]
+fn renamed_items_and_parameters() {
+    sol! {
+        #![sol(abi, rename_all = "camelCase")]
+
+        #[sol(rename = "ActualStruct", rename_all = "snake_case")]
+        struct RustStruct {
+            uint256 SomeField;
+            #[sol(rename = "exactField")]
+            bool OtherField;
+        }
+
+        function use_struct(RustStruct InputStruct) returns (RustStruct OutputStruct);
+
+        #[sol(rename = "exactFunction", rename_all = "UPPERCASE")]
+        function RustFunction(
+            #[sol(rename = "exactInput")] uint256 FirstInput,
+            uint256 SecondInput
+        ) returns (uint256 OutputValue);
+
+        event RustEvent(#[sol(rename = "exactEventInput")] uint256 EventInput);
+        error RustError(#[sol(rename = "exactErrorInput")] uint256 ErrorInput);
+    }
+
+    let use_struct = use_structCall::abi();
+    assert_eq!(use_struct.name, "useStruct");
+    assert_eq!(use_struct.inputs[0].name, "inputStruct");
+    assert_eq!(use_struct.outputs[0].name, "outputStruct");
+    assert_eq!(use_struct.inputs[0].components[0].name, "some_field");
+    assert_eq!(use_struct.inputs[0].components[1].name, "exactField");
+
+    let function = RustFunctionCall::abi();
+    assert_eq!(function.name, "exactFunction");
+    assert_eq!(function.inputs[0].name, "exactInput");
+    assert_eq!(function.inputs[1].name, "SECONDINPUT");
+    assert_eq!(function.outputs[0].name, "OUTPUTVALUE");
+
+    let event = RustEvent::abi();
+    assert_eq!(event.name, "rustEvent");
+    assert_eq!(event.inputs[0].name, "exactEventInput");
+
+    let error = RustError::abi();
+    assert_eq!(error.name, "rustError");
+    assert_eq!(error.inputs[0].name, "exactErrorInput");
+}
+
+#[test]
 fn equal_abis() {
     let contract = Contract::abi::contract();
 

--- a/crates/sol-types/tests/macros/sol/json.rs
+++ b/crates/sol-types/tests/macros/sol/json.rs
@@ -5,6 +5,68 @@ use pretty_assertions::assert_eq;
 use std::borrow::Cow;
 
 #[test]
+fn dollar_sign_names() {
+    sol!(
+        #[sol(abi)]
+        DollarContract,
+        r#"[
+            {
+                "type": "function",
+                "name": "do$thing",
+                "inputs": [{"name": "value$old", "type": "uint256"}],
+                "outputs": [{"name": "result$new", "type": "uint256"}],
+                "stateMutability": "view"
+            },
+            {
+                "type": "function",
+                "name": "use$struct",
+                "inputs": [{
+                    "name": "input$value",
+                    "type": "tuple",
+                    "internalType": "struct Dollar$Struct",
+                    "components": [{"name": "field$value", "type": "uint256"}]
+                }],
+                "outputs": [],
+                "stateMutability": "nonpayable"
+            },
+            {
+                "type": "event",
+                "name": "Event$Name",
+                "inputs": [{"name": "event$value", "type": "uint256", "indexed": false}],
+                "anonymous": false
+            },
+            {
+                "type": "error",
+                "name": "Error$Name",
+                "inputs": [{"name": "error$value", "type": "uint256"}]
+            }
+        ]"#
+    );
+
+    let _ = DollarContract::do_thingCall { value_old: U256::ZERO };
+    assert_eq!(DollarContract::do_thingCall::SIGNATURE, "do$thing(uint256)");
+    assert_eq!(DollarContract::use_structCall::SIGNATURE, "use$struct((uint256))");
+    assert_eq!(DollarContract::Event_Name::SIGNATURE, "Event$Name(uint256)");
+    assert_eq!(DollarContract::Error_Name::SIGNATURE, "Error$Name(uint256)");
+
+    assert_eq!(DollarContract::Dollar_Struct::NAME, "Dollar$Struct");
+    assert_eq!(
+        DollarContract::Dollar_Struct::eip712_root_type(),
+        "Dollar$Struct(uint256 field$value)"
+    );
+
+    let abi = DollarContract::abi::contract();
+    let function = &abi.function("do$thing").unwrap()[0];
+    assert_eq!(function.inputs[0].name, "value$old");
+    assert_eq!(function.outputs[0].name, "result$new");
+    let use_struct = &abi.function("use$struct").unwrap()[0];
+    assert_eq!(use_struct.inputs[0].name, "input$value");
+    assert_eq!(use_struct.inputs[0].components[0].name, "field$value");
+    assert_eq!(abi.event("Event$Name").unwrap()[0].inputs[0].name, "event$value");
+    assert_eq!(abi.error("Error$Name").unwrap()[0].inputs[0].name, "error$value");
+}
+
+#[test]
 fn large_array() {
     sol!(
         #[sol(abi)]

--- a/crates/sol-types/tests/macros/sol/mod.rs
+++ b/crates/sol-types/tests/macros/sol/mod.rs
@@ -1085,20 +1085,20 @@ fn regression_overloads() {
 fn renamed_overloads() {
     sol! {
         contract Renamed {
-            #[sol(rename = "submit_old")]
-            function submit(uint256);
-            #[sol(rename = "submit_new")]
-            function submit(string);
+            #[sol(rename = "submit")]
+            function submit_old(uint256);
+            #[sol(rename = "submit")]
+            function submit_new(string);
 
-            #[sol(rename = "OldEvent")]
-            event RenamedEvent(uint256);
-            #[sol(rename = "NewEvent")]
-            event RenamedEvent(string);
+            #[sol(rename = "RenamedEvent")]
+            event OldEvent(uint256);
+            #[sol(rename = "RenamedEvent")]
+            event NewEvent(string);
 
-            #[sol(rename = "OldError")]
-            error RenamedError(uint256);
-            #[sol(rename = "NewError")]
-            error RenamedError(string);
+            #[sol(rename = "RenamedError")]
+            error OldError(uint256);
+            #[sol(rename = "RenamedError")]
+            error NewError(string);
         }
     }
 
@@ -1113,6 +1113,88 @@ fn renamed_overloads() {
     let error = Renamed::OldError(U256::ZERO);
     assert_eq!(Renamed::OldError::SIGNATURE, "RenamedError(uint256)");
     let _ = Renamed::RenamedErrors::OldError(error);
+}
+
+#[test]
+fn rename_and_rename_all() {
+    sol! {
+        #![sol(rename_all = "camelCase")]
+
+        #[sol(rename = "ActualStruct", rename_all = "SCREAMING_SNAKE_CASE")]
+        struct rust_struct {
+            #[sol(rename = "exactField")]
+            uint256 rust_field;
+            uint256 second_field;
+        }
+
+        #[sol(rename = "ActualChild")]
+        struct rust_child {
+            uint256 value;
+        }
+
+        #[sol(rename = "ActualParent")]
+        struct rust_parent {
+            rust_child child;
+        }
+
+        #[sol(rename = "ActualType")]
+        type rust_type is uint256;
+
+        #[sol(rename_all = "snake_case")]
+        enum rust_enum {
+            #[sol(rename = "first_value")]
+            FirstValue,
+            SecondValue
+        }
+
+        function do_thing(uint256 value);
+        event thing_happened(uint256 value);
+        error bad_thing(uint256 value);
+    }
+
+    let _ = rust_struct { rust_field: U256::ZERO, second_field: U256::ZERO };
+    assert_eq!(rust_struct::NAME, "ActualStruct");
+    assert_eq!(
+        rust_struct::eip712_root_type(),
+        "ActualStruct(uint256 exactField,uint256 SECOND_FIELD)"
+    );
+
+    assert_eq!(rust_child::NAME, "ActualChild");
+    assert_eq!(rust_parent::NAME, "ActualParent");
+    assert_eq!(rust_parent::eip712_root_type(), "ActualParent(ActualChild child)");
+    assert_eq!(rust_type::NAME, "ActualType");
+
+    assert_eq!(do_thingCall::SIGNATURE, "doThing(uint256)");
+    assert_eq!(thing_happened::SIGNATURE, "thingHappened(uint256)");
+    assert_eq!(bad_thing::SIGNATURE, "badThing(uint256)");
+    assert_eq!(
+        rust_enum::try_from(2).err().unwrap(),
+        alloy_sol_types::Error::InvalidEnumValue { name: "rustEnum", value: 2, max: 1 }
+    );
+}
+
+#[test]
+fn contract_rename_all() {
+    sol! {
+        #[sol(rename = "ActualContract", rename_all = "snake_case")]
+        contract RustContract {
+            struct InnerType {
+                uint256 someField;
+            }
+
+            function DoThing(uint256 SomeValue);
+            event SomeEvent(uint256 SomeValue);
+            error SomeError(uint256 SomeValue);
+            uint256 public SomeValue;
+        }
+    }
+
+    assert_eq!(RustContract::InnerType::NAME, "inner_type");
+    assert_eq!(RustContract::InnerType::eip712_root_type(), "inner_type(uint256 some_field)");
+    assert_eq!(RustContract::DoThingCall::SIGNATURE, "do_thing(uint256)");
+    assert_eq!(RustContract::SomeEvent::SIGNATURE, "some_event(uint256)");
+    assert_eq!(RustContract::SomeError::SIGNATURE, "some_error(uint256)");
+    assert_eq!(RustContract::SomeValueCall::SIGNATURE, "some_value()");
 }
 
 #[test]

--- a/crates/sol-types/tests/macros/sol/mod.rs
+++ b/crates/sol-types/tests/macros/sol/mod.rs
@@ -1082,6 +1082,40 @@ fn regression_overloads() {
 }
 
 #[test]
+fn renamed_overloads() {
+    sol! {
+        contract Renamed {
+            #[sol(rename = "submit_old")]
+            function submit(uint256);
+            #[sol(rename = "submit_new")]
+            function submit(string);
+
+            #[sol(rename = "OldEvent")]
+            event RenamedEvent(uint256);
+            #[sol(rename = "NewEvent")]
+            event RenamedEvent(string);
+
+            #[sol(rename = "OldError")]
+            error RenamedError(uint256);
+            #[sol(rename = "NewError")]
+            error RenamedError(string);
+        }
+    }
+
+    let call = Renamed::submit_oldCall(U256::ZERO);
+    assert_eq!(Renamed::submit_oldCall::SIGNATURE, "submit(uint256)");
+    let _ = Renamed::RenamedCalls::submit_old(call);
+
+    let event = Renamed::OldEvent { _0: U256::ZERO };
+    assert_eq!(Renamed::OldEvent::SIGNATURE, "RenamedEvent(uint256)");
+    let _ = Renamed::RenamedEvents::OldEvent(event);
+
+    let error = Renamed::OldError(U256::ZERO);
+    assert_eq!(Renamed::OldError::SIGNATURE, "RenamedError(uint256)");
+    let _ = Renamed::RenamedErrors::OldError(error);
+}
+
+#[test]
 fn normal_paths() {
     sol! {
         interface I {

--- a/crates/sol-types/tests/ui/rename.rs
+++ b/crates/sol-types/tests/ui/rename.rs
@@ -1,0 +1,24 @@
+use alloy_sol_types::sol;
+
+sol! {
+    #[sol(rename = "same")]
+    function first(uint256);
+    #[sol(rename = "same")]
+    function second(uint256);
+}
+
+sol! {
+    #![sol(rename_all = "lowercase")]
+
+    function foo_bar(uint256);
+    function foobar(uint256);
+}
+
+sol! {
+    struct InvalidFieldAttribute {
+        #[sol(rename = "one", rename = "two")]
+        uint256 field;
+    }
+}
+
+fn main() {}

--- a/crates/sol-types/tests/ui/rename.stderr
+++ b/crates/sol-types/tests/ui/rename.stderr
@@ -1,0 +1,23 @@
+error: function selector `0x8f5383a4` collides with `first`
+
+         = note: other declaration is here
+
+ --> tests/ui/rename.rs:7:14
+  |
+7 |     function second(uint256);
+  |              ^^^^^^
+
+error: function selector `0x14ba3f12` collides with `foo_bar`
+
+         = note: other declaration is here
+
+  --> tests/ui/rename.rs:14:14
+   |
+14 |     function foobar(uint256);
+   |              ^^^^^^
+
+error: duplicate attribute
+  --> tests/ui/rename.rs:19:31
+   |
+19 |         #[sol(rename = "one", rename = "two")]
+   |                               ^^^^^^


### PR DESCRIPTION
## Motivation

`sol!` parses Rust-compatible identifiers, but ABI names can require different stable names—for example semantic aliases for versioned overloads or JSON ABI identifiers containing `$`. The existing `rename` and `rename_all` attributes were parsed but unimplemented.

This enables names such as `BatchSubmitted_T10` in Rust while preserving `BatchSubmitted` as the Solidity event name, as requested in https://github.com/tempoxyz/zones/pull/1287#discussion_r3862162391.

## Solution

- Implement `rename` for functions, events, errors, structs, enums, UDVTs, contracts, parameters, fields, variants, and generated state-variable getters.
- Implement hierarchical `rename_all` for file, contract, and item scopes with explicit `rename` taking precedence.
- Preserve renamed Solidity names in selectors, signatures, EIP-712 metadata, JSON ABI output, and diagnostics while keeping parsed identifiers as Rust names.
- Preserve `$` identifiers end to end when converting JSON ABIs to `sol!` input.
- Add macro, ABI, EIP-712, JSON conversion, doctest, casing, collision, and invalid-attribute coverage.

Prompted by: @DaniPopes

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes