### PR TITLE
feat(sol-types): add strict ABI layout decoding

### DIFF
--- a/crates/sol-types/src/abi/decoder.rs
+++ b/crates/sol-types/src/abi/decoder.rs
@@ -31,6 +31,7 @@ pub struct AbiDecoderConfig {
     recursion_limit: usize,
     memory_limit: usize,
     validate: bool,
+    strict: bool,
 }
 
 impl Default for AbiDecoderConfig {
@@ -56,6 +57,7 @@ impl fmt::Debug for AbiDecoderConfig {
             .field("recursion_limit", &self.recursion_limit)
             .field("memory_limit", &self.memory_limit)
             .field("validate", &self.validate)
+            .field("strict", &self.strict)
             .finish()
     }
 }
@@ -64,7 +66,12 @@ impl AbiDecoderConfig {
     /// Creates a decoder configuration with the default limits.
     #[inline]
     pub const fn new() -> Self {
-        Self { recursion_limit: 16, memory_limit: DEFAULT_MEMORY_LIMIT, validate: false }
+        Self {
+            recursion_limit: 16,
+            memory_limit: DEFAULT_MEMORY_LIMIT,
+            validate: false,
+            strict: false,
+        }
     }
 
     /// Returns the maximum recursion depth.
@@ -83,6 +90,12 @@ impl AbiDecoderConfig {
     #[inline]
     pub const fn get_validate(&self) -> bool {
         self.validate
+    }
+
+    /// Returns whether strict ABI layout validation is enabled.
+    #[inline]
+    pub const fn get_strict(&self) -> bool {
+        self.strict
     }
 
     /// Sets the maximum recursion depth.
@@ -112,6 +125,16 @@ impl AbiDecoderConfig {
         self
     }
 
+    /// Enables or disables strict ABI layout validation.
+    ///
+    /// When enabled, dynamic values must be encoded contiguously and in the
+    /// same order as their offsets appear in the containing head.
+    #[inline]
+    pub const fn strict(mut self, strict: bool) -> Self {
+        self.strict = strict;
+        self
+    }
+
     /// Sets the maximum recursion depth in place.
     #[inline]
     pub const fn set_recursion_limit(&mut self, limit: usize) {
@@ -128,6 +151,12 @@ impl AbiDecoderConfig {
     #[inline]
     pub const fn set_validate(&mut self, validate: bool) {
         self.validate = validate;
+    }
+
+    /// Enables or disables strict ABI layout validation in place.
+    #[inline]
+    pub const fn set_strict(&mut self, strict: bool) {
+        self.strict = strict;
     }
 }
 
@@ -164,6 +193,8 @@ pub struct Decoder<'de, 'state> {
     config: AbiDecoderConfig,
     /// Shared decoder state.
     state: DecoderState<'state>,
+    /// The end of the most recently decoded sequence, relative to `buf`.
+    sequence_end: Option<usize>,
 }
 
 impl fmt::Debug for Decoder<'_, '_> {
@@ -207,12 +238,20 @@ impl<'de> Decoder<'de, 'static> {
             depth: 0,
             config: AbiDecoderConfig::new(),
             state: DecoderState::Root(Cell::new(0)),
+            sequence_end: None,
         }
     }
 
     #[inline]
     const fn with_config(buf: &'de [u8], config: AbiDecoderConfig) -> Self {
-        Self { buf, offset: 0, depth: 0, config, state: DecoderState::Root(Cell::new(0)) }
+        Self {
+            buf,
+            offset: 0,
+            depth: 0,
+            config,
+            state: DecoderState::Root(Cell::new(0)),
+            sequence_end: None,
+        }
     }
 }
 
@@ -225,12 +264,23 @@ impl<'de, 'state> Decoder<'de, 'state> {
             depth: parent.depth + 1,
             config: parent.config,
             state: DecoderState::Child(parent.memory_used()),
+            sequence_end: None,
         }
     }
 
     #[inline]
     const fn memory_used(&self) -> &Cell<usize> {
         self.state.memory_used()
+    }
+
+    #[inline]
+    pub(crate) const fn is_strict(&self) -> bool {
+        self.config.get_strict()
+    }
+
+    #[inline]
+    pub(crate) const fn set_sequence_end(&mut self, end: usize) {
+        self.sequence_end = Some(end);
     }
 
     /// Returns the current offset in the buffer.
@@ -498,6 +548,12 @@ pub fn decode_sequence_with_config<'de, T: TokenSeq<'de>>(
 ) -> Result<T> {
     let mut decoder = Decoder::with_config(data, config);
     let result = decoder.decode_sequence::<T>()?;
+    if config.get_strict() && decoder.sequence_end != Some(data.len()) {
+        return Err(Error::NonCanonicalOffset {
+            expected: decoder.sequence_end.unwrap_or_default(),
+            actual: data.len(),
+        });
+    }
     Ok(result)
 }
 
@@ -1046,18 +1102,134 @@ mod tests {
         assert_eq!(config.get_recursion_limit(), 16);
         assert_eq!(config.get_memory_limit(), DEFAULT_MEMORY_LIMIT);
         assert!(!config.get_validate());
+        assert!(!config.get_strict());
 
         config.set_recursion_limit(300);
         config.set_memory_limit(42);
         config.set_validate(true);
+        config.set_strict(true);
         assert_eq!(config.get_recursion_limit(), 300);
         assert_eq!(config.get_memory_limit(), 42);
         assert!(config.get_validate());
+        assert!(config.get_strict());
 
-        let config = AbiDecoderConfig::new().recursion_limit(400).memory_limit(24).validate(true);
+        let config = AbiDecoderConfig::new()
+            .recursion_limit(400)
+            .memory_limit(24)
+            .validate(true)
+            .strict(true);
         assert_eq!(config.get_recursion_limit(), 400);
         assert_eq!(config.get_memory_limit(), 24);
         assert!(config.get_validate());
+        assert!(config.get_strict());
+    }
+
+    #[test]
+    fn strict_decoder_accepts_canonical_layout() {
+        type Ty = (sol_data::Bytes, sol_data::Bytes);
+
+        let value = (bytes!("01"), bytes!("0203"));
+        let encoded = Ty::abi_encode_sequence(&value);
+        let decoded =
+            Ty::abi_decode_sequence_with_config(&encoded, AbiDecoderConfig::new().strict(true))
+                .unwrap();
+        assert_eq!(decoded, value);
+
+        type Array = sol_data::Array<sol_data::Bytes>;
+
+        let value = vec![bytes!("01"), bytes!("0203")];
+        let encoded = Array::abi_encode(&value);
+        let decoded =
+            Array::abi_decode_with_config(&encoded, AbiDecoderConfig::new().strict(true)).unwrap();
+        assert_eq!(decoded, value);
+
+        type FixedArray = sol_data::FixedArray<sol_data::Bytes, 2>;
+
+        let value = [bytes!("01"), bytes!("0203")];
+        let encoded = FixedArray::abi_encode(&value);
+        let decoded =
+            FixedArray::abi_decode_with_config(&encoded, AbiDecoderConfig::new().strict(true))
+                .unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn strict_decoder_rejects_aliased_offsets_before_second_allocation() {
+        type Ty = (sol_data::Array<sol_data::Address>, sol_data::Array<sol_data::Address>);
+
+        let encoded = hex!(
+            "0000000000000000000000000000000000000000000000000000000000000040"
+            "0000000000000000000000000000000000000000000000000000000000000040"
+            "0000000000000000000000000000000000000000000000000000000000000001"
+            "0000000000000000000000001111111111111111111111111111111111111111"
+        );
+        assert!(
+            Ty::abi_decode_sequence_with_config(&encoded, AbiDecoderConfig::new().strict(false),)
+                .is_ok()
+        );
+
+        let err = Ty::abi_decode_sequence_with_config(
+            &encoded,
+            AbiDecoderConfig::new().strict(true).memory_limit(32),
+        )
+        .unwrap_err();
+        assert_eq!(err, Error::NonCanonicalOffset { expected: 128, actual: 64 });
+    }
+
+    #[test]
+    fn strict_decoder_rejects_gaps_and_trailing_data() {
+        type Ty = (sol_data::Bytes, sol_data::Bytes);
+
+        let gapped = hex!(
+            "0000000000000000000000000000000000000000000000000000000000000040"
+            "00000000000000000000000000000000000000000000000000000000000000a0"
+            "0000000000000000000000000000000000000000000000000000000000000001"
+            "1100000000000000000000000000000000000000000000000000000000000000"
+            "0000000000000000000000000000000000000000000000000000000000000000"
+            "0000000000000000000000000000000000000000000000000000000000000001"
+            "2200000000000000000000000000000000000000000000000000000000000000"
+        );
+        assert!(
+            Ty::abi_decode_sequence_with_config(&gapped, AbiDecoderConfig::new().strict(false),)
+                .is_ok()
+        );
+        assert_eq!(
+            Ty::abi_decode_sequence_with_config(&gapped, AbiDecoderConfig::new().strict(true),)
+                .unwrap_err(),
+            Error::NonCanonicalOffset { expected: 128, actual: 160 }
+        );
+
+        let value = (bytes!("01"), bytes!("02"));
+        let mut trailing = Ty::abi_encode_sequence(&value);
+        trailing.extend([0_u8; 32]);
+        assert_eq!(
+            Ty::abi_decode_sequence_with_config(&trailing, AbiDecoderConfig::new().strict(true),)
+                .unwrap_err(),
+            Error::NonCanonicalOffset { expected: trailing.len() - 32, actual: trailing.len() }
+        );
+    }
+
+    #[test]
+    fn strict_decoder_rejects_nested_aliases() {
+        type Ty = (sol_data::Array<sol_data::Bytes>,);
+
+        let encoded = hex!(
+            "0000000000000000000000000000000000000000000000000000000000000020"
+            "0000000000000000000000000000000000000000000000000000000000000002"
+            "0000000000000000000000000000000000000000000000000000000000000040"
+            "0000000000000000000000000000000000000000000000000000000000000040"
+            "0000000000000000000000000000000000000000000000000000000000000001"
+            "1100000000000000000000000000000000000000000000000000000000000000"
+        );
+        assert!(
+            Ty::abi_decode_sequence_with_config(&encoded, AbiDecoderConfig::new().strict(false),)
+                .is_ok()
+        );
+        assert_eq!(
+            Ty::abi_decode_sequence_with_config(&encoded, AbiDecoderConfig::new().strict(true),)
+                .unwrap_err(),
+            Error::NonCanonicalOffset { expected: 128, actual: 64 }
+        );
     }
 
     #[test]

--- a/crates/sol-types/src/abi/token.rs
+++ b/crates/sol-types/src/abi/token.rs
@@ -128,6 +128,51 @@ pub trait TokenSeq<'a>: Token<'a> {
     fn decode_sequence(dec: &mut Decoder<'a, '_>) -> Result<Self>;
 }
 
+struct SequenceCursor {
+    next_tail: Option<usize>,
+}
+
+impl SequenceCursor {
+    #[inline]
+    fn new(dec: &Decoder<'_, '_>, head_words: usize) -> Result<Self> {
+        let next_tail = if dec.is_strict() {
+            Some(head_words.checked_mul(Word::len_bytes()).ok_or(crate::Error::Overrun)?)
+        } else {
+            None
+        };
+        Ok(Self { next_tail })
+    }
+
+    #[inline]
+    fn decode<'de, T: Token<'de>>(&mut self, dec: &mut Decoder<'de, '_>) -> Result<T> {
+        if !T::DYNAMIC {
+            return T::decode_from(dec);
+        }
+
+        let Some(expected) = self.next_tail else {
+            return T::decode_from(dec);
+        };
+
+        let actual = dec.peek_offset()?;
+        if actual != expected {
+            return Err(crate::Error::NonCanonicalOffset { expected, actual });
+        }
+
+        let token = T::decode_from(dec)?;
+        let tail_bytes =
+            token.tail_words().checked_mul(Word::len_bytes()).ok_or(crate::Error::Overrun)?;
+        self.next_tail = Some(expected.checked_add(tail_bytes).ok_or(crate::Error::Overrun)?);
+        Ok(token)
+    }
+
+    #[inline]
+    const fn finish(self, dec: &mut Decoder<'_, '_>) {
+        if let Some(end) = self.next_tail {
+            dec.set_sequence_end(end);
+        }
+    }
+}
+
 /// A single EVM word - T for any value type.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(transparent)]
@@ -372,9 +417,9 @@ impl<'de, T: Token<'de>, const N: usize> TokenSeq<'de> for FixedSeqToken<T, N> {
     fn decode_sequence(dec: &mut Decoder<'de, '_>) -> Result<Self> {
         let mut arr = crate::impl_core::uninit_array::<T, N>();
         // SAFETY: `arr` is valid writable memory for `N` elements.
-        // `decode_many_from` initializes all elements on success.
+        // `decode_sequence_impl` initializes all elements on success.
         unsafe {
-            T::decode_many_from(dec, &mut arr)?;
+            decode_sequence_impl(dec, &mut arr)?;
             Ok(Self(crate::impl_core::array_assume_init(arr)))
         }
     }
@@ -454,9 +499,9 @@ impl<'de, T: Token<'de>> Token<'de> for DynSeqToken<T> {
         child.reserve_elements::<T>(len)?;
         let mut tokens = vec_try_with_capacity(len)?;
         // SAFETY: `spare_capacity_mut` returns valid writable memory.
-        // `decode_many_from` initializes all `len` elements on success.
+        // `decode_sequence_impl` initializes all `len` elements on success.
         unsafe {
-            T::decode_many_from(&mut child, &mut tokens.spare_capacity_mut()[..len])?;
+            decode_sequence_impl(&mut child, &mut tokens.spare_capacity_mut()[..len])?;
             tokens.set_len(len);
         }
         Ok(Self(tokens))
@@ -494,7 +539,10 @@ impl<'de, T: Token<'de>> TokenSeq<'de> for DynSeqToken<T> {
 
     #[inline]
     fn decode_sequence(dec: &mut Decoder<'de, '_>) -> Result<Self> {
-        Self::decode_from(dec)
+        let mut cursor = SequenceCursor::new(dec, Self::MINIMUM_WORDS)?;
+        let token = cursor.decode(dec)?;
+        cursor.finish(dec);
+        Ok(token)
     }
 }
 
@@ -683,12 +731,19 @@ macro_rules! tuple_impls {
 
             #[inline]
             fn decode_sequence(dec: &mut Decoder<'de, '_>) -> Result<Self> {
-                Ok(($(
-                    match <$ty as Token>::decode_from(dec) {
+                let head_words = 0usize $(
+                    .checked_add(<$ty as Token>::MINIMUM_WORDS)
+                    .ok_or(crate::Error::Overrun)?
+                )+;
+                let mut cursor = SequenceCursor::new(dec, head_words)?;
+                let result = ($(
+                    match cursor.decode::<$ty>(dec) {
                         Ok(t) => t,
                         Err(e) => return Err(e),
                     },
-                )+))
+                )+);
+                cursor.finish(dec);
+                Ok(result)
             }
         }
     };
@@ -727,7 +782,8 @@ impl<'de> TokenSeq<'de> for () {
     fn encode_sequence(&self, _enc: &mut Encoder) {}
 
     #[inline]
-    fn decode_sequence(_dec: &mut Decoder<'de, '_>) -> Result<Self> {
+    fn decode_sequence(dec: &mut Decoder<'de, '_>) -> Result<Self> {
+        SequenceCursor::new(dec, 0)?.finish(dec);
         Ok(())
     }
 }
@@ -752,6 +808,28 @@ fn encode_sequence_impl<'de, T: Token<'de>>(tokens: &[T], enc: &mut Encoder) {
     } else {
         T::head_append_many(tokens, enc);
     }
+}
+
+/// Shared implementation for decoding a homogeneous token sequence.
+///
+/// # Safety
+///
+/// `out` must point to valid, writable memory for `out.len()` elements.
+#[inline]
+unsafe fn decode_sequence_impl<'a, 'de, T: Token<'de>>(
+    dec: &mut Decoder<'de, '_>,
+    out: &'a mut [MaybeUninit<T>],
+) -> Result<&'a mut [T]> {
+    let head_words = T::MINIMUM_WORDS.checked_mul(out.len()).ok_or(crate::Error::Overrun)?;
+    let mut cursor = SequenceCursor::new(dec, head_words)?;
+    let decoded = if T::DYNAMIC && dec.is_strict() {
+        try_init_each(out, || cursor.decode(dec))?
+    } else {
+        // SAFETY: upheld by the caller.
+        unsafe { T::decode_many_from(dec, out)? }
+    };
+    cursor.finish(dec);
+    Ok(decoded)
 }
 
 /// Initializes each element of `out` by calling `f` for each slot.

--- a/crates/sol-types/src/errors.rs
+++ b/crates/sol-types/src/errors.rs
@@ -38,6 +38,14 @@ pub enum Error {
     /// Validation reserialization did not match input.
     ReserMismatch,
 
+    /// A dynamic offset does not match the canonical ABI layout.
+    NonCanonicalOffset {
+        /// The canonical offset.
+        expected: usize,
+        /// The decoded offset.
+        actual: usize,
+    },
+
     /// ABI Decoding recursion limit exceeded.
     RecursionLimitExceeded(usize),
 
@@ -123,6 +131,9 @@ impl fmt::Display for Error {
                 }
             }
             Self::Reserve(e) => e.fmt(f),
+            Self::NonCanonicalOffset { expected, actual } => {
+                write!(f, "non-canonical ABI offset: expected {expected}, got {actual}")
+            }
             Self::InvalidEnumValue { name, value, max } => {
                 write!(f, "`{value}` is not a valid {name} enum value (max: `{max}`)")
             }


### PR DESCRIPTION
## Motivation

ABI offsets may alias or overlap dynamic tails, allowing the same encoded data to be decoded repeatedly and amplify allocations. Consumers need an opt-in mode that requires canonical, contiguous dynamic layout and rejects invalid offsets before following them.

## Solution

Add a strict option to AbiDecoderConfig, disabled by default. Strict decoding tracks the next canonical tail offset independently for each tuple or array sequence, validates each dynamic offset before decoding its value, and rejects gaps, aliases, out-of-order tails, and trailing data. Static and permissive homogeneous sequences continue using the existing batch decode path.

Add focused coverage for canonical tuples and arrays, aliased offsets, nested aliases, gaps, trailing data, and rejection before a second aliased allocation.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes

## Verification

- cargo +nightly clippy -p alloy-sol-types --lib --tests
- cargo test -p alloy-sol-types --lib (131 passed)
- cargo fmt --package alloy-sol-types -- --check