### PR TITLE
fix(primitives): allow resizing a signed integer to the target's MIN

### DIFF
--- a/crates/primitives/src/signed/conversions.rs
+++ b/crates/primitives/src/signed/conversions.rs
@@ -35,16 +35,22 @@ impl<const BITS: usize, const LIMBS: usize, const BITS_SRC: usize, const LIMBS_S
     #[inline]
     fn uint_try_from(value: Signed<BITS_SRC, LIMBS_SRC>) -> Result<Self, ToUintError<Self>> {
         let (sign, abs) = value.into_sign_and_abs();
-        let resized = Self::from_raw(Uint::<BITS, LIMBS>::uint_try_from(abs).map_err(signed_err)?);
-        if resized.is_negative() {
-            return Err(ToUintError::ValueNegative(BITS, resized));
-        }
-        Ok(match sign {
-            Sign::Negative => {
-                resized.checked_neg().ok_or(ToUintError::ValueTooLarge(BITS, resized))?
+        let abs = Uint::<BITS, LIMBS>::uint_try_from(abs).map_err(signed_err)?;
+        let resized = Self::from_raw(abs);
+        match sign {
+            // When `abs == 2^(BITS-1)` the resized value is the target's `MIN`: its raw form
+            // has the sign bit set, so the old `is_negative()` check wrongly rejected it as
+            // overflow. Build negatives from sign+magnitude, which represents `MIN` exactly.
+            Sign::Negative => Self::checked_from_sign_and_abs(Sign::Negative, abs)
+                .ok_or(ToUintError::ValueTooLarge(BITS, resized)),
+            Sign::Positive => {
+                if resized.is_negative() {
+                    Err(ToUintError::ValueNegative(BITS, resized))
+                } else {
+                    Ok(resized)
+                }
             }
-            Sign::Positive => resized,
-        })
+        }
     }
 }
 
@@ -58,24 +64,24 @@ impl<const BITS: usize, const LIMBS: usize, const BITS_TARGET: usize, const LIMB
     ) -> Result<Signed<BITS_TARGET, LIMBS_TARGET>, FromUintError<Signed<BITS_TARGET, LIMBS_TARGET>>>
     {
         let (sign, abs) = self.into_sign_and_abs();
-        let resized = Signed::<BITS_TARGET, LIMBS_TARGET>::from_raw(
-            Uint::uint_try_to(&abs).map_err(|e| match e {
-                FromUintError::Overflow(b, t, v) => {
-                    FromUintError::Overflow(b, Signed(t), Signed(v))
+        let abs: Uint<BITS_TARGET, LIMBS_TARGET> = Uint::uint_try_to(&abs).map_err(|e| match e {
+            FromUintError::Overflow(b, t, v) => FromUintError::Overflow(b, Signed(t), Signed(v)),
+        })?;
+        let resized = Signed::<BITS_TARGET, LIMBS_TARGET>::from_raw(abs);
+        match sign {
+            // When `abs == 2^(BITS-1)` the resized value is the target's `MIN`: its raw form
+            // has the sign bit set, so the old `is_negative()` check wrongly rejected it as
+            // overflow. Build negatives from sign+magnitude, which represents `MIN` exactly.
+            Sign::Negative => Signed::checked_from_sign_and_abs(Sign::Negative, abs)
+                .ok_or(FromUintError::Overflow(BITS_TARGET, resized, Signed::MAX)),
+            Sign::Positive => {
+                if resized.is_negative() {
+                    Err(FromUintError::Overflow(BITS_TARGET, resized, Signed::MAX))
+                } else {
+                    Ok(resized)
                 }
-            })?,
-        );
-        if resized.is_negative() {
-            return Err(FromUintError::Overflow(BITS_TARGET, resized, Signed::MAX));
+            }
         }
-        Ok(match sign {
-            Sign::Negative => resized.checked_neg().ok_or(FromUintError::Overflow(
-                BITS_TARGET,
-                resized,
-                Signed::MAX,
-            ))?,
-            Sign::Positive => resized,
-        })
     }
 }
 
@@ -363,4 +369,24 @@ impl_conversions! {
     u32  [low_u64  -> low_u32,   as_u32],   i32  [low_u64  -> low_i32,   as_i32];
     u64  [low_u64  -> low_u64,   as_u64],   i64  [low_u64  -> low_i64,   as_i64];
     usize[low_u64  -> low_usize, as_usize], isize[low_u64  -> low_isize, as_isize];
+}
+
+#[cfg(test)]
+mod resize_min_tests {
+    use super::*;
+    use crate::aliases::{I8, I16};
+
+    #[test]
+    fn resize_negative_min_uint_try_to() {
+        let src = I16::try_from(-128i16).unwrap();
+        let dst: Result<I8, _> = UintTryTo::<I8>::uint_try_to(&src);
+        assert_eq!(dst.unwrap(), I8::MIN);
+    }
+
+    #[test]
+    fn resize_negative_min_uint_try_from() {
+        let src = I16::try_from(-128i16).unwrap();
+        let dst: Result<I8, _> = UintTryFrom::<I16>::uint_try_from(src);
+        assert_eq!(dst.unwrap(), I8::MIN);
+    }
 }


### PR DESCRIPTION
### What
`I16(-128).to::<I8>()` (and `I8::try_from` via `UintTryFrom`) returned an **error**, even though `-128` is exactly `I8::MIN` and representable.

### Why
Both cross-width `Signed → Signed` impls did, in essence:
```rust
let resized = /* absolute value, resized to the target width */;
if resized.is_negative() {          // runs for BOTH signs
    return Err(..);                 // rejects the MIN case here
}
match sign {
    Sign::Negative => resized.checked_neg()?,  // also fails for MIN
    Sign::Positive => resized,
}
```
For a magnitude of `2^(BITS-1)` (the target's `MIN`), the resized bits have the sign bit set, so `resized.is_negative()` is `true` and the value is rejected as overflow **before the sign is even consulted**. Even past that, `checked_neg()` can't produce `MIN`.

### Fix
Move the `is_negative()` guard into **only** the positive branch (where a set sign bit genuinely means positive overflow), and build the negative result with `checked_from_sign_and_abs(Sign::Negative, abs)` — which yields `MIN` when the magnitude is exactly `2^(BITS-1)` and errors only on real overflow. Applied symmetrically to `UintTryFrom<Signed>` and `UintTryTo<Signed>`, with tests for `I16(-128) → I8`.

Verified locally: `cargo test -p alloy-primitives --lib resize_negative_min` passes with the fix, fails without it; `cargo fmt --check` clean.

<sub>Developed with AI assistance (Claude Code); I directed, reviewed, and verified it locally.</sub>
