### PR TITLE
fix(primitives): use BITS in Signed overflowing_shl/shr overflow check

### DIFF
--- a/crates/primitives/src/signed/int.rs
+++ b/crates/primitives/src/signed/int.rs
@@ -957,6 +957,37 @@ mod tests {
     }
 
     #[test]
+    fn bit_shift_overflow() {
+        // Regression: the overflow check used a hardcoded `256` instead of the type's own
+        // `BITS`, so for every width below 256 a shift by `BITS..256` silently reported no
+        // overflow. `checked_shl`/`checked_shr` then returned `Some(ZERO)` instead of `None`,
+        // unlike `Uint` and the Rust primitives.
+        macro_rules! run_test {
+            ($i_struct:ty) => {
+                let bits = <$i_struct>::BITS;
+
+                assert_eq!(<$i_struct>::ONE.overflowing_shl(bits), (<$i_struct>::ZERO, true));
+                assert_eq!(<$i_struct>::ONE.checked_shl(bits), None);
+                assert_eq!(<$i_struct>::MINUS_ONE.overflowing_shr(bits), (<$i_struct>::ZERO, true));
+                assert_eq!(<$i_struct>::MINUS_ONE.checked_shr(bits), None);
+
+                // A shift by one less than the width is still in range.
+                assert!(!<$i_struct>::ONE.overflowing_shl(bits - 1).1);
+                assert!(<$i_struct>::ONE.checked_shl(bits - 1).is_some());
+                assert!(!<$i_struct>::MINUS_ONE.overflowing_shr(bits - 1).1);
+                assert!(<$i_struct>::MINUS_ONE.checked_shr(bits - 1).is_some());
+            };
+        }
+
+        run_test!(I8);
+        run_test!(I24);
+        run_test!(I64);
+        run_test!(I128);
+        run_test!(I160);
+        run_test!(I256);
+    }
+
+    #[test]
     fn arithmetic_shift_right() {
         macro_rules! run_test {
             ($i_struct:ty, $u_struct:ty) => {

--- a/crates/primitives/src/signed/ops.rs
+++ b/crates/primitives/src/signed/ops.rs
@@ -653,7 +653,7 @@ impl<const BITS: usize, const LIMBS: usize> Signed<BITS, LIMBS> {
     #[inline]
     #[must_use]
     pub fn overflowing_shl(self, rhs: usize) -> (Self, bool) {
-        if rhs >= 256 { (Self::ZERO, true) } else { (Self(self.0 << rhs), false) }
+        if rhs >= BITS { (Self::ZERO, true) } else { (Self(self.0 << rhs), false) }
     }
 
     /// Checked shift left. Computes `self << rhs`, returning `None` if `rhs` is
@@ -683,7 +683,7 @@ impl<const BITS: usize, const LIMBS: usize> Signed<BITS, LIMBS> {
     #[inline]
     #[must_use]
     pub fn overflowing_shr(self, rhs: usize) -> (Self, bool) {
-        if rhs >= 256 { (Self::ZERO, true) } else { (Self(self.0 >> rhs), false) }
+        if rhs >= BITS { (Self::ZERO, true) } else { (Self(self.0 >> rhs), false) }
     }
 
     /// Checked shift right. Computes `self >> rhs`, returning `None` if `rhs`


### PR DESCRIPTION
## Motivation

`Signed::overflowing_shl` and `Signed::overflowing_shr` compare the shift amount against a hardcoded `256` instead of the type's own `BITS`:

```rust
pub fn overflowing_shl(self, rhs: usize) -> (Self, bool) {
    if rhs >= 256 { (Self::ZERO, true) } else { (Self(self.0 << rhs), false) }
}
```

For every `Signed` width below 256, a shift by `BITS..256` falls into the `else` branch. The inner `Uint` shift still wraps the value to zero, but the returned flag says no overflow happened. That contradicts the documented contract ("a boolean indicating whether the shift value was larger than or equal to the number of bits") and propagates into `checked_shl` / `checked_shr`, which then hand back `Some(ZERO)` instead of `None`:

```rust
assert_eq!(I64::ONE.overflowing_shl(64), (I64::ZERO, false)); // expected (ZERO, true)
assert_eq!(I64::ONE.checked_shl(64),     Some(I64::ZERO));    // expected None
assert_eq!(I64::MINUS_ONE.checked_shr(64), Some(I64::ZERO));  // expected None
assert_eq!(I128::ONE.checked_shl(200),   Some(I128::ZERO));   // expected None
```

Both the unsigned sibling and the Rust primitives disagree with this:

```rust
assert_eq!(U64::from(1).overflowing_shl(64), (U64::ZERO, true));
assert_eq!(1i64.checked_shl(64), None);
```

So a caller that uses `checked_shl` to reject an out-of-range shift on `I8`..`I248` (the widths `sol!` generates for Solidity `intN`) silently gets a zero instead of an error.

## Solution

Compare against `BITS` instead of `256`.

Only the reported overflow flag changes. `wrapping_shl` / `wrapping_shr` and the `Shl` / `Shr` operators already produced zero across the whole `BITS..256` range, since `Uint`'s shift wraps there, so their output is byte-for-byte identical. `I256` is unaffected because `BITS == 256`.

Added `bit_shift_overflow`, which checks `overflowing_*` / `checked_*` at exactly `BITS` (must overflow) and at `BITS - 1` (must not) for `I8`, `I24`, `I64`, `I128`, `I160` and `I256`.

Verified on `main` (`cargo test -p alloy-primitives --lib bit_shift_overflow`):

- before the one-line fix: `1 failed`, panicking on the first `I8` assertion with `left: (0, false)` / `right: (0, true)`
- after: `1 passed`
- full crate suite after the fix: `100 passed; 0 failed` and `32 passed; 0 failed`, `cargo +nightly fmt --check` clean

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
