### PR TITLE
feat(sol-types): add strict ABI decoding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,13 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-on-failure: true
+      - name: disable allocative on nightly
+        if: ${{ matrix.rust == 'nightly' }}
+        shell: bash
+        run: |
+          sed -i '/^allocative = { workspace = true, optional = true }$/d' crates/primitives/Cargo.toml
+          sed -i 's/^allocative = \["dep:allocative"\]$/allocative = []/' crates/primitives/Cargo.toml
+          sed -i 's/feature = "allocative"/all(feature = "allocative", any())/g' crates/primitives/src/lib.rs crates/primitives/src/bits/{fixed.rs,macros.rs}
       # Only run tests on latest stable and above
       - name: pin deps
         if: ${{ matrix.rust == '1.85' }} # MSRV
@@ -94,6 +101,11 @@ jobs:
           toolchain: nightly
           components: miri
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - name: disable allocative on nightly
+        run: |
+          sed -i '/^allocative = { workspace = true, optional = true }$/d' crates/primitives/Cargo.toml
+          sed -i 's/^allocative = \["dep:allocative"\]$/allocative = []/' crates/primitives/Cargo.toml
+          sed -i 's/feature = "allocative"/all(feature = "allocative", any())/g' crates/primitives/src/lib.rs crates/primitives/src/bits/{fixed.rs,macros.rs}
       - run: cargo miri test ${{ matrix.flags }}
 
   wasm:
@@ -139,6 +151,12 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-on-failure: true
+      - name: disable allocative on nightly
+        if: ${{ matrix.rust == 'nightly' }}
+        run: |
+          sed -i '/^allocative = { workspace = true, optional = true }$/d' crates/primitives/Cargo.toml
+          sed -i 's/^allocative = \["dep:allocative"\]$/allocative = []/' crates/primitives/Cargo.toml
+          sed -i 's/feature = "allocative"/all(feature = "allocative", any())/g' crates/primitives/src/lib.rs crates/primitives/src/bits/{fixed.rs,macros.rs}
       - name: cargo hack
         run: |
           args=(${{ matrix.flags }})
@@ -194,6 +212,11 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-on-failure: true
+      - name: disable allocative on nightly
+        run: |
+          sed -i '/^allocative = { workspace = true, optional = true }$/d' crates/primitives/Cargo.toml
+          sed -i 's/^allocative = \["dep:allocative"\]$/allocative = []/' crates/primitives/Cargo.toml
+          sed -i 's/feature = "allocative"/all(feature = "allocative", any())/g' crates/primitives/src/lib.rs crates/primitives/src/bits/{fixed.rs,macros.rs}
       - run: cargo clippy --workspace --all-targets --all-features
         env:
           RUSTFLAGS: -Dwarnings

--- a/crates/dyn-abi/src/dynamic/token.rs
+++ b/crates/dyn-abi/src/dynamic/token.rs
@@ -184,6 +184,7 @@ impl<'a> DynToken<'a> {
 
                 let required_words =
                     minimum_words.checked_mul(size).ok_or(alloy_sol_types::Error::Overrun)?;
+                child.set_strict_head_words(required_words)?;
                 if child.remaining_words() < required_words {
                     return Err(alloy_sol_types::Error::Overrun.into());
                 }
@@ -213,9 +214,18 @@ impl<'a> DynToken<'a> {
     pub(crate) fn decode_sequence_populate(&mut self, dec: &mut Decoder<'a, '_>) -> Result<()> {
         match self {
             Self::FixedSeq(buf, size) => {
+                let head_words = buf
+                    .iter()
+                    .take(*size)
+                    .try_fold(0usize, |sum, item| sum.checked_add(item.minimum_words()))
+                    .ok_or(alloy_sol_types::Error::Overrun)?;
+                dec.set_strict_head_words(head_words)?;
                 buf.to_mut().iter_mut().take(*size).try_for_each(|item| item.decode_populate(dec))
             }
-            Self::DynSeq { .. } => self.decode_populate(dec),
+            Self::DynSeq { .. } => {
+                dec.set_strict_head_words(1)?;
+                self.decode_populate(dec)
+            }
             _ => Err(Error::custom("Called decode_sequence_populate on non-sequence token")),
         }
     }

--- a/crates/sol-macro-expander/src/expand/contract.rs
+++ b/crates/sol-macro-expander/src/expand/contract.rs
@@ -868,7 +868,7 @@ impl CallLikeExpander<'_> {
                 match topics.first().copied() {
                     #(
                         Some(<#variants as alloy_sol_types::#trait_>::SIGNATURE_HASH) =>
-                            #ret <#variants as alloy_sol_types::#trait_>::decode_raw_log(topics, data)
+                            #ret <#variants as alloy_sol_types::#trait_>::decode_raw_log_with_config(topics, data, config)
                                 .map(Self::#variants),
                     )*
                     _ => { #ret_err }
@@ -879,32 +879,6 @@ impl CallLikeExpander<'_> {
             let variants = events.iter().filter(|e| e.is_anonymous()).map(e_name);
             quote! {
                 #(
-                    if let Ok(res) = <#variants as alloy_sol_types::#trait_>::decode_raw_log(topics, data) {
-                        return Ok(Self::#variants(res));
-                    }
-                )*
-                #err
-            }
-        });
-        let non_anon_config_impl = has_non_anon.then(|| {
-            let variants = events.iter().filter(|e| !e.is_anonymous()).map(e_name);
-            let ret = has_anon.then(|| quote!(return));
-            let ret_err = (!has_anon).then_some(&err);
-            quote! {
-                match topics.first().copied() {
-                    #(
-                        Some(<#variants as alloy_sol_types::#trait_>::SIGNATURE_HASH) =>
-                            #ret <#variants as alloy_sol_types::#trait_>::decode_raw_log_with_config(topics, data, config)
-                                .map(Self::#variants),
-                    )*
-                    _ => { #ret_err }
-                }
-            }
-        });
-        let anon_config_impl = has_anon.then(|| {
-            let variants = events.iter().filter(|e| e.is_anonymous()).map(e_name);
-            quote! {
-                #(
                     if let Ok(res) = <#variants as alloy_sol_types::#trait_>::decode_raw_log_with_config(topics, data, config) {
                         return Ok(Self::#variants(res));
                     }
@@ -912,7 +886,6 @@ impl CallLikeExpander<'_> {
                 #err
             }
         });
-
         let into_impl = {
             let variants = events.iter().map(e_name);
             let v2 = variants.clone();
@@ -945,8 +918,11 @@ impl CallLikeExpander<'_> {
                 const COUNT: usize = #count;
 
                 fn decode_raw_log(topics: &[alloy_sol_types::Word], data: &[u8]) -> alloy_sol_types::Result<Self> {
-                    #non_anon_impl
-                    #anon_impl
+                    Self::decode_raw_log_with_config(
+                        topics,
+                        data,
+                        alloy_sol_types::abi::AbiDecoderConfig::default(),
+                    )
                 }
 
                 fn decode_raw_log_with_config(
@@ -954,8 +930,8 @@ impl CallLikeExpander<'_> {
                     data: &[u8],
                     config: alloy_sol_types::abi::AbiDecoderConfig,
                 ) -> alloy_sol_types::Result<Self> {
-                    #non_anon_config_impl
-                    #anon_config_impl
+                    #non_anon_impl
+                    #anon_impl
                 }
             }
 

--- a/crates/sol-macro-expander/src/expand/contract.rs
+++ b/crates/sol-macro-expander/src/expand/contract.rs
@@ -852,6 +852,16 @@ impl CallLikeExpander<'_> {
 
         let e_name = |&e: &&ItemEvent| self.cx.overloaded_name(e.into());
         let err = quote! {
+            if topics
+                .len()
+                .checked_mul(alloy_sol_types::Word::len_bytes())
+                .and_then(|len| len.checked_add(data.len()))
+                .is_none_or(|len| len > config.get_memory_limit())
+            {
+                return alloy_sol_types::private::Err(alloy_sol_types::Error::MemoryLimitExceeded(
+                    config.get_memory_limit(),
+                ));
+            }
             alloy_sol_types::private::Err(alloy_sol_types::Error::InvalidLog {
                 name: <Self as alloy_sol_types::SolEventInterface>::NAME,
                 log: alloy_sol_types::private::Box::new(alloy_sol_types::private::LogData::new_unchecked(
@@ -879,8 +889,12 @@ impl CallLikeExpander<'_> {
             let variants = events.iter().filter(|e| e.is_anonymous()).map(e_name);
             quote! {
                 #(
-                    if let Ok(res) = <#variants as alloy_sol_types::#trait_>::decode_raw_log_with_config(topics, data, config) {
-                        return Ok(Self::#variants(res));
+                    match <#variants as alloy_sol_types::#trait_>::decode_raw_log_with_config(topics, data, config) {
+                        Ok(res) => return Ok(Self::#variants(res)),
+                        Err(alloy_sol_types::Error::MemoryLimitExceeded(limit)) => {
+                            return alloy_sol_types::private::Err(alloy_sol_types::Error::MemoryLimitExceeded(limit));
+                        }
+                        Err(_) => {}
                     }
                 )*
                 #err

--- a/crates/sol-macro-expander/src/expand/contract.rs
+++ b/crates/sol-macro-expander/src/expand/contract.rs
@@ -888,15 +888,23 @@ impl CallLikeExpander<'_> {
         let anon_impl = has_anon.then(|| {
             let variants = events.iter().filter(|e| e.is_anonymous()).map(e_name);
             quote! {
+                let mut resource_error = None;
                 #(
                     match <#variants as alloy_sol_types::#trait_>::decode_raw_log_with_config(topics, data, config) {
                         Ok(res) => return Ok(Self::#variants(res)),
-                        Err(alloy_sol_types::Error::MemoryLimitExceeded(limit)) => {
-                            return alloy_sol_types::private::Err(alloy_sol_types::Error::MemoryLimitExceeded(limit));
+                        Err(err @ (
+                            alloy_sol_types::Error::MemoryLimitExceeded(_)
+                            | alloy_sol_types::Error::RecursionLimitExceeded(_)
+                            | alloy_sol_types::Error::Reserve(_)
+                        )) => {
+                            resource_error.get_or_insert(err);
                         }
                         Err(_) => {}
                     }
                 )*
+                if let Some(err) = resource_error {
+                    return alloy_sol_types::private::Err(err);
+                }
                 #err
             }
         });

--- a/crates/sol-macro-expander/src/expand/contract.rs
+++ b/crates/sol-macro-expander/src/expand/contract.rs
@@ -886,6 +886,32 @@ impl CallLikeExpander<'_> {
                 #err
             }
         });
+        let non_anon_config_impl = has_non_anon.then(|| {
+            let variants = events.iter().filter(|e| !e.is_anonymous()).map(e_name);
+            let ret = has_anon.then(|| quote!(return));
+            let ret_err = (!has_anon).then_some(&err);
+            quote! {
+                match topics.first().copied() {
+                    #(
+                        Some(<#variants as alloy_sol_types::#trait_>::SIGNATURE_HASH) =>
+                            #ret <#variants as alloy_sol_types::#trait_>::decode_raw_log_with_config(topics, data, config)
+                                .map(Self::#variants),
+                    )*
+                    _ => { #ret_err }
+                }
+            }
+        });
+        let anon_config_impl = has_anon.then(|| {
+            let variants = events.iter().filter(|e| e.is_anonymous()).map(e_name);
+            quote! {
+                #(
+                    if let Ok(res) = <#variants as alloy_sol_types::#trait_>::decode_raw_log_with_config(topics, data, config) {
+                        return Ok(Self::#variants(res));
+                    }
+                )*
+                #err
+            }
+        });
 
         let into_impl = {
             let variants = events.iter().map(e_name);
@@ -921,6 +947,15 @@ impl CallLikeExpander<'_> {
                 fn decode_raw_log(topics: &[alloy_sol_types::Word], data: &[u8]) -> alloy_sol_types::Result<Self> {
                     #non_anon_impl
                     #anon_impl
+                }
+
+                fn decode_raw_log_with_config(
+                    topics: &[alloy_sol_types::Word],
+                    data: &[u8],
+                    config: alloy_sol_types::abi::AbiDecoderConfig,
+                ) -> alloy_sol_types::Result<Self> {
+                    #non_anon_config_impl
+                    #anon_config_impl
                 }
             }
 

--- a/crates/sol-macro-expander/src/expand/contract.rs
+++ b/crates/sol-macro-expander/src/expand/contract.rs
@@ -940,7 +940,7 @@ impl CallLikeExpander<'_> {
                 const COUNT: usize = #count;
 
                 fn decode_raw_log(topics: &[alloy_sol_types::Word], data: &[u8]) -> alloy_sol_types::Result<Self> {
-                    Self::decode_raw_log_with_config(
+                    <Self as alloy_sol_types::SolEventInterface>::decode_raw_log_with_config(
                         topics,
                         data,
                         alloy_sol_types::abi::AbiDecoderConfig::default(),

--- a/crates/sol-types/src/abi/decoder.rs
+++ b/crates/sol-types/src/abi/decoder.rs
@@ -1262,6 +1262,43 @@ mod tests {
     }
 
     #[test]
+    fn strict_decoder_accepts_dynamic_fixed_array_sequence() {
+        type Ty = sol_data::FixedArray<sol_data::Bytes, 2>;
+
+        let value = [bytes![0x11u8; 1], bytes!("2233")];
+        let encoded = Ty::abi_encode_sequence(&value);
+
+        assert_eq!(
+            Ty::abi_decode_sequence_with_config(&encoded, AbiDecoderConfig::new().strict(true)),
+            Ok(value),
+        );
+    }
+
+    #[test]
+    fn strict_decoder_accepts_empty_dynamic_sequences() {
+        type Fixed = sol_data::FixedArray<sol_data::Bytes, 0>;
+
+        let fixed: [alloy_primitives::Bytes; 0] = [];
+        let encoded = Fixed::abi_encode(&fixed);
+        assert_eq!(
+            Fixed::abi_decode_with_config(&encoded, AbiDecoderConfig::new().strict(true)),
+            Ok(fixed),
+        );
+
+        type Dynamic = sol_data::Array<()>;
+
+        let dynamic = vec![(), ()];
+        let encoded = Dynamic::abi_encode(&dynamic);
+        assert_eq!(
+            Dynamic::abi_decode_sequence_with_config(
+                &encoded,
+                AbiDecoderConfig::new().strict(true)
+            ),
+            Ok(dynamic),
+        );
+    }
+
+    #[test]
     fn strict_decoder_rejects_gapped_offsets() {
         type Ty = (sol_data::String, sol_data::String);
 

--- a/crates/sol-types/src/abi/decoder.rs
+++ b/crates/sol-types/src/abi/decoder.rs
@@ -98,6 +98,15 @@ impl AbiDecoderConfig {
         self.strict
     }
 
+    /// Returns whether this is the default decoder configuration.
+    #[inline]
+    pub const fn is_default(&self) -> bool {
+        self.recursion_limit == 16
+            && self.memory_limit == DEFAULT_MEMORY_LIMIT
+            && !self.validate
+            && !self.strict
+    }
+
     /// Sets the maximum recursion depth.
     #[inline]
     pub const fn recursion_limit(mut self, limit: usize) -> Self {
@@ -227,7 +236,9 @@ pub struct Decoder<'de, 'state> {
 impl fmt::Debug for Decoder<'_, '_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut body = self.buf.chunks(32).map(hex::encode_prefixed).collect::<Vec<_>>();
-        body[self.offset / 32].push_str(" <-- Next Word");
+        if let Some(word) = body.get_mut(self.offset / 32) {
+            word.push_str(" <-- Next Word");
+        }
 
         f.debug_struct("Decoder")
             .field("buf", &body)
@@ -319,7 +330,7 @@ impl<'de, 'state> Decoder<'de, 'state> {
     }
 
     #[inline]
-    const fn is_strict(&self) -> bool {
+    pub(crate) const fn is_strict(&self) -> bool {
         self.config.get_strict()
     }
 
@@ -538,9 +549,9 @@ impl<'de, 'state> Decoder<'de, 'state> {
 impl Drop for Decoder<'_, '_> {
     fn drop(&mut self) {
         if let Some(parent) = self.state.strict_parent() {
-            parent.next_offset.set(
-                parent.start.saturating_add(self.offset.max(self.state.strict_next_offset().get())),
-            );
+            let offset =
+                parent.start.saturating_add(self.offset.max(self.state.strict_next_offset().get()));
+            parent.next_offset.set(parent.next_offset.get().max(offset));
         }
     }
 }
@@ -977,14 +988,16 @@ mod tests {
     }
 
     #[test]
-    fn decode_huge_dynamic_array_of_zero_sized_type() {
+    fn decode_huge_dynamic_array_of_zero_sized_type_exceeds_memory_limit() {
         type MyTy = sol_data::Array<()>;
         let mut encoded = Vec::with_capacity(64);
         encoded.extend_from_slice(pad_usize(32).as_slice());
         encoded.extend_from_slice(pad_usize(u32::MAX as usize).as_slice());
 
-        let token = decode_sequence::<<MyTy as SolType>::Token<'_>>(&encoded).unwrap();
-        assert_eq!(token.0.len(), u32::MAX as usize);
+        assert_eq!(
+            decode_sequence::<<MyTy as SolType>::Token<'_>>(&encoded),
+            Err(Error::MemoryLimitExceeded(DEFAULT_MEMORY_LIMIT)),
+        );
     }
 
     #[test]
@@ -1167,6 +1180,7 @@ mod tests {
         assert_eq!(config.get_memory_limit(), DEFAULT_MEMORY_LIMIT);
         assert!(!config.get_validate());
         assert!(!config.get_strict());
+        assert!(config.is_default());
 
         config.set_recursion_limit(300);
         config.set_memory_limit(42);
@@ -1176,12 +1190,34 @@ mod tests {
         assert_eq!(config.get_memory_limit(), 42);
         assert!(config.get_validate());
         assert!(config.get_strict());
+        assert!(!config.is_default());
 
         let config = AbiDecoderConfig::new().recursion_limit(400).memory_limit(24).strict(true);
         assert_eq!(config.get_recursion_limit(), 400);
         assert_eq!(config.get_memory_limit(), 24);
         assert!(config.get_validate());
         assert!(config.get_strict());
+    }
+
+    #[test]
+    fn child_drop_keeps_the_furthest_strict_offset() {
+        let decoder = Decoder::with_config(&[0; 192], AbiDecoderConfig::new().strict(true));
+        let mut first = decoder.child(64).unwrap();
+        let mut second = decoder.child(128).unwrap();
+        first.take_word().unwrap();
+        second.take_word().unwrap();
+
+        drop(second);
+        drop(first);
+
+        assert_eq!(decoder.state.strict_next_offset().get(), 160);
+    }
+
+    #[test]
+    fn exhausted_decoder_debug_does_not_panic() {
+        let mut decoder = Decoder::new(&[0; 32]);
+        decoder.take_word().unwrap();
+        assert!(!format!("{decoder:?}").is_empty());
     }
 
     #[test]
@@ -1321,7 +1357,7 @@ mod tests {
 
         type Dynamic = sol_data::Array<()>;
 
-        let dynamic = vec![(), ()];
+        let dynamic = vec![];
         let encoded = Dynamic::abi_encode(&dynamic);
         assert_eq!(
             Dynamic::abi_decode_sequence_with_config(
@@ -1329,6 +1365,26 @@ mod tests {
                 AbiDecoderConfig::new().strict(true)
             ),
             Ok(dynamic),
+        );
+    }
+
+    #[test]
+    fn strict_decoder_rejects_nonempty_zero_sized_dynamic_arrays() {
+        type Ty = sol_data::Array<()>;
+
+        let encoded = hex!(
+            "0000000000000000000000000000000000000000000000000000000000000020"
+            "0000000000000000000000000000000000000000000000000000000000000001"
+        );
+
+        assert_eq!(Ty::abi_decode_sequence(&encoded), Ok(vec![()]));
+        assert_eq!(
+            Ty::abi_decode_sequence_with_config(&encoded, AbiDecoderConfig::new().memory_limit(0)),
+            Err(Error::MemoryLimitExceeded(0)),
+        );
+        assert_eq!(
+            Ty::abi_decode_sequence_with_config(&encoded, AbiDecoderConfig::new().strict(true)),
+            Err(Error::ReserMismatch),
         );
     }
 

--- a/crates/sol-types/src/abi/decoder.rs
+++ b/crates/sol-types/src/abi/decoder.rs
@@ -1217,6 +1217,27 @@ mod tests {
     }
 
     #[test]
+    fn strict_decoder_rejects_noncanonical_bool() {
+        let encoded = Word::with_last_byte(2);
+
+        assert_eq!(sol_data::Bool::abi_decode(encoded.as_slice()), Ok(true));
+        assert!(
+            sol_data::Bool::abi_decode_with_config(
+                encoded.as_slice(),
+                AbiDecoderConfig::new().validate(true),
+            )
+            .is_err()
+        );
+        assert!(
+            sol_data::Bool::abi_decode_with_config(
+                encoded.as_slice(),
+                AbiDecoderConfig::new().strict(true),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
     fn strict_decoder_rejects_overlapping_nested_offsets() {
         type Ty = sol_data::Array<sol_data::Bytes>;
 

--- a/crates/sol-types/src/abi/decoder.rs
+++ b/crates/sol-types/src/abi/decoder.rs
@@ -1566,6 +1566,19 @@ mod tests {
             Err(err) => err,
         };
         assert_eq!(err, Error::MemoryLimitExceeded(memory_used - 1));
+
+        let strict_memory_used = width
+            * (core::mem::size_of::<<Scope as SolType>::Token<'_>>()
+                + core::mem::size_of::<<Rule as SolType>::Token<'_>>()
+                + core::mem::size_of::<<Address as SolType>::Token<'_>>());
+        let err = match applyCall::abi_decode_with_config(
+            &data,
+            AbiDecoderConfig::new().memory_limit(strict_memory_used).strict(true),
+        ) {
+            Ok(_) => panic!("strict decoding should reject aliased offsets"),
+            Err(err) => err,
+        };
+        assert_eq!(err, Error::ReserMismatch);
     }
 
     #[test]

--- a/crates/sol-types/src/abi/decoder.rs
+++ b/crates/sol-types/src/abi/decoder.rs
@@ -1249,6 +1249,19 @@ mod tests {
     }
 
     #[test]
+    fn strict_decoder_accepts_dynamic_array_sequence() {
+        type Ty = sol_data::Array<sol_data::Bytes>;
+
+        let value = vec![bytes![0x11u8; 1], bytes!("2233")];
+        let encoded = Ty::abi_encode(&value);
+
+        assert_eq!(
+            Ty::abi_decode_sequence_with_config(&encoded, AbiDecoderConfig::new().strict(true)),
+            Ok(value),
+        );
+    }
+
+    #[test]
     fn strict_decoder_rejects_gapped_offsets() {
         type Ty = (sol_data::String, sol_data::String);
 
@@ -1260,6 +1273,21 @@ mod tests {
         assert_eq!(Ty::abi_decode(&encoded), Ok(value));
         assert_eq!(
             Ty::abi_decode_with_config(&encoded, AbiDecoderConfig::new().strict(true)),
+            Err(Error::ReserMismatch),
+        );
+    }
+
+    #[test]
+    fn strict_decoder_rejects_trailing_data() {
+        type Ty = (sol_data::Bytes, sol_data::Bytes);
+
+        let value = (bytes![0x11u8; 1], bytes![0x22u8; 1]);
+        let mut encoded = Ty::abi_encode_params(&value);
+        encoded.extend([0; 32]);
+
+        assert_eq!(Ty::abi_decode_params(&encoded), Ok(value));
+        assert_eq!(
+            Ty::abi_decode_params_with_config(&encoded, AbiDecoderConfig::new().strict(true)),
             Err(Error::ReserMismatch),
         );
     }

--- a/crates/sol-types/src/abi/decoder.rs
+++ b/crates/sol-types/src/abi/decoder.rs
@@ -259,16 +259,7 @@ impl<'de> Decoder<'de, 'static> {
     /// Instantiates a new decoder from a byte slice.
     #[inline]
     pub const fn new(buf: &'de [u8]) -> Self {
-        Self {
-            buf,
-            offset: 0,
-            depth: 0,
-            config: AbiDecoderConfig::new(),
-            state: DecoderState::Root {
-                memory_used: Cell::new(0),
-                strict_next_offset: Cell::new(0),
-            },
-        }
+        Self::with_config(buf, AbiDecoderConfig::new())
     }
 
     #[inline]

--- a/crates/sol-types/src/abi/decoder.rs
+++ b/crates/sol-types/src/abi/decoder.rs
@@ -98,15 +98,6 @@ impl AbiDecoderConfig {
         self.strict
     }
 
-    /// Returns whether this is the default decoder configuration.
-    #[inline]
-    pub const fn is_default(&self) -> bool {
-        self.recursion_limit == 16
-            && self.memory_limit == DEFAULT_MEMORY_LIMIT
-            && !self.validate
-            && !self.strict
-    }
-
     /// Sets the maximum recursion depth.
     #[inline]
     pub const fn recursion_limit(mut self, limit: usize) -> Self {
@@ -1180,7 +1171,6 @@ mod tests {
         assert_eq!(config.get_memory_limit(), DEFAULT_MEMORY_LIMIT);
         assert!(!config.get_validate());
         assert!(!config.get_strict());
-        assert!(config.is_default());
 
         config.set_recursion_limit(300);
         config.set_memory_limit(42);
@@ -1190,7 +1180,6 @@ mod tests {
         assert_eq!(config.get_memory_limit(), 42);
         assert!(config.get_validate());
         assert!(config.get_strict());
-        assert!(!config.is_default());
 
         let config = AbiDecoderConfig::new().recursion_limit(400).memory_limit(24).strict(true);
         assert_eq!(config.get_recursion_limit(), 400);
@@ -1384,6 +1373,24 @@ mod tests {
         );
         assert_eq!(
             Ty::abi_decode_sequence_with_config(&encoded, AbiDecoderConfig::new().strict(true)),
+            Err(Error::ReserMismatch),
+        );
+    }
+
+    #[test]
+    fn strict_decoder_checks_dynamic_elements_before_reserving_the_outer_array() {
+        type Ty = sol_data::Array<sol_data::FixedArray<sol_data::Bytes, 64>>;
+
+        let mut encoded = Vec::with_capacity(32 * 66);
+        encoded.extend_from_slice(pad_usize(32).as_slice());
+        encoded.extend_from_slice(pad_usize(1).as_slice());
+        encoded.resize(32 * 66, 0);
+
+        assert_eq!(
+            Ty::abi_decode_sequence_with_config(
+                &encoded,
+                AbiDecoderConfig::new().memory_limit(0).strict(true),
+            ),
             Err(Error::ReserMismatch),
         );
     }

--- a/crates/sol-types/src/abi/decoder.rs
+++ b/crates/sol-types/src/abi/decoder.rs
@@ -321,7 +321,8 @@ impl<'de, 'state> Decoder<'de, 'state> {
         if self.config.get_strict() {
             let bytes = words.checked_mul(Word::len_bytes()).ok_or(Error::Overrun)?;
             let offset = self.offset.checked_add(bytes).ok_or(Error::Overrun)?;
-            self.state.strict_next_offset().set(offset);
+            let next = self.state.strict_next_offset();
+            next.set(next.get().max(offset));
         }
         Ok(())
     }
@@ -1240,6 +1241,27 @@ mod tests {
         type Ty = (sol_data::Bytes, sol_data::Bytes);
 
         let value = (bytes![0x11u8, 0x22], bytes![0x33u8, 0x44]);
+        let encoded = Ty::abi_encode_params(&value);
+
+        assert_eq!(
+            Ty::abi_decode_params_with_config(&encoded, AbiDecoderConfig::new().strict(true)),
+            Ok(value),
+        );
+    }
+
+    #[test]
+    fn strict_decoder_accepts_static_composites_around_dynamic_fields() {
+        type Uint = sol_data::Uint<256>;
+        type StaticTuple = (Uint, Uint);
+        type StaticArray = sol_data::FixedArray<StaticTuple, 2>;
+        type Ty = (StaticTuple, sol_data::Bytes, StaticArray, sol_data::Bytes);
+
+        let value = (
+            (U256::from(1), U256::from(2)),
+            bytes![0x11u8; 1],
+            [(U256::from(3), U256::from(4)), (U256::from(5), U256::from(6))],
+            bytes![0x22u8; 1],
+        );
         let encoded = Ty::abi_encode_params(&value);
 
         assert_eq!(

--- a/crates/sol-types/src/abi/decoder.rs
+++ b/crates/sol-types/src/abi/decoder.rs
@@ -31,6 +31,7 @@ pub struct AbiDecoderConfig {
     recursion_limit: usize,
     memory_limit: usize,
     validate: bool,
+    strict: bool,
 }
 
 impl Default for AbiDecoderConfig {
@@ -56,6 +57,7 @@ impl fmt::Debug for AbiDecoderConfig {
             .field("recursion_limit", &self.recursion_limit)
             .field("memory_limit", &self.memory_limit)
             .field("validate", &self.validate)
+            .field("strict", &self.strict)
             .finish()
     }
 }
@@ -64,7 +66,12 @@ impl AbiDecoderConfig {
     /// Creates a decoder configuration with the default limits.
     #[inline]
     pub const fn new() -> Self {
-        Self { recursion_limit: 16, memory_limit: DEFAULT_MEMORY_LIMIT, validate: false }
+        Self {
+            recursion_limit: 16,
+            memory_limit: DEFAULT_MEMORY_LIMIT,
+            validate: false,
+            strict: false,
+        }
     }
 
     /// Returns the maximum recursion depth.
@@ -82,7 +89,13 @@ impl AbiDecoderConfig {
     /// Returns whether decoded tokens are validated before detokenization.
     #[inline]
     pub const fn get_validate(&self) -> bool {
-        self.validate
+        self.validate || self.strict
+    }
+
+    /// Returns whether strict ABI encoding is required.
+    #[inline]
+    pub const fn get_strict(&self) -> bool {
+        self.strict
     }
 
     /// Sets the maximum recursion depth.
@@ -112,6 +125,16 @@ impl AbiDecoderConfig {
         self
     }
 
+    /// Requires strictly ABI-encoded input.
+    ///
+    /// Strict mode implies `validate`.
+    /// It also rejects gaps or overlaps between dynamic data areas while decoding.
+    #[inline]
+    pub const fn strict(mut self, strict: bool) -> Self {
+        self.strict = strict;
+        self
+    }
+
     /// Sets the maximum recursion depth in place.
     #[inline]
     pub const fn set_recursion_limit(&mut self, limit: usize) {
@@ -129,21 +152,56 @@ impl AbiDecoderConfig {
     pub const fn set_validate(&mut self, validate: bool) {
         self.validate = validate;
     }
+
+    /// Requires or allows non-strict ABI encoding in place.
+    #[inline]
+    pub const fn set_strict(&mut self, strict: bool) {
+        self.strict = strict;
+    }
 }
 
 enum DecoderState<'state> {
-    Root(Cell<usize>),
-    Child(&'state Cell<usize>),
+    Root {
+        memory_used: Cell<usize>,
+        strict_next_offset: Cell<usize>,
+    },
+    Child {
+        memory_used: &'state Cell<usize>,
+        strict_next_offset: Cell<usize>,
+        strict_parent: Option<StrictParent<'state>>,
+    },
 }
 
 impl<'state> DecoderState<'state> {
     #[inline]
     const fn memory_used(&self) -> &Cell<usize> {
         match self {
-            Self::Root(memory_used) => memory_used,
-            Self::Child(memory_used) => memory_used,
+            Self::Root { memory_used, .. } => memory_used,
+            Self::Child { memory_used, .. } => memory_used,
         }
     }
+
+    #[inline]
+    const fn strict_next_offset(&self) -> &Cell<usize> {
+        match self {
+            Self::Root { strict_next_offset, .. } | Self::Child { strict_next_offset, .. } => {
+                strict_next_offset
+            }
+        }
+    }
+
+    #[inline]
+    const fn strict_parent(&self) -> Option<&StrictParent<'state>> {
+        match self {
+            Self::Root { .. } => None,
+            Self::Child { strict_parent, .. } => strict_parent.as_ref(),
+        }
+    }
+}
+
+struct StrictParent<'state> {
+    next_offset: &'state Cell<usize>,
+    start: usize,
 }
 
 /// The [`Decoder`] wraps a byte slice with necessary info to progressively
@@ -206,13 +264,25 @@ impl<'de> Decoder<'de, 'static> {
             offset: 0,
             depth: 0,
             config: AbiDecoderConfig::new(),
-            state: DecoderState::Root(Cell::new(0)),
+            state: DecoderState::Root {
+                memory_used: Cell::new(0),
+                strict_next_offset: Cell::new(0),
+            },
         }
     }
 
     #[inline]
     const fn with_config(buf: &'de [u8], config: AbiDecoderConfig) -> Self {
-        Self { buf, offset: 0, depth: 0, config, state: DecoderState::Root(Cell::new(0)) }
+        Self {
+            buf,
+            offset: 0,
+            depth: 0,
+            config,
+            state: DecoderState::Root {
+                memory_used: Cell::new(0),
+                strict_next_offset: Cell::new(0),
+            },
+        }
     }
 }
 
@@ -224,13 +294,41 @@ impl<'de, 'state> Decoder<'de, 'state> {
             offset: 0,
             depth: parent.depth + 1,
             config: parent.config,
-            state: DecoderState::Child(parent.memory_used()),
+            state: DecoderState::Child {
+                memory_used: parent.memory_used(),
+                strict_next_offset: Cell::new(0),
+                strict_parent: if parent.config.get_strict() {
+                    Some(StrictParent {
+                        next_offset: parent.state.strict_next_offset(),
+                        start: parent.buf.len() - buf.len(),
+                    })
+                } else {
+                    None
+                },
+            },
         }
     }
 
     #[inline]
     const fn memory_used(&self) -> &Cell<usize> {
         self.state.memory_used()
+    }
+
+    /// Sets the size of the current zone's head in words for strict decoding.
+    #[doc(hidden)]
+    #[inline]
+    pub fn set_strict_head_words(&self, words: usize) -> Result<()> {
+        if self.config.get_strict() {
+            let bytes = words.checked_mul(Word::len_bytes()).ok_or(Error::Overrun)?;
+            let offset = self.offset.checked_add(bytes).ok_or(Error::Overrun)?;
+            self.state.strict_next_offset().set(offset);
+        }
+        Ok(())
+    }
+
+    #[inline]
+    const fn is_strict(&self) -> bool {
+        self.config.get_strict()
     }
 
     /// Returns the current offset in the buffer.
@@ -381,6 +479,9 @@ impl<'de, 'state> Decoder<'de, 'state> {
     #[inline]
     pub fn take_indirection<'child>(&'child mut self) -> Result<Decoder<'de, 'child>, Error> {
         let offset = self.take_offset()?;
+        if self.is_strict() && offset != self.state.strict_next_offset().get() {
+            return Err(Error::ReserMismatch);
+        }
         self.child(offset)
     }
 
@@ -394,6 +495,20 @@ impl<'de, 'state> Decoder<'de, 'state> {
     #[inline]
     pub fn take_slice(&mut self, len: usize) -> Result<&'de [u8]> {
         self.peek_len(len).inspect(|_| self.increase_offset(len))
+    }
+
+    /// Takes a padded slice and validates its padding in strict mode.
+    #[doc(hidden)]
+    #[inline]
+    pub fn take_padded_slice(&mut self, len: usize) -> Result<&'de [u8]> {
+        let bytes = self.take_slice(len)?;
+        if self.is_strict() {
+            let padding = (Word::len_bytes() - len % Word::len_bytes()) % Word::len_bytes();
+            if self.take_slice(padding)?.iter().any(|&byte| byte != 0) {
+                return Err(Error::ReserMismatch);
+            }
+        }
+        Ok(bytes)
     }
 
     /// Takes the offset from the child decoder and sets it as the current
@@ -425,6 +540,16 @@ impl<'de, 'state> Decoder<'de, 'state> {
     #[inline]
     pub fn decode_sequence<T: Token<'de> + TokenSeq<'de>>(&mut self) -> Result<T> {
         T::decode_sequence(self)
+    }
+}
+
+impl Drop for Decoder<'_, '_> {
+    fn drop(&mut self) {
+        if let Some(parent) = self.state.strict_parent() {
+            parent.next_offset.set(
+                parent.start.saturating_add(self.offset.max(self.state.strict_next_offset().get())),
+            );
+        }
     }
 }
 
@@ -498,6 +623,9 @@ pub fn decode_sequence_with_config<'de, T: TokenSeq<'de>>(
 ) -> Result<T> {
     let mut decoder = Decoder::with_config(data, config);
     let result = decoder.decode_sequence::<T>()?;
+    if config.get_strict() && decoder.state.strict_next_offset().get() != data.len() {
+        return Err(Error::ReserMismatch);
+    }
     Ok(result)
 }
 
@@ -1046,18 +1174,22 @@ mod tests {
         assert_eq!(config.get_recursion_limit(), 16);
         assert_eq!(config.get_memory_limit(), DEFAULT_MEMORY_LIMIT);
         assert!(!config.get_validate());
+        assert!(!config.get_strict());
 
         config.set_recursion_limit(300);
         config.set_memory_limit(42);
         config.set_validate(true);
+        config.set_strict(true);
         assert_eq!(config.get_recursion_limit(), 300);
         assert_eq!(config.get_memory_limit(), 42);
         assert!(config.get_validate());
+        assert!(config.get_strict());
 
-        let config = AbiDecoderConfig::new().recursion_limit(400).memory_limit(24).validate(true);
+        let config = AbiDecoderConfig::new().recursion_limit(400).memory_limit(24).strict(true);
         assert_eq!(config.get_recursion_limit(), 400);
         assert_eq!(config.get_memory_limit(), 24);
         assert!(config.get_validate());
+        assert!(config.get_strict());
     }
 
     #[test]
@@ -1073,6 +1205,152 @@ mod tests {
                 AbiDecoderConfig::new().validate(true),
             )
             .is_err()
+        );
+        assert!(
+            sol_data::Bool::abi_decode_with_config(
+                encoded.as_slice(),
+                AbiDecoderConfig::new().strict(true),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn strict_decoder_rejects_overlapping_nested_offsets() {
+        type Ty = sol_data::Array<sol_data::Bytes>;
+
+        let encoded = hex!(
+            "0000000000000000000000000000000000000000000000000000000000000020" // array offset
+            "0000000000000000000000000000000000000000000000000000000000000002" // array length
+            "0000000000000000000000000000000000000000000000000000000000000040" // first bytes offset
+            "0000000000000000000000000000000000000000000000000000000000000040" // second bytes offset
+            "0000000000000000000000000000000000000000000000000000000000000001" // bytes length
+            "1100000000000000000000000000000000000000000000000000000000000000"
+        );
+
+        assert_eq!(Ty::abi_decode(&encoded).unwrap(), vec![bytes![0x11u8; 1], bytes![0x11u8; 1]]);
+        assert_eq!(
+            Ty::abi_decode_with_config(&encoded, AbiDecoderConfig::new().strict(true)),
+            Err(Error::ReserMismatch),
+        );
+    }
+
+    #[test]
+    fn strict_decoder_accepts_canonical_offsets() {
+        type Ty = (sol_data::Bytes, sol_data::Bytes);
+
+        let value = (bytes![0x11u8, 0x22], bytes![0x33u8, 0x44]);
+        let encoded = Ty::abi_encode_params(&value);
+
+        assert_eq!(
+            Ty::abi_decode_params_with_config(&encoded, AbiDecoderConfig::new().strict(true)),
+            Ok(value),
+        );
+    }
+
+    #[test]
+    fn strict_decoder_rejects_gapped_offsets() {
+        type Ty = (sol_data::String, sol_data::String);
+
+        let value = ("one".to_string(), "two".to_string());
+        let mut encoded = Ty::abi_encode(&value);
+        encoded[95] = 0xa0;
+        encoded.splice(160..160, [0; 32]);
+
+        assert_eq!(Ty::abi_decode(&encoded), Ok(value));
+        assert_eq!(
+            Ty::abi_decode_with_config(&encoded, AbiDecoderConfig::new().strict(true)),
+            Err(Error::ReserMismatch),
+        );
+    }
+
+    #[test]
+    fn strict_decoder_accepts_nested_encoder_output() {
+        type Ty = (
+            sol_data::String,
+            sol_data::Array<sol_data::Array<sol_data::Address>>,
+            sol_data::Bytes,
+        );
+
+        let value = (
+            "strict".to_string(),
+            vec![vec![Address::repeat_byte(0x11)], vec![Address::repeat_byte(0x22)]],
+            bytes!("beef"),
+        );
+        let encoded = Ty::abi_encode(&value);
+
+        assert_eq!(
+            Ty::abi_decode_with_config(&encoded, AbiDecoderConfig::new().strict(true)),
+            Ok(value),
+        );
+    }
+
+    #[test]
+    fn strict_decoder_rejects_nonzero_padding() {
+        let encoded = hex!(
+            "0000000000000000000000000000000000000000000000000000000000000020"
+            "0000000000000000000000000000000000000000000000000000000000000001"
+            "11ff000000000000000000000000000000000000000000000000000000000000"
+        );
+
+        assert_eq!(sol_data::Bytes::abi_decode(&encoded).unwrap(), bytes![0x11u8; 1]);
+        assert_eq!(
+            sol_data::Bytes::abi_decode_with_config(&encoded, AbiDecoderConfig::new().strict(true)),
+            Err(Error::ReserMismatch),
+        );
+    }
+
+    #[test]
+    fn strict_decoder_rejects_overlapping_bytes_offsets() {
+        type Ty = (sol_data::Bytes, sol_data::Bytes);
+
+        let encoded = hex!(
+            "0000000000000000000000000000000000000000000000000000000000000040" // first bytes offset
+            "0000000000000000000000000000000000000000000000000000000000000040" // second bytes offset
+            "0000000000000000000000000000000000000000000000000000000000000003" // bytes length
+            "1122330000000000000000000000000000000000000000000000000000000000"
+        );
+
+        assert_eq!(
+            Ty::abi_decode_params(&encoded).unwrap(),
+            (bytes![0x11u8, 0x22, 0x33], bytes![0x11u8, 0x22, 0x33]),
+        );
+        assert_eq!(
+            Ty::abi_decode_params_with_config(&encoded, AbiDecoderConfig::new().strict(true)),
+            Err(Error::ReserMismatch),
+        );
+    }
+
+    #[test]
+    fn strict_decoder_rejects_overlapping_dynamic_array_offsets() {
+        type Ty = (sol_data::Array<sol_data::Uint<256>>, sol_data::Array<sol_data::Uint<256>>);
+
+        let encoded = hex!(
+            "0000000000000000000000000000000000000000000000000000000000000040" // first array offset
+            "0000000000000000000000000000000000000000000000000000000000000040" // second array offset
+            "0000000000000000000000000000000000000000000000000000000000000002" // array length
+            "0000000000000000000000000000000000000000000000000000000000000001"
+            "0000000000000000000000000000000000000000000000000000000000000002"
+        );
+
+        assert_eq!(
+            Ty::abi_decode_params(&encoded).unwrap(),
+            (vec![U256::from(1), U256::from(2)], vec![U256::from(1), U256::from(2)]),
+        );
+        assert_eq!(
+            Ty::abi_decode_params_with_config(&encoded, AbiDecoderConfig::new().strict(true)),
+            Err(Error::ReserMismatch),
+        );
+        assert_eq!(
+            Ty::abi_decode_params_with_config(&encoded, AbiDecoderConfig::new().memory_limit(64)),
+            Err(Error::MemoryLimitExceeded(64)),
+        );
+        assert_eq!(
+            Ty::abi_decode_params_with_config(
+                &encoded,
+                AbiDecoderConfig::new().memory_limit(64).strict(true),
+            ),
+            Err(Error::ReserMismatch),
         );
     }
 

--- a/crates/sol-types/src/abi/token.rs
+++ b/crates/sol-types/src/abi/token.rs
@@ -458,6 +458,19 @@ impl<'de, T: Token<'de>> Token<'de> for DynSeqToken<T> {
         if required_words > child.remaining_words() {
             return Err(crate::Error::Overrun);
         }
+        if child.is_strict() && T::DYNAMIC {
+            let mut tokens = Vec::new();
+            for _ in 0..len {
+                let token = T::decode_from(&mut child)?;
+                if tokens.len() == tokens.capacity() {
+                    let additional = tokens.capacity().max(1).min(len - tokens.len());
+                    child.reserve_elements::<T>(additional)?;
+                    tokens.try_reserve_exact(additional)?;
+                }
+                tokens.push(token);
+            }
+            return Ok(Self(tokens));
+        }
         child.reserve_elements::<T>(len)?;
         let mut tokens = vec_try_with_capacity(len)?;
         // SAFETY: `spare_capacity_mut` returns valid writable memory.

--- a/crates/sol-types/src/abi/token.rs
+++ b/crates/sol-types/src/abi/token.rs
@@ -431,6 +431,11 @@ impl<'de, T: Token<'de>> Token<'de> for DynSeqToken<T> {
         let len = child.take_offset()?;
         if T::MINIMUM_WORDS == 0 {
             debug_assert_eq!(core::mem::size_of::<T>(), 0);
+            if child.is_strict() && len != 0 {
+                return Err(crate::Error::ReserMismatch);
+            }
+            // Charge a byte per element to bound work on zero-sized tokens.
+            child.reserve(len)?;
             #[allow(clippy::uninit_vec)]
             let tokens = {
                 let mut tokens = Vec::new();

--- a/crates/sol-types/src/abi/token.rs
+++ b/crates/sol-types/src/abi/token.rs
@@ -496,6 +496,7 @@ impl<'de, T: Token<'de>> TokenSeq<'de> for DynSeqToken<T> {
 
     #[inline]
     fn decode_sequence(dec: &mut Decoder<'de, '_>) -> Result<Self> {
+        dec.set_strict_head_words(Self::MINIMUM_WORDS)?;
         Self::decode_from(dec)
     }
 }

--- a/crates/sol-types/src/abi/token.rs
+++ b/crates/sol-types/src/abi/token.rs
@@ -370,6 +370,7 @@ impl<'de, T: Token<'de>, const N: usize> TokenSeq<'de> for FixedSeqToken<T, N> {
 
     #[inline]
     fn decode_sequence(dec: &mut Decoder<'de, '_>) -> Result<Self> {
+        dec.set_strict_head_words(T::MINIMUM_WORDS.checked_mul(N).ok_or(crate::Error::Overrun)?)?;
         let mut arr = crate::impl_core::uninit_array::<T, N>();
         // SAFETY: `arr` is valid writable memory for `N` elements.
         // `decode_many_from` initializes all elements on success.
@@ -446,8 +447,9 @@ impl<'de, T: Token<'de>> Token<'de> for DynSeqToken<T> {
         // specifies that offsets are relative to the first word of
         // `enc(X)`. But known-good test vectors are relative to the
         // word AFTER the array size
-        let mut child = child.raw_child()?;
         let required_words = T::MINIMUM_WORDS.checked_mul(len).ok_or(crate::Error::Overrun)?;
+        let mut child = child.raw_child()?;
+        child.set_strict_head_words(required_words)?;
         if required_words > child.remaining_words() {
             return Err(crate::Error::Overrun);
         }
@@ -545,7 +547,7 @@ impl<'de: 'a, 'a> Token<'de> for PackedSeqToken<'a> {
     fn decode_from(dec: &mut Decoder<'de, '_>) -> Result<Self> {
         let mut child = dec.take_indirection()?;
         let len = child.take_offset()?;
-        let bytes = child.peek_len(len)?;
+        let bytes = child.take_padded_slice(len)?;
         child.reserve(len)?;
         Ok(PackedSeqToken(bytes))
     }
@@ -683,6 +685,11 @@ macro_rules! tuple_impls {
 
             #[inline]
             fn decode_sequence(dec: &mut Decoder<'de, '_>) -> Result<Self> {
+                let head_words = 0usize $(
+                    .checked_add(<$ty as Token>::MINIMUM_WORDS)
+                    .ok_or(crate::Error::Overrun)?
+                )+;
+                dec.set_strict_head_words(head_words)?;
                 Ok(($(
                     match <$ty as Token>::decode_from(dec) {
                         Ok(t) => t,

--- a/crates/sol-types/src/errors.rs
+++ b/crates/sol-types/src/errors.rs
@@ -102,7 +102,11 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::TypeCheckFail { expected_type, data } => {
-                write!(f, "type check failed for {expected_type:?} with data: {data}",)
+                write!(f, "type check failed for {expected_type:?}")?;
+                if !data.is_empty() {
+                    write!(f, " with data: {data}")?;
+                }
+                Ok(())
             }
             Self::Overrun
             | Self::BufferNotEmpty
@@ -223,5 +227,13 @@ mod tests {
         let error = Error::type_check_fail_token::<crate::sol_data::Bool>(&token);
         let Error::TypeCheckFail { data, .. } = error else { unreachable!() };
         assert!(data.is_empty());
+    }
+
+    #[test]
+    fn empty_type_check_fail_data_is_not_displayed() {
+        assert_eq!(
+            Error::type_check_fail(&[], "test").to_string(),
+            "type check failed for \"test\""
+        );
     }
 }

--- a/crates/sol-types/src/errors.rs
+++ b/crates/sol-types/src/errors.rs
@@ -213,6 +213,7 @@ impl From<TryReserveError> for Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::string::ToString;
 
     #[test]
     fn type_check_fail_data_is_bounded() {

--- a/crates/sol-types/src/errors.rs
+++ b/crates/sol-types/src/errors.rs
@@ -7,10 +7,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::abi;
 use alloc::{borrow::Cow, boxed::Box, collections::TryReserveError, string::String};
 use alloy_primitives::{B256, LogData, hex};
-use core::fmt;
+use core::{cmp, fmt};
+
+const MAX_TYPE_CHECK_FAIL_DATA_LEN: usize = 128;
 
 /// ABI result type.
 pub type Result<T, E = Error> = core::result::Result<T, E>;
@@ -22,7 +23,7 @@ pub enum Error {
     TypeCheckFail {
         /// The Solidity type we failed to produce.
         expected_type: Cow<'static, str>,
-        /// Hex-encoded data.
+        /// Hex-encoded data, when available.
         data: String,
     },
 
@@ -163,13 +164,14 @@ impl Error {
 
     /// Instantiates a new [`Error::TypeCheckFail`] with the provided token.
     #[cold]
-    pub fn type_check_fail_token<T: crate::SolType>(token: &T::Token<'_>) -> Self {
-        Self::type_check_fail(&abi::encode(token), T::SOL_NAME)
+    pub fn type_check_fail_token<T: crate::SolType>(_token: &T::Token<'_>) -> Self {
+        Self::type_check_fail(&[], T::SOL_NAME)
     }
 
     /// Instantiates a new [`Error::TypeCheckFail`] with the provided data.
     #[cold]
     pub fn type_check_fail(data: &[u8], expected_type: impl Into<Cow<'static, str>>) -> Self {
+        let data = &data[..cmp::min(data.len(), MAX_TYPE_CHECK_FAIL_DATA_LEN)];
         Self::TypeCheckFail { expected_type: expected_type.into(), data: hex::encode(data) }
     }
 
@@ -201,5 +203,25 @@ impl From<TryReserveError> for Error {
     #[inline]
     fn from(value: TryReserveError) -> Self {
         Self::Reserve(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn type_check_fail_data_is_bounded() {
+        let error = Error::type_check_fail(&[0; MAX_TYPE_CHECK_FAIL_DATA_LEN + 1], "test");
+        let Error::TypeCheckFail { data, .. } = error else { unreachable!() };
+        assert_eq!(data.len(), MAX_TYPE_CHECK_FAIL_DATA_LEN * 2);
+    }
+
+    #[test]
+    fn type_check_fail_token_omits_token_data() {
+        let token = crate::abi::token::WordToken(crate::Word::ZERO);
+        let error = Error::type_check_fail_token::<crate::sol_data::Bool>(&token);
+        let Error::TypeCheckFail { data, .. } = error else { unreachable!() };
+        assert!(data.is_empty());
     }
 }

--- a/crates/sol-types/src/types/data_type.rs
+++ b/crates/sol-types/src/types/data_type.rs
@@ -49,7 +49,7 @@ impl SolType for Bool {
 
     #[inline]
     fn valid_token(token: &Self::Token<'_>) -> bool {
-        utils::check_zeroes(&token.0[..31])
+        token.0 == Word::ZERO || token.0 == Word::with_last_byte(1)
     }
 
     #[inline]

--- a/crates/sol-types/src/types/data_type.rs
+++ b/crates/sol-types/src/types/data_type.rs
@@ -49,7 +49,7 @@ impl SolType for Bool {
 
     #[inline]
     fn valid_token(token: &Self::Token<'_>) -> bool {
-        token.0 == Word::ZERO || token.0 == Word::with_last_byte(1)
+        utils::check_zeroes(&token.0[..31]) && token.0[31] <= 1
     }
 
     #[inline]

--- a/crates/sol-types/src/types/event/mod.rs
+++ b/crates/sol-types/src/types/event/mod.rs
@@ -270,7 +270,7 @@ pub trait SolEvent: Sized {
 
     /// Decode the event from the given log object.
     fn decode_log(log: &Log) -> Result<Log<Self>> {
-        Self::decode_log_with_config(log, AbiDecoderConfig::default())
+        Self::decode_log_data(&log.data).map(|data| Log { address: log.address, data })
     }
 
     /// Decodes the event from the given log object with a custom decoder configuration.

--- a/crates/sol-types/src/types/event/mod.rs
+++ b/crates/sol-types/src/types/event/mod.rs
@@ -167,7 +167,7 @@ pub trait SolEvent: Sized {
         I: IntoIterator<Item = D>,
         D: Into<WordToken>,
     {
-        <Self::TopicList as TopicList>::detokenize(topics)
+        Self::decode_topics_with_config(topics, AbiDecoderConfig::default())
     }
 
     /// Decode the topics of this event with a custom decoder configuration.
@@ -217,11 +217,7 @@ pub trait SolEvent: Sized {
         I: IntoIterator<Item = D>,
         D: Into<WordToken>,
     {
-        let topics = Self::decode_topics(topics)?;
-        // Check signature before decoding the data.
-        Self::check_signature(&topics)?;
-        let body = Self::abi_decode_data(data)?;
-        Ok(Self::new(topics, body))
+        Self::decode_raw_log_with_config(topics, data, AbiDecoderConfig::default())
     }
 
     /// Decodes the event from the given log info with a custom decoder configuration.
@@ -235,6 +231,7 @@ pub trait SolEvent: Sized {
         D: Into<WordToken>,
     {
         let topics = Self::decode_topics_with_config(topics, config)?;
+        // Check signature before decoding the data.
         Self::check_signature(&topics)?;
         let body = Self::abi_decode_data_with_config(data, config)?;
         Ok(Self::new(topics, body))
@@ -273,7 +270,7 @@ pub trait SolEvent: Sized {
 
     /// Decode the event from the given log object.
     fn decode_log(log: &Log) -> Result<Log<Self>> {
-        Self::decode_log_data(&log.data).map(|data| Log { address: log.address, data })
+        Self::decode_log_with_config(log, AbiDecoderConfig::default())
     }
 
     /// Decodes the event from the given log object with a custom decoder configuration.

--- a/crates/sol-types/src/types/event/mod.rs
+++ b/crates/sol-types/src/types/event/mod.rs
@@ -170,6 +170,19 @@ pub trait SolEvent: Sized {
         <Self::TopicList as TopicList>::detokenize(topics)
     }
 
+    /// Decode the topics of this event with a custom decoder configuration.
+    #[inline]
+    fn decode_topics_with_config<I, D>(
+        topics: I,
+        config: AbiDecoderConfig,
+    ) -> Result<<Self::TopicList as SolType>::RustType>
+    where
+        I: IntoIterator<Item = D>,
+        D: Into<WordToken>,
+    {
+        <Self::TopicList as TopicList>::detokenize_with_config(topics, config)
+    }
+
     /// ABI-decodes the dynamic data of this event from the given buffer.
     #[inline]
     fn abi_decode_data<'a>(data: &'a [u8]) -> Result<<Self::DataTuple<'a> as SolType>::RustType> {
@@ -221,7 +234,7 @@ pub trait SolEvent: Sized {
         I: IntoIterator<Item = D>,
         D: Into<WordToken>,
     {
-        let topics = Self::decode_topics(topics)?;
+        let topics = Self::decode_topics_with_config(topics, config)?;
         Self::check_signature(&topics)?;
         let body = Self::abi_decode_data_with_config(data, config)?;
         Ok(Self::new(topics, body))

--- a/crates/sol-types/src/types/event/topic_list.rs
+++ b/crates/sol-types/src/types/event/topic_list.rs
@@ -1,4 +1,7 @@
-use crate::{Error, Result, SolType, abi::token::WordToken};
+use crate::{
+    Error, Result, SolType,
+    abi::{AbiDecoderConfig, token::WordToken},
+};
 use alloc::borrow::Cow;
 
 #[allow(unknown_lints, unnameable_types)]
@@ -34,6 +37,12 @@ pub trait TopicList: SolType + Sealed {
     where
         I: IntoIterator<Item = D>,
         D: Into<WordToken>;
+
+    /// Detokenize the topics into a tuple of Rust types with a decoder configuration.
+    fn detokenize_with_config<I, D>(topics: I, config: AbiDecoderConfig) -> Result<Self::RustType>
+    where
+        I: IntoIterator<Item = D>,
+        D: Into<WordToken>;
 }
 
 macro_rules! impl_topic_list_tuples {
@@ -47,9 +56,23 @@ macro_rules! impl_topic_list_tuples {
                 I: IntoIterator<Item = D>,
                 D: Into<WordToken>
             {
+                Self::detokenize_with_config(topics, AbiDecoderConfig::new())
+            }
+
+            fn detokenize_with_config<I, D>(topics: I, config: AbiDecoderConfig) -> Result<Self::RustType>
+            where
+                I: IntoIterator<Item = D>,
+                D: Into<WordToken>
+            {
                 let mut iter = topics.into_iter();
                 let topics = ($(
-                    <$t>::detokenize(iter.next().ok_or_else(length_mismatch)?.into()),
+                    {
+                        let topic = iter.next().ok_or_else(length_mismatch)?.into();
+                        if config.get_validate() {
+                            <$t>::type_check(&topic)?;
+                        }
+                        <$t>::detokenize(topic)
+                    },
                 )*);
                 if iter.next().is_some() {
                     return Err(length_mismatch());
@@ -66,6 +89,15 @@ impl TopicList for () {
 
     #[inline]
     fn detokenize<I, D>(topics: I) -> Result<Self::RustType>
+    where
+        I: IntoIterator<Item = D>,
+        D: Into<WordToken>,
+    {
+        Self::detokenize_with_config(topics, AbiDecoderConfig::new())
+    }
+
+    #[inline]
+    fn detokenize_with_config<I, D>(topics: I, _config: AbiDecoderConfig) -> Result<Self::RustType>
     where
         I: IntoIterator<Item = D>,
         D: Into<WordToken>,

--- a/crates/sol-types/src/types/event/topic_list.rs
+++ b/crates/sol-types/src/types/event/topic_list.rs
@@ -36,7 +36,10 @@ pub trait TopicList: SolType + Sealed {
     fn detokenize<I, D>(topics: I) -> Result<Self::RustType>
     where
         I: IntoIterator<Item = D>,
-        D: Into<WordToken>;
+        D: Into<WordToken>,
+    {
+        Self::detokenize_with_config(topics, AbiDecoderConfig::default())
+    }
 
     /// Detokenize the topics into a tuple of Rust types with a decoder configuration.
     fn detokenize_with_config<I, D>(topics: I, config: AbiDecoderConfig) -> Result<Self::RustType>
@@ -50,14 +53,6 @@ macro_rules! impl_topic_list_tuples {
         impl<$($t,)*> Sealed for ($($t,)*) {}
         impl<$($lt,)* $($t: SolType<Token<$lt> = WordToken>,)*> TopicList for ($($t,)*) {
             const COUNT: usize = $c;
-
-            fn detokenize<I, D>(topics: I) -> Result<Self::RustType>
-            where
-                I: IntoIterator<Item = D>,
-                D: Into<WordToken>
-            {
-                Self::detokenize_with_config(topics, AbiDecoderConfig::new())
-            }
 
             fn detokenize_with_config<I, D>(topics: I, config: AbiDecoderConfig) -> Result<Self::RustType>
             where
@@ -86,15 +81,6 @@ macro_rules! impl_topic_list_tuples {
 impl Sealed for () {}
 impl TopicList for () {
     const COUNT: usize = 0;
-
-    #[inline]
-    fn detokenize<I, D>(topics: I) -> Result<Self::RustType>
-    where
-        I: IntoIterator<Item = D>,
-        D: Into<WordToken>,
-    {
-        Self::detokenize_with_config(topics, AbiDecoderConfig::new())
-    }
 
     #[inline]
     fn detokenize_with_config<I, D>(topics: I, _config: AbiDecoderConfig) -> Result<Self::RustType>

--- a/crates/sol-types/src/types/function.rs
+++ b/crates/sol-types/src/types/function.rs
@@ -138,13 +138,18 @@ pub trait SolCall: Sized {
 
     /// ABI-decodes this call's return values with a custom decoder configuration.
     ///
-    /// The default implementation ignores the configuration and delegates to
-    /// [`abi_decode_returns`](Self::abi_decode_returns).
+    /// The default implementation supports only the default configuration.
     fn abi_decode_returns_with_config(
         data: &[u8],
-        _config: AbiDecoderConfig,
+        config: AbiDecoderConfig,
     ) -> Result<Self::Return> {
-        Self::abi_decode_returns(data)
+        if config.is_default() {
+            Self::abi_decode_returns(data)
+        } else {
+            Err(crate::Error::custom(
+                "decoder config is unsupported by this SolCall implementation",
+            ))
+        }
     }
 
     /// ABI decode this call's return values from the given slice, with validation.

--- a/crates/sol-types/src/types/function.rs
+++ b/crates/sol-types/src/types/function.rs
@@ -138,17 +138,17 @@ pub trait SolCall: Sized {
 
     /// ABI-decodes this call's return values with a custom decoder configuration.
     ///
-    /// The default implementation supports only the default configuration.
+    /// The default implementation does not support strict decoding.
     fn abi_decode_returns_with_config(
         data: &[u8],
         config: AbiDecoderConfig,
     ) -> Result<Self::Return> {
-        if config.is_default() {
-            Self::abi_decode_returns(data)
-        } else {
+        if config.get_strict() {
             Err(crate::Error::custom(
-                "decoder config is unsupported by this SolCall implementation",
+                "strict decoding is unsupported by this SolCall implementation",
             ))
+        } else {
+            Self::abi_decode_returns(data)
         }
     }
 

--- a/crates/sol-types/src/types/interface/event.rs
+++ b/crates/sol-types/src/types/interface/event.rs
@@ -22,19 +22,19 @@ pub trait SolEventInterface: Sized {
 
     /// Decode the events from the given log info with a custom decoder configuration.
     ///
-    /// The default implementation supports only the default configuration.
+    /// The default implementation does not support strict decoding.
     #[inline]
     fn decode_raw_log_with_config(
         topics: &[Word],
         data: &[u8],
         config: AbiDecoderConfig,
     ) -> Result<Self> {
-        if config.is_default() {
-            Self::decode_raw_log(topics, data)
-        } else {
+        if config.get_strict() {
             Err(crate::Error::custom(
-                "decoder config is unsupported by this SolEventInterface implementation",
+                "strict decoding is unsupported by this SolEventInterface implementation",
             ))
+        } else {
+            Self::decode_raw_log(topics, data)
         }
     }
 
@@ -55,20 +55,24 @@ pub trait SolEventInterface: Sized {
 mod tests {
     use super::*;
 
-    enum Legacy {}
+    struct Legacy;
 
     impl SolEventInterface for Legacy {
         const NAME: &'static str = "Legacy";
         const COUNT: usize = 0;
 
         fn decode_raw_log(_topics: &[Word], _data: &[u8]) -> Result<Self> {
-            Err(crate::Error::custom("legacy decoder"))
+            Ok(Self)
         }
     }
 
     #[test]
-    fn legacy_interfaces_reject_custom_configs() {
-        assert!(Legacy::decode_raw_log_with_config(&[], &[], AbiDecoderConfig::new()).is_err());
+    fn legacy_interfaces_reject_strict_configs() {
+        assert!(Legacy::decode_raw_log_with_config(&[], &[], AbiDecoderConfig::new()).is_ok());
+        assert!(
+            Legacy::decode_raw_log_with_config(&[], &[], AbiDecoderConfig::new().validate(true))
+                .is_ok()
+        );
         assert!(
             Legacy::decode_raw_log_with_config(&[], &[], AbiDecoderConfig::new().strict(true))
                 .is_err()

--- a/crates/sol-types/src/types/interface/event.rs
+++ b/crates/sol-types/src/types/interface/event.rs
@@ -1,4 +1,4 @@
-use crate::{Result, Word};
+use crate::{Result, Word, abi::AbiDecoderConfig};
 use alloy_primitives::Log;
 
 /// A collection of [`SolEvent`]s.
@@ -20,9 +20,25 @@ pub trait SolEventInterface: Sized {
     /// Decode the events from the given log info.
     fn decode_raw_log(topics: &[Word], data: &[u8]) -> Result<Self>;
 
+    /// Decode the events from the given log info with a custom decoder configuration.
+    #[inline]
+    fn decode_raw_log_with_config(
+        topics: &[Word],
+        data: &[u8],
+        _config: AbiDecoderConfig,
+    ) -> Result<Self> {
+        Self::decode_raw_log(topics, data)
+    }
+
     /// Decode the events from the given log object.
     fn decode_log(log: &Log) -> Result<Log<Self>> {
         Self::decode_raw_log(log.topics(), &log.data.data)
+            .map(|data| Log { address: log.address, data })
+    }
+
+    /// Decode the events from the given log object with a custom decoder configuration.
+    fn decode_log_with_config(log: &Log, config: AbiDecoderConfig) -> Result<Log<Self>> {
+        Self::decode_raw_log_with_config(log.topics(), &log.data.data, config)
             .map(|data| Log { address: log.address, data })
     }
 }

--- a/crates/sol-types/src/types/interface/event.rs
+++ b/crates/sol-types/src/types/interface/event.rs
@@ -21,23 +21,57 @@ pub trait SolEventInterface: Sized {
     fn decode_raw_log(topics: &[Word], data: &[u8]) -> Result<Self>;
 
     /// Decode the events from the given log info with a custom decoder configuration.
+    ///
+    /// The default implementation supports only the default configuration.
     #[inline]
     fn decode_raw_log_with_config(
         topics: &[Word],
         data: &[u8],
-        _config: AbiDecoderConfig,
+        config: AbiDecoderConfig,
     ) -> Result<Self> {
-        Self::decode_raw_log(topics, data)
+        if config.is_default() {
+            Self::decode_raw_log(topics, data)
+        } else {
+            Err(crate::Error::custom(
+                "decoder config is unsupported by this SolEventInterface implementation",
+            ))
+        }
     }
 
     /// Decode the events from the given log object.
     fn decode_log(log: &Log) -> Result<Log<Self>> {
-        Self::decode_log_with_config(log, AbiDecoderConfig::default())
+        Self::decode_raw_log(log.topics(), &log.data.data)
+            .map(|data| Log { address: log.address, data })
     }
 
     /// Decode the events from the given log object with a custom decoder configuration.
     fn decode_log_with_config(log: &Log, config: AbiDecoderConfig) -> Result<Log<Self>> {
         Self::decode_raw_log_with_config(log.topics(), &log.data.data, config)
             .map(|data| Log { address: log.address, data })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    enum Legacy {}
+
+    impl SolEventInterface for Legacy {
+        const NAME: &'static str = "Legacy";
+        const COUNT: usize = 0;
+
+        fn decode_raw_log(_topics: &[Word], _data: &[u8]) -> Result<Self> {
+            Err(crate::Error::custom("legacy decoder"))
+        }
+    }
+
+    #[test]
+    fn legacy_interfaces_reject_custom_configs() {
+        assert!(Legacy::decode_raw_log_with_config(&[], &[], AbiDecoderConfig::new()).is_err());
+        assert!(
+            Legacy::decode_raw_log_with_config(&[], &[], AbiDecoderConfig::new().strict(true))
+                .is_err()
+        );
     }
 }

--- a/crates/sol-types/src/types/interface/event.rs
+++ b/crates/sol-types/src/types/interface/event.rs
@@ -32,8 +32,7 @@ pub trait SolEventInterface: Sized {
 
     /// Decode the events from the given log object.
     fn decode_log(log: &Log) -> Result<Log<Self>> {
-        Self::decode_raw_log(log.topics(), &log.data.data)
-            .map(|data| Log { address: log.address, data })
+        Self::decode_log_with_config(log, AbiDecoderConfig::default())
     }
 
     /// Decode the events from the given log object with a custom decoder configuration.

--- a/crates/sol-types/src/types/interface/mod.rs
+++ b/crates/sol-types/src/types/interface/mod.rs
@@ -63,16 +63,16 @@ pub trait SolInterface: Sized {
 
     /// ABI-decodes the given data with a custom decoder configuration.
     ///
-    /// The default implementation supports only the default configuration.
+    /// The default implementation does not support strict decoding.
     fn abi_decode_raw_with_config(
         selector: [u8; 4],
         data: &[u8],
         config: AbiDecoderConfig,
     ) -> Result<Self> {
-        if config.is_default() {
-            Self::abi_decode_raw(selector, data)
+        if config.get_strict() {
+            Err(Error::custom("strict decoding is unsupported by this SolInterface implementation"))
         } else {
-            Err(Error::custom("decoder config is unsupported by this SolInterface implementation"))
+            Self::abi_decode_raw(selector, data)
         }
     }
 
@@ -174,13 +174,9 @@ impl SolInterface for Infallible {
     fn abi_decode_raw_with_config(
         selector: [u8; 4],
         data: &[u8],
-        config: AbiDecoderConfig,
+        _config: AbiDecoderConfig,
     ) -> Result<Self> {
-        if config.is_default() {
-            Self::abi_decode_raw(selector, data)
-        } else {
-            Err(Error::custom("decoder config is unsupported by this SolInterface implementation"))
-        }
+        Self::abi_decode_raw(selector, data)
     }
 
     #[inline]
@@ -651,6 +647,19 @@ mod tests {
         assert_eq!(
             GenericContractError::selectors().collect::<Vec<_>>(),
             [sel("Error(string)"), sel("Panic(uint256)")]
+        );
+    }
+
+    #[test]
+    fn generic_contract_error_preserves_unknown_selectors_in_strict_mode() {
+        let selector = [0; 4];
+        assert_eq!(
+            GenericContractError::abi_decode_raw_with_config(
+                selector,
+                &[],
+                AbiDecoderConfig::new().strict(true),
+            ),
+            Err(Error::UnknownSelector { name: "GenericContractError", selector: selector.into() }),
         );
     }
 

--- a/crates/sol-types/src/types/interface/mod.rs
+++ b/crates/sol-types/src/types/interface/mod.rs
@@ -63,14 +63,17 @@ pub trait SolInterface: Sized {
 
     /// ABI-decodes the given data with a custom decoder configuration.
     ///
-    /// The default implementation ignores the configuration and delegates to
-    /// [`abi_decode_raw`](Self::abi_decode_raw).
+    /// The default implementation supports only the default configuration.
     fn abi_decode_raw_with_config(
         selector: [u8; 4],
         data: &[u8],
-        _config: AbiDecoderConfig,
+        config: AbiDecoderConfig,
     ) -> Result<Self> {
-        Self::abi_decode_raw(selector, data)
+        if config.is_default() {
+            Self::abi_decode_raw(selector, data)
+        } else {
+            Err(Error::custom("decoder config is unsupported by this SolInterface implementation"))
+        }
     }
 
     /// ABI-decodes the given data into one of the variants of `self`, with validation.
@@ -171,9 +174,13 @@ impl SolInterface for Infallible {
     fn abi_decode_raw_with_config(
         selector: [u8; 4],
         data: &[u8],
-        _config: AbiDecoderConfig,
+        config: AbiDecoderConfig,
     ) -> Result<Self> {
-        Self::abi_decode_raw(selector, data)
+        if config.is_default() {
+            Self::abi_decode_raw(selector, data)
+        } else {
+            Err(Error::custom("decoder config is unsupported by this SolInterface implementation"))
+        }
     }
 
     #[inline]

--- a/crates/sol-types/tests/macros/sol/mod.rs
+++ b/crates/sol-types/tests/macros/sol/mod.rs
@@ -1377,6 +1377,50 @@ fn event_interface_respects_decoder_config() {
 }
 
 #[test]
+fn anonymous_event_interface_tries_later_candidates() {
+    sol! {
+        contract AnonymousCandidates {
+            event A(string data) anonymous;
+            event B(
+                uint256 a,
+                uint256 b,
+                uint256 c,
+                uint256 d,
+                uint256 e,
+                bytes data
+            ) anonymous;
+        }
+    }
+    use AnonymousCandidates::*;
+
+    let event = B {
+        a: U256::from(32),
+        b: U256::from(200),
+        c: U256::ZERO,
+        d: U256::ZERO,
+        e: U256::ZERO,
+        data: bytes![0x11; 64],
+    };
+    let data = event.encode_data();
+
+    let Ok(AnonymousCandidatesEvents::B(decoded)) =
+        AnonymousCandidatesEvents::decode_raw_log_with_config(
+            &[],
+            &data,
+            AbiDecoderConfig::new().memory_limit(100),
+        )
+    else {
+        panic!("later anonymous candidate should decode");
+    };
+    assert_eq!(decoded.a, event.a);
+    assert_eq!(decoded.b, event.b);
+    assert_eq!(decoded.c, event.c);
+    assert_eq!(decoded.d, event.d);
+    assert_eq!(decoded.e, event.e);
+    assert_eq!(decoded.data, event.data);
+}
+
+#[test]
 fn anonymous_event_rejects_topic_count_mismatch() {
     sol! {
         #[derive(Debug)]

--- a/crates/sol-types/tests/macros/sol/mod.rs
+++ b/crates/sol-types/tests/macros/sol/mod.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::{Address, B256, I256, U256, b256, bytes, hex, keccak256};
 use alloy_sol_types::{
-    SolCall, SolError, SolEvent, SolStruct, SolType, abi::AbiDecoderConfig, sol,
+    SolCall, SolError, SolEvent, SolEventInterface, SolStruct, SolType, abi::AbiDecoderConfig, sol,
 };
 use serde::Serialize;
 use serde_json::Value;
@@ -1322,6 +1322,42 @@ fn indexed_topics_respect_decoder_config() {
         IndexedAddress::decode_raw_log_with_config(
             [dirty_address],
             &[],
+            AbiDecoderConfig::new().strict(true),
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn event_interface_respects_decoder_config() {
+    sol! {
+        contract TopicConfig {
+            event Value(bool indexed value, bytes data);
+        }
+    }
+    use TopicConfig::*;
+
+    let event = Value { value: false, data: bytes!("11") };
+    let data = event.encode_data();
+    let topics = [Value::SIGNATURE_HASH, B256::ZERO];
+
+    assert!(TopicConfigEvents::decode_raw_log(&topics, &data).is_ok());
+    assert!(
+        TopicConfigEvents::decode_raw_log_with_config(
+            &[Value::SIGNATURE_HASH, B256::with_last_byte(2)],
+            &data,
+            AbiDecoderConfig::new().strict(true),
+        )
+        .is_err()
+    );
+
+    let mut trailing = data;
+    trailing.extend([0; 32]);
+    assert!(TopicConfigEvents::decode_raw_log(&topics, &trailing).is_ok());
+    assert!(
+        TopicConfigEvents::decode_raw_log_with_config(
+            &topics,
+            &trailing,
             AbiDecoderConfig::new().strict(true),
         )
         .is_err()

--- a/crates/sol-types/tests/macros/sol/mod.rs
+++ b/crates/sol-types/tests/macros/sol/mod.rs
@@ -1421,6 +1421,20 @@ fn anonymous_event_interface_tries_later_candidates() {
 }
 
 #[test]
+fn event_interface_builder_name_does_not_shadow_decoding() {
+    sol! {
+        contract BuilderName {
+            event DecodeRawLogWithConfig();
+        }
+    }
+    use BuilderName::*;
+
+    assert!(
+        BuilderNameEvents::decode_raw_log(&[DecodeRawLogWithConfig::SIGNATURE_HASH], &[]).is_ok()
+    );
+}
+
+#[test]
 fn anonymous_event_rejects_topic_count_mismatch() {
     sol! {
         #[derive(Debug)]

--- a/crates/sol-types/tests/macros/sol/mod.rs
+++ b/crates/sol-types/tests/macros/sol/mod.rs
@@ -1,5 +1,7 @@
 use alloy_primitives::{Address, B256, I256, U256, b256, bytes, hex, keccak256};
-use alloy_sol_types::{SolCall, SolError, SolEvent, SolStruct, SolType, sol};
+use alloy_sol_types::{
+    SolCall, SolError, SolEvent, SolStruct, SolType, abi::AbiDecoderConfig, sol,
+};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -1286,6 +1288,44 @@ fn anonymous_event_decodes_indexed_and_data_fields() {
     let decoded_validate = MyEventAnonymous::decode_log_data_validate(&log).unwrap();
     assert_eq!(decoded, event);
     assert_eq!(decoded_validate, event);
+}
+
+#[test]
+fn indexed_topics_respect_decoder_config() {
+    sol! {
+        event IndexedBool(bool indexed value) anonymous;
+        event IndexedAddress(address indexed value) anonymous;
+    }
+
+    let dirty_bool = B256::with_last_byte(2);
+    assert!(IndexedBool::decode_raw_log([dirty_bool], &[]).is_ok());
+    assert!(
+        IndexedBool::decode_raw_log_with_config(
+            [dirty_bool],
+            &[],
+            AbiDecoderConfig::new().validate(true),
+        )
+        .is_err()
+    );
+    assert!(
+        IndexedBool::decode_raw_log_with_config(
+            [dirty_bool],
+            &[],
+            AbiDecoderConfig::new().strict(true),
+        )
+        .is_err()
+    );
+
+    let dirty_address = B256::repeat_byte(0x11);
+    assert!(IndexedAddress::decode_raw_log([dirty_address], &[]).is_ok());
+    assert!(
+        IndexedAddress::decode_raw_log_with_config(
+            [dirty_address],
+            &[],
+            AbiDecoderConfig::new().strict(true),
+        )
+        .is_err()
+    );
 }
 
 #[test]

--- a/crates/sol-types/tests/macros/sol/mod.rs
+++ b/crates/sol-types/tests/macros/sol/mod.rs
@@ -1,6 +1,7 @@
 use alloy_primitives::{Address, B256, I256, U256, b256, bytes, hex, keccak256};
 use alloy_sol_types::{
-    SolCall, SolError, SolEvent, SolEventInterface, SolStruct, SolType, abi::AbiDecoderConfig, sol,
+    Error, SolCall, SolError, SolEvent, SolEventInterface, SolStruct, SolType,
+    abi::AbiDecoderConfig, sol,
 };
 use serde::Serialize;
 use serde_json::Value;
@@ -1333,6 +1334,7 @@ fn event_interface_respects_decoder_config() {
     sol! {
         contract TopicConfig {
             event Value(bool indexed value, bytes data);
+            event Anonymous(bytes data) anonymous;
         }
     }
     use TopicConfig::*;
@@ -1362,6 +1364,16 @@ fn event_interface_respects_decoder_config() {
         )
         .is_err()
     );
+
+    let anonymous = Anonymous { data: bytes!("11") };
+    let Err(error) = TopicConfigEvents::decode_raw_log_with_config(
+        &[],
+        &anonymous.encode_data(),
+        AbiDecoderConfig::new().memory_limit(0),
+    ) else {
+        panic!("anonymous event should exceed the memory limit");
+    };
+    assert_eq!(error, Error::MemoryLimitExceeded(0));
 }
 
 #[test]


### PR DESCRIPTION
Add an opt-in strict ABI decoder that requires each dynamic tail to begin at the next canonical offset. The decoder checks offsets before following child decoders or reserving memory, so aliased nested tails cannot repeatedly expand allocations.

Strict mode also enables type validation, rejects non-zero dynamic-byte padding, and rejects gaps and trailing data. Validation now rejects noncanonical bool values and dirty indexed topics. The tests cover canonical nested values, aliases, direct dynamic-array sequences, dynamic fixed arrays, and empty dynamic tails.