### PR TITLE
fix: allow non atomic targets

### DIFF
--- a/crates/dyn-abi/src/specifier.rs
+++ b/crates/dyn-abi/src/specifier.rs
@@ -232,6 +232,11 @@ deref_impls! {
     [T: ?Sized + Specifier<DynSolType>] alloc::boxed::Box<T>,
     [T: ?Sized + alloc::borrow::ToOwned + Specifier<DynSolType>] alloc::borrow::Cow<'_, T>,
     [T: ?Sized + Specifier<DynSolType>] alloc::rc::Rc<T>,
+}
+
+// `Arc` needs pointer-sized atomics
+#[cfg(target_has_atomic = "ptr")]
+deref_impls! {
     [T: ?Sized + Specifier<DynSolType>] alloc::sync::Arc<T>,
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

This crate does not compile for targets that don't support atomic operations.
This is because `Arc` needs them, and there is a `deref_impls` for `Arc`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

To not compile the `Arc` `deref_impls` for targets without atomic operations.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
