### PR TITLE
chore(ci): disable allocative in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,13 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-on-failure: true
+      - name: disable allocative on nightly
+        if: ${{ matrix.rust == 'nightly' }}
+        shell: bash
+        run: |
+          sed -i '/^allocative = { workspace = true, optional = true }$/d' crates/primitives/Cargo.toml
+          sed -i 's/^allocative = \["dep:allocative"\]$/allocative = []/' crates/primitives/Cargo.toml
+          sed -i 's/feature = "allocative"/all(feature = "allocative", any())/g' crates/primitives/src/lib.rs crates/primitives/src/bits/{fixed.rs,macros.rs}
       # Only run tests on latest stable and above
       - name: pin deps
         if: ${{ matrix.rust == '1.85' }} # MSRV
@@ -94,6 +101,11 @@ jobs:
           toolchain: nightly
           components: miri
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - name: disable allocative on nightly
+        run: |
+          sed -i '/^allocative = { workspace = true, optional = true }$/d' crates/primitives/Cargo.toml
+          sed -i 's/^allocative = \["dep:allocative"\]$/allocative = []/' crates/primitives/Cargo.toml
+          sed -i 's/feature = "allocative"/all(feature = "allocative", any())/g' crates/primitives/src/lib.rs crates/primitives/src/bits/{fixed.rs,macros.rs}
       - run: cargo miri test ${{ matrix.flags }}
 
   wasm:
@@ -139,6 +151,12 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-on-failure: true
+      - name: disable allocative on nightly
+        if: ${{ matrix.rust == 'nightly' }}
+        run: |
+          sed -i '/^allocative = { workspace = true, optional = true }$/d' crates/primitives/Cargo.toml
+          sed -i 's/^allocative = \["dep:allocative"\]$/allocative = []/' crates/primitives/Cargo.toml
+          sed -i 's/feature = "allocative"/all(feature = "allocative", any())/g' crates/primitives/src/lib.rs crates/primitives/src/bits/{fixed.rs,macros.rs}
       - name: cargo hack
         run: |
           args=(${{ matrix.flags }})
@@ -194,6 +212,11 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-on-failure: true
+      - name: disable allocative on nightly
+        run: |
+          sed -i '/^allocative = { workspace = true, optional = true }$/d' crates/primitives/Cargo.toml
+          sed -i 's/^allocative = \["dep:allocative"\]$/allocative = []/' crates/primitives/Cargo.toml
+          sed -i 's/feature = "allocative"/all(feature = "allocative", any())/g' crates/primitives/src/lib.rs crates/primitives/src/bits/{fixed.rs,macros.rs}
       - run: cargo clippy --workspace --all-targets --all-features
         env:
           RUSTFLAGS: -Dwarnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,7 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-on-failure: true
-      - name: disable allocative on nightly
-        if: ${{ matrix.rust == 'nightly' }}
+      - name: disable allocative
         shell: bash
         run: |
           sed -i '/^allocative = { workspace = true, optional = true }$/d' crates/primitives/Cargo.toml
@@ -101,7 +100,7 @@ jobs:
           toolchain: nightly
           components: miri
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
-      - name: disable allocative on nightly
+      - name: disable allocative
         run: |
           sed -i '/^allocative = { workspace = true, optional = true }$/d' crates/primitives/Cargo.toml
           sed -i 's/^allocative = \["dep:allocative"\]$/allocative = []/' crates/primitives/Cargo.toml
@@ -124,6 +123,11 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-on-failure: true
+      - name: disable allocative
+        run: |
+          sed -i '/^allocative = { workspace = true, optional = true }$/d' crates/primitives/Cargo.toml
+          sed -i 's/^allocative = \["dep:allocative"\]$/allocative = []/' crates/primitives/Cargo.toml
+          sed -i 's/feature = "allocative"/all(feature = "allocative", any())/g' crates/primitives/src/lib.rs crates/primitives/src/bits/{fixed.rs,macros.rs}
       - name: check
         run: cargo check --workspace --target wasm32-unknown-unknown
 
@@ -151,8 +155,7 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-on-failure: true
-      - name: disable allocative on nightly
-        if: ${{ matrix.rust == 'nightly' }}
+      - name: disable allocative
         run: |
           sed -i '/^allocative = { workspace = true, optional = true }$/d' crates/primitives/Cargo.toml
           sed -i 's/^allocative = \["dep:allocative"\]$/allocative = []/' crates/primitives/Cargo.toml
@@ -183,6 +186,11 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-on-failure: true
+      - name: disable allocative
+        run: |
+          sed -i '/^allocative = { workspace = true, optional = true }$/d' crates/primitives/Cargo.toml
+          sed -i 's/^allocative = \["dep:allocative"\]$/allocative = []/' crates/primitives/Cargo.toml
+          sed -i 's/feature = "allocative"/all(feature = "allocative", any())/g' crates/primitives/src/lib.rs crates/primitives/src/bits/{fixed.rs,macros.rs}
       - run: ./scripts/check_no_std.sh
 
   typos:
@@ -212,7 +220,7 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-on-failure: true
-      - name: disable allocative on nightly
+      - name: disable allocative
         run: |
           sed -i '/^allocative = { workspace = true, optional = true }$/d' crates/primitives/Cargo.toml
           sed -i 's/^allocative = \["dep:allocative"\]$/allocative = []/' crates/primitives/Cargo.toml
@@ -237,6 +245,11 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-on-failure: true
+      - name: disable allocative
+        run: |
+          sed -i '/^allocative = { workspace = true, optional = true }$/d' crates/primitives/Cargo.toml
+          sed -i 's/^allocative = \["dep:allocative"\]$/allocative = []/' crates/primitives/Cargo.toml
+          sed -i 's/feature = "allocative"/all(feature = "allocative", any())/g' crates/primitives/src/lib.rs crates/primitives/src/bits/{fixed.rs,macros.rs}
       - name: Build documentation
         run: cargo doc --workspace --all-features --no-deps --document-private-items
         env:


### PR DESCRIPTION
## Motivation

Current Rust nightly unifies `Infallible` with the never type, causing conflicting `Allocative` implementations in `allocative` 0.3.6. The feature should be excluded consistently from CI rather than only patched around the failing nightly jobs.

## Solution

Disable the `allocative` dependency and its code paths with `sed` in every CI job that builds or checks the workspace: test, Miri, Wasm, feature checks, no-std, clippy, and docs.

Validated with `RUSTFLAGS=-Dwarnings cargo +nightly clippy --workspace --all-targets --all-features`; the initial workaround also passed all 31 checks on #1180.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

Prompted by: @DaniPopes