### PR TITLE
feat(primitives): add sqlx PgHasArrayType for BYTEA types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ fixed-cache = { version = "0.1.8", default-features = false }
 
 # sqlx support (optional, for DB integration)
 sqlx-core = { version = "0.8"}
+sqlx-postgres = { version = "0.8"}
 
 [patch.crates-io]
 # Fix Miri CI: https://github.com/rkyv/rkyv/commit/aea82f04757ed6a3674642f9e7f22b168ec7f955

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -113,6 +113,7 @@ diesel = { workspace = true, optional = true }
 
 # sqlx support (optional, for DB integration)
 sqlx-core = { workspace = true, optional = true }
+sqlx-postgres = { workspace = true, optional = true }
 
 [dev-dependencies]
 bcs.workspace = true
@@ -206,6 +207,7 @@ arbitrary = [
 postgres = ["std", "dep:postgres-types", "ruint/postgres"]
 diesel = ["std", "dep:diesel", "ruint/diesel"]
 sqlx = ["std", "dep:sqlx-core", "ruint/sqlx"]
+sqlx-postgres = ["sqlx", "dep:sqlx-postgres"]
 
 # `const-hex` compatibility feature for `hex`.
 # Should not be needed most of the time.

--- a/crates/primitives/src/bits/macros.rs
+++ b/crates/primitives/src/bits/macros.rs
@@ -983,6 +983,8 @@ macro_rules! impl_sqlx {
                     <$crate::FixedBytes<$n> as Decode<DB>>::decode(value).map(Self)
                 }
             }
+
+            $crate::impl_sqlx_postgres!($t, $n);
         };
     };
 }
@@ -991,6 +993,26 @@ macro_rules! impl_sqlx {
 #[macro_export]
 #[cfg(not(feature = "sqlx"))]
 macro_rules! impl_sqlx {
+    ($t:ty, $n:literal) => {};
+}
+
+#[doc(hidden)]
+#[macro_export]
+#[cfg(feature = "sqlx-postgres")]
+macro_rules! impl_sqlx_postgres {
+    ($t:ty, $n:literal) => {
+        impl $crate::private::sqlx_postgres::PgHasArrayType for $t {
+            fn array_type_info() -> $crate::private::sqlx_postgres::PgTypeInfo {
+                <$crate::FixedBytes<$n> as $crate::private::sqlx_postgres::PgHasArrayType>::array_type_info()
+            }
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+#[cfg(not(feature = "sqlx-postgres"))]
+macro_rules! impl_sqlx_postgres {
     ($t:ty, $n:literal) => {};
 }
 

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -130,6 +130,9 @@ pub mod private {
     #[cfg(feature = "sqlx")]
     pub use sqlx_core;
 
+    #[cfg(feature = "sqlx-postgres")]
+    pub use sqlx_postgres;
+
     #[cfg(feature = "schemars")]
     pub use schemars;
 }

--- a/crates/primitives/src/sqlx.rs
+++ b/crates/primitives/src/sqlx.rs
@@ -1,6 +1,7 @@
 //! Support for the [`sqlx`](https://crates.io/crates/sqlx) crate.
 //!
 //! Supports big-endian binary serialization via sqlx binary types (e.g., BINARY(N), BYTEA, BLOB).
+//! With the `sqlx-postgres` feature, `Vec<T>` of these types maps to `BYTEA[]`.
 //! Similar to [`ruint`'s implementation](https://github.com/recmo/uint/blob/main/src/support/sqlx.rs)
 
 #![cfg_attr(docsrs, doc(cfg(feature = "sqlx")))]
@@ -17,6 +18,9 @@ use sqlx_core::{
 };
 
 use crate::{Bytes, FixedBytes, Signed};
+
+#[cfg(feature = "sqlx-postgres")]
+use sqlx_postgres::{PgHasArrayType, PgTypeInfo};
 
 impl<const BYTES: usize, DB> Type<DB> for FixedBytes<BYTES>
 where
@@ -122,5 +126,26 @@ where
 {
     fn decode(value: <DB as Database>::ValueRef<'a>) -> Result<Self, BoxDynError> {
         Vec::<u8>::decode(value).map(Self::from)
+    }
+}
+
+#[cfg(feature = "sqlx-postgres")]
+impl<const BYTES: usize> PgHasArrayType for FixedBytes<BYTES> {
+    fn array_type_info() -> PgTypeInfo {
+        PgTypeInfo::array_of("bytea")
+    }
+}
+
+#[cfg(feature = "sqlx-postgres")]
+impl<const BITS: usize, const LIMBS: usize> PgHasArrayType for Signed<BITS, LIMBS> {
+    fn array_type_info() -> PgTypeInfo {
+        PgTypeInfo::array_of("bytea")
+    }
+}
+
+#[cfg(feature = "sqlx-postgres")]
+impl PgHasArrayType for Bytes {
+    fn array_type_info() -> PgTypeInfo {
+        PgTypeInfo::array_of("bytea")
     }
 }

--- a/crates/primitives/src/sqlx.rs
+++ b/crates/primitives/src/sqlx.rs
@@ -149,3 +149,72 @@ impl PgHasArrayType for Bytes {
         PgTypeInfo::array_of("bytea")
     }
 }
+
+#[cfg(all(test, feature = "sqlx-postgres"))]
+mod test {
+    use super::*;
+    use crate::{Address, B256, Bloom, Function, I256};
+    use sqlx_core::{decode::Decode, encode::Encode, type_info::TypeInfo, types::Type};
+    use sqlx_postgres::{PgArgumentBuffer, Postgres};
+
+    fn encode_pg<T>(value: &T) -> Vec<u8>
+    where
+        T: for<'q> Encode<'q, Postgres>,
+    {
+        let mut buf = PgArgumentBuffer::default();
+        let _ = value.encode_by_ref(&mut buf).unwrap();
+        buf.to_vec()
+    }
+
+    fn assert_bytea_array<T>()
+    where
+        T: Type<Postgres> + for<'q> Encode<'q, Postgres> + for<'r> Decode<'r, Postgres>,
+    {
+        assert_eq!(T::type_info().name(), "bytea[]");
+    }
+
+    #[test]
+    fn vec_primitives_are_bytea_array() {
+        assert_bytea_array::<Vec<Address>>();
+        assert_bytea_array::<Vec<Bloom>>();
+        assert_bytea_array::<Vec<Function>>();
+        assert_bytea_array::<Vec<FixedBytes<20>>>();
+        assert_bytea_array::<Vec<B256>>();
+        assert_bytea_array::<Vec<Bytes>>();
+        assert_bytea_array::<Vec<I256>>();
+    }
+
+    #[test]
+    fn vec_primitives_encode_as_bytea_array() {
+        let addresses = vec![Address::repeat_byte(0x11), Address::repeat_byte(0x22)];
+        assert_eq!(
+            encode_pg(&addresses),
+            encode_pg(&addresses.iter().map(|a| a.as_slice().to_vec()).collect::<Vec<_>>())
+        );
+        assert_eq!(encode_pg(&Vec::<Address>::new()), encode_pg(&Vec::<Vec<u8>>::new()));
+
+        let fixed = vec![FixedBytes::<20>::repeat_byte(0x33), FixedBytes::<20>::repeat_byte(0x44)];
+        assert_eq!(
+            encode_pg(&fixed),
+            encode_pg(&fixed.iter().map(|b| b.as_slice().to_vec()).collect::<Vec<_>>())
+        );
+
+        let hashes = vec![B256::repeat_byte(0x55), B256::ZERO];
+        assert_eq!(
+            encode_pg(&hashes),
+            encode_pg(&hashes.iter().map(|h| h.as_slice().to_vec()).collect::<Vec<_>>())
+        );
+
+        let bytes = vec![Bytes::from_static(&[0xde, 0xad]), Bytes::from_static(&[0xbe, 0xef])];
+        assert_eq!(
+            encode_pg(&bytes),
+            encode_pg(&bytes.iter().map(|b| b.to_vec()).collect::<Vec<_>>())
+        );
+
+        let signed = vec![I256::ONE, I256::MINUS_ONE, I256::ZERO];
+        assert_eq!(
+            encode_pg(&signed),
+            encode_pg(&signed.iter().map(|s| s.to_be_bytes::<32>().to_vec()).collect::<Vec<_>>())
+        );
+    }
+}

--- a/crates/primitives/src/sqlx.rs
+++ b/crates/primitives/src/sqlx.rs
@@ -132,21 +132,21 @@ where
 #[cfg(feature = "sqlx-postgres")]
 impl<const BYTES: usize> PgHasArrayType for FixedBytes<BYTES> {
     fn array_type_info() -> PgTypeInfo {
-        PgTypeInfo::array_of("bytea")
+        <Vec<u8> as PgHasArrayType>::array_type_info()
     }
 }
 
 #[cfg(feature = "sqlx-postgres")]
 impl<const BITS: usize, const LIMBS: usize> PgHasArrayType for Signed<BITS, LIMBS> {
     fn array_type_info() -> PgTypeInfo {
-        PgTypeInfo::array_of("bytea")
+        <Vec<u8> as PgHasArrayType>::array_type_info()
     }
 }
 
 #[cfg(feature = "sqlx-postgres")]
 impl PgHasArrayType for Bytes {
     fn array_type_info() -> PgTypeInfo {
-        PgTypeInfo::array_of("bytea")
+        <Vec<u8> as PgHasArrayType>::array_type_info()
     }
 }
 
@@ -154,7 +154,7 @@ impl PgHasArrayType for Bytes {
 mod test {
     use super::*;
     use crate::{Address, B256, Bloom, Function, I256};
-    use sqlx_core::{decode::Decode, encode::Encode, type_info::TypeInfo, types::Type};
+    use sqlx_core::{decode::Decode, encode::Encode, types::Type};
     use sqlx_postgres::{PgArgumentBuffer, Postgres};
 
     fn encode_pg<T>(value: &T) -> Vec<u8>
@@ -170,7 +170,11 @@ mod test {
     where
         T: Type<Postgres> + for<'q> Encode<'q, Postgres> + for<'r> Decode<'r, Postgres>,
     {
-        assert_eq!(T::type_info().name(), "bytea[]");
+        let expected = <Vec<Vec<u8>> as Type<Postgres>>::type_info();
+        let actual = T::type_info();
+        assert_eq!(actual, expected);
+        // `PartialEq` treats `array_of("bytea")` as compatible; Debug pins the built-in OID.
+        assert_eq!(format!("{actual:?}"), format!("{expected:?}"));
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

Closes #1181.

I store arrays of Ethereum addresses and fixed-size hashes in Postgres as `BYTEA[]`. Alloy already implements sqlx `Type` / `Encode` / `Decode` for these primitives as scalar `BYTEA`, but sqlx will not treat `Vec<T>` as `BYTEA[]` unless `T: PgHasArrayType`. That trait lives in `sqlx-postgres`, which Alloy does not depend on today.

The current workaround is to bind/decode `Vec<Vec<u8>>` and convert with `Address::from_slice` / `FixedBytes::try_from`.

## Solution

- Add an optional `sqlx-postgres` feature (does not change the generic `sqlx` feature).
- Implement `PgHasArrayType` with `PgTypeInfo::array_of("bytea")` for `FixedBytes`, `Bytes`, and `Signed`.
- Delegate the same impl to `wrap_fixed_bytes!` types (`Address`, `Bloom`, `Function`) via `impl_sqlx_postgres!`.
- sqlx’s blanket `Vec<T>` impls then bind/decode as `BYTEA[]`.
- Unit tests check `Type::type_info().name() == "bytea[]"` and that encoding matches `Vec<Vec<u8>>`.

Related but distinct: #1032 (rust-postgres `ToSql`/`FromSql` for `Address`).

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes