### PR TITLE
chore(primitives): remove allocative support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,6 @@ rapidhash = { version = "4", default-features = false }
 rustc-hash = { version = "2.1", default-features = false }
 
 # misc
-allocative = { version = "0.3.2", default-features = false }
 alloy-rlp = { version = "0.3", default-features = false, features = ["core-net", "core-error"] }
 arbitrary = "1.3"
 bcs = "0.2.1"

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -102,9 +102,6 @@ arbitrary = { workspace = true, optional = true, features = ["derive"] }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-# allocative
-allocative = { workspace = true, optional = true }
-
 # postgres
 postgres-types = { workspace = true, optional = true }
 
@@ -193,7 +190,6 @@ serde = [
 schemars = ["dep:schemars"]
 borsh = ["dep:borsh", "ruint/borsh"]
 
-allocative = ["dep:allocative"]
 arbitrary = [
     "std",
     "dep:arbitrary",

--- a/crates/primitives/src/bits/fixed.rs
+++ b/crates/primitives/src/bits/fixed.rs
@@ -16,7 +16,6 @@ use hex::FromHex;
     Clone, Copy, PartialEq, Eq, Hash, Deref, DerefMut, From, Index, IndexMut, IntoIterator,
 )]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary, proptest_derive::Arbitrary))]
-#[cfg_attr(feature = "allocative", derive(allocative::Allocative))]
 #[cfg_attr(feature = "diesel", derive(diesel::AsExpression, diesel::FromSqlRow))]
 #[cfg_attr(feature = "diesel", diesel(sql_type = diesel::sql_types::Binary))]
 #[cfg_attr(feature = "rkyv", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]

--- a/crates/primitives/src/bits/macros.rs
+++ b/crates/primitives/src/bits/macros.rs
@@ -232,7 +232,6 @@ macro_rules! wrap_fixed_bytes {
         $crate::impl_rlp!($name, $n);
         $crate::impl_serde!($name);
         $crate::impl_schemars!($name, $n);
-        $crate::impl_allocative!($name);
         $crate::impl_arbitrary!($name, $n);
         $crate::impl_rand!($name);
         $crate::impl_diesel!($name, $n);
@@ -669,28 +668,6 @@ macro_rules! impl_borsh {
 #[cfg(not(feature = "borsh"))]
 macro_rules! impl_borsh {
     ($($t:tt)*) => {};
-}
-
-#[doc(hidden)]
-#[macro_export]
-#[cfg(feature = "allocative")]
-macro_rules! impl_allocative {
-    ($t:ty) => {
-        #[cfg_attr(docsrs, doc(cfg(feature = "allocative")))]
-        impl $crate::private::allocative::Allocative for $t {
-            #[inline]
-            fn visit<'a, 'b: 'a>(&self, visitor: &'a mut $crate::private::allocative::Visitor<'b>) {
-                $crate::private::allocative::Allocative::visit(&self.0, visitor)
-            }
-        }
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-#[cfg(not(feature = "allocative"))]
-macro_rules! impl_allocative {
-    ($t:ty) => {};
 }
 
 #[doc(hidden)]

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -112,9 +112,6 @@ pub mod private {
     #[cfg(feature = "rlp")]
     pub use alloy_rlp;
 
-    #[cfg(feature = "allocative")]
-    pub use allocative;
-
     #[cfg(feature = "serde")]
     pub use serde;
 


### PR DESCRIPTION
## Motivation

`allocative` is no longer maintained and its implementations for both the never type and `Infallible` will conflict once those types are unified in a future Rust version.

## Solution

Remove the `allocative` workspace dependency and the `alloy-primitives` feature, re-export, derives, and helper macro.

**This is temporary to unblock CI and should be rolled back before a release**
