### PR TITLE
feat(primitives): add Postgres support to fixed-bytes wrappers

### DIFF
--- a/crates/primitives/src/bits/macros.rs
+++ b/crates/primitives/src/bits/macros.rs
@@ -235,6 +235,7 @@ macro_rules! wrap_fixed_bytes {
         $crate::impl_allocative!($name);
         $crate::impl_arbitrary!($name, $n);
         $crate::impl_rand!($name);
+        $crate::impl_postgres!($name, $n);
         $crate::impl_diesel!($name, $n);
         $crate::impl_sqlx!($name, $n);
 
@@ -813,6 +814,59 @@ macro_rules! impl_arbitrary {
 #[macro_export]
 #[cfg(not(feature = "arbitrary"))]
 macro_rules! impl_arbitrary {
+    ($t:ty, $n:literal) => {};
+}
+
+#[doc(hidden)]
+#[macro_export]
+#[cfg(feature = "postgres")]
+macro_rules! impl_postgres {
+    ($t:ty, $n:literal) => {
+        const _: () = {
+            use $crate::private::{
+                Box,
+                bytes::BytesMut,
+                postgres_types::{FromSql, IsNull, ToSql, Type},
+            };
+
+            impl ToSql for $t {
+                fn to_sql(
+                    &self,
+                    ty: &Type,
+                    out: &mut BytesMut,
+                ) -> Result<IsNull, Box<dyn $crate::private::core::error::Error + Sync + Send>>
+                {
+                    <$crate::FixedBytes<$n> as ToSql>::to_sql(&self.0, ty, out)
+                }
+
+                fn accepts(ty: &Type) -> bool {
+                    <$crate::FixedBytes<$n> as ToSql>::accepts(ty)
+                }
+
+                $crate::private::postgres_types::to_sql_checked!();
+            }
+
+            impl<'a> FromSql<'a> for $t {
+                fn from_sql(
+                    ty: &Type,
+                    raw: &'a [u8],
+                ) -> Result<Self, Box<dyn $crate::private::core::error::Error + Sync + Send>>
+                {
+                    <$crate::FixedBytes<$n> as FromSql>::from_sql(ty, raw).map(Self)
+                }
+
+                fn accepts(ty: &Type) -> bool {
+                    <$crate::FixedBytes<$n> as FromSql>::accepts(ty)
+                }
+            }
+        };
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+#[cfg(not(feature = "postgres"))]
+macro_rules! impl_postgres {
     ($t:ty, $n:literal) => {};
 }
 

--- a/crates/primitives/src/bits/macros.rs
+++ b/crates/primitives/src/bits/macros.rs
@@ -843,7 +843,14 @@ macro_rules! impl_postgres {
                     <$crate::FixedBytes<$n> as ToSql>::accepts(ty)
                 }
 
-                $crate::private::postgres_types::to_sql_checked!();
+                fn to_sql_checked(
+                    &self,
+                    ty: &Type,
+                    out: &mut BytesMut,
+                ) -> Result<IsNull, Box<dyn $crate::private::core::error::Error + Sync + Send>>
+                {
+                    $crate::private::postgres_types::__to_sql_checked(self, ty, out)
+                }
             }
 
             impl<'a> FromSql<'a> for $t {

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -94,7 +94,7 @@ pub use ::hex::serde as serde_hex;
 // Not public API.
 #[doc(hidden)]
 pub mod private {
-    pub use alloc::{borrow::Cow, vec::Vec};
+    pub use alloc::{borrow::Cow, boxed::Box, vec::Vec};
     pub use core::{
         self,
         borrow::{Borrow, BorrowMut},
@@ -126,6 +126,9 @@ pub mod private {
 
     #[cfg(feature = "diesel")]
     pub use diesel;
+
+    #[cfg(feature = "postgres")]
+    pub use {bytes, postgres_types};
 
     #[cfg(feature = "sqlx")]
     pub use sqlx_core;

--- a/crates/primitives/src/postgres.rs
+++ b/crates/primitives/src/postgres.rs
@@ -3,7 +3,7 @@
 //! **WARNING**: this module depends entirely on [`postgres_types`], which is not yet stable,
 //! therefore this module is exempt from the semver guarantees of this crate.
 
-use super::{FixedBytes, Sign, Signed};
+use super::{Address, FixedBytes, Sign, Signed};
 use bytes::{BufMut, BytesMut};
 use derive_more::Display;
 use postgres_types::{FromSql, IsNull, ToSql, Type, WrongType, accepts, to_sql_checked};
@@ -27,6 +27,27 @@ impl<const BITS: usize> ToSql for FixedBytes<BITS> {
 
 /// Converts `FixedBytes` From Postgres Bytea Type.
 impl<'a, const BITS: usize> FromSql<'a> for FixedBytes<BITS> {
+    accepts!(BYTEA);
+
+    fn from_sql(_: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        Ok(Self::try_from(raw)?)
+    }
+}
+
+/// Converts `Address` to Postgres Bytea Type.
+impl ToSql for Address {
+    fn to_sql(&self, _: &Type, out: &mut BytesMut) -> Result<IsNull, BoxedError> {
+        out.put_slice(&self[..]);
+        Ok(IsNull::No)
+    }
+
+    accepts!(BYTEA);
+
+    to_sql_checked!();
+}
+
+/// Converts `Address` From Postgres Bytea Type.
+impl<'a> FromSql<'a> for Address {
     accepts!(BYTEA);
 
     fn from_sql(_: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
@@ -419,5 +440,25 @@ mod test {
                 0x00, 0x01, // digit: 1
             ],
         );
+    }
+
+    #[test]
+    fn address_bytea_round_trip() {
+        let addr = Address::from([
+            0xd8, 0xda, 0x6b, 0xf2, 0x69, 0x64, 0xaf, 0x9d, 0x7e, 0xed, 0x9e, 0x03, 0xe5, 0x34,
+            0x15, 0xd3, 0x7a, 0xa9, 0x60, 0x45,
+        ]);
+
+        let mut bytes = BytesMut::with_capacity(20);
+        addr.to_sql(&Type::BYTEA, &mut bytes).unwrap();
+        assert_eq!(&*bytes, addr.as_slice());
+
+        assert_eq!(Address::from_sql(&Type::BYTEA, &bytes).unwrap(), addr);
+    }
+
+    #[test]
+    fn address_from_sql_rejects_wrong_length() {
+        assert!(Address::from_sql(&Type::BYTEA, &[0u8; 19]).is_err());
+        assert!(Address::from_sql(&Type::BYTEA, &[0u8; 21]).is_err());
     }
 }

--- a/crates/primitives/src/postgres.rs
+++ b/crates/primitives/src/postgres.rs
@@ -3,7 +3,7 @@
 //! **WARNING**: this module depends entirely on [`postgres_types`], which is not yet stable,
 //! therefore this module is exempt from the semver guarantees of this crate.
 
-use super::{Address, FixedBytes, Sign, Signed};
+use super::{FixedBytes, Sign, Signed};
 use bytes::{BufMut, BytesMut};
 use derive_more::Display;
 use postgres_types::{FromSql, IsNull, ToSql, Type, WrongType, accepts, to_sql_checked};
@@ -27,27 +27,6 @@ impl<const BITS: usize> ToSql for FixedBytes<BITS> {
 
 /// Converts `FixedBytes` From Postgres Bytea Type.
 impl<'a, const BITS: usize> FromSql<'a> for FixedBytes<BITS> {
-    accepts!(BYTEA);
-
-    fn from_sql(_: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
-        Ok(Self::try_from(raw)?)
-    }
-}
-
-/// Converts `Address` to Postgres Bytea Type.
-impl ToSql for Address {
-    fn to_sql(&self, _: &Type, out: &mut BytesMut) -> Result<IsNull, BoxedError> {
-        out.put_slice(&self[..]);
-        Ok(IsNull::No)
-    }
-
-    accepts!(BYTEA);
-
-    to_sql_checked!();
-}
-
-/// Converts `Address` From Postgres Bytea Type.
-impl<'a> FromSql<'a> for Address {
     accepts!(BYTEA);
 
     fn from_sql(_: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
@@ -372,7 +351,7 @@ impl<'a, const BITS: usize, const LIMBS: usize> FromSql<'a> for Signed<BITS, LIM
 mod test {
     use super::*;
 
-    use crate::I256;
+    use crate::{Address, I256};
 
     #[test]
     fn positive_i256_from_sql() {


### PR DESCRIPTION
Closes #1032. `Address` is declared with `wrap_fixed_bytes!` rather than being an alias, so the blanket `FixedBytes<BITS>` impls at the top of the module never applied to it and users had to wrap it themselves.

Kept to BYTEA only, matching what the `FixedBytes` pair accepts. `Signed` supports text and numeric types too but an address has no meaningful numeric reading, and adding a hex TEXT path would be a guess at what people store rather than something the issue asked for.
